### PR TITLE
redoing chart link to use https instead of ssh

### DIFF
--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -1,6 +1,6 @@
 
 - repo_name: "managed-serviceaccount"
-  github_ref: "git@github.com:stolostron/managed-serviceaccount.git"
+  github_ref: "https://github.com/stolostron/managed-serviceaccount.git"
   charts:
     - name: "managed-serviceaccount"
       chart-path: "charts/managed-serviceaccount"


### PR DESCRIPTION
Signed-off-by: Nathan Weatherly <nweather@redhat.com>

Related issue: https://github.com/stolostron/backlog/issues/19275
