### PR TITLE
Configure webhook for mce v1

### DIFF
--- a/pkg/templates/core/validatingwebhook.yaml
+++ b/pkg/templates/core/validatingwebhook.yaml
@@ -19,7 +19,7 @@ webhooks:
   - apiGroups:
     - multicluster.openshift.io
     apiVersions:
-    - v1alpha1
+    - v1
     operations:
     - CREATE
     - UPDATE


### PR DESCRIPTION
Webhook wasn't functioning because it was configured for v1alpha1 rather than the new v1 MCE apiversion

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>