### PR TITLE
Fix hypershift yaml format error and render test

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-deployment.yaml
@@ -77,10 +77,10 @@ spec:
             - '--namespace={{ .Values.global.namespace }}'
             - '--with-image-override=true'
           env:
-            - name: HYPERSHIFT_OPERATOR_IMAGE_NAME
-              value: '{{ .Values.global.imageOverrides.hypershift_operator }}'
-            - name: HYPERSHIFT_ADDON_IMAGE_NAME
-              value: '{{ .Values.global.imageOverrides.hypershift_addon_operator }}'
+          - name: HYPERSHIFT_OPERATOR_IMAGE_NAME
+            value: '{{ .Values.global.imageOverrides.hypershift_operator }}'
+          - name: HYPERSHIFT_ADDON_IMAGE_NAME
+            value: '{{ .Values.global.imageOverrides.hypershift_addon_operator }}'
 {{- if .Values.hubconfig.proxyConfigs }}
           - name: HTTP_PROXY
             value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}


### PR DESCRIPTION
Issue: https://github.com/stolostron/backlog/issues/20979

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>

The env vars were misaligned in the hypershift yaml and it wasn't caught because the renderer function test was pointing to the wrong directory.