### PR TITLE
Remove console plugin injection

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 const (
-	ManagedServiceAccount string = "managed-service-account"
+	ManagedServiceAccount string = "managedserviceaccount-preview"
 	ConsoleMCE            string = "console-mce"
 	Discovery             string = "discovery"
 	Hive                  string = "hive"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,11 +20,11 @@ var onComponents = []string{
 	backplanev1.Discovery,
 	backplanev1.Hive,
 	backplanev1.ServerFoundation,
-	// backplanev1.ConsoleMCE, // determined by OCP version
-	// backplanev1.HyperShift,
+	// backplanev1.ConsoleMCE, -- determined by OCP version
 }
 
 var offComponents = []string{
+	// These components are previews in 2.5
 	backplanev1.ManagedServiceAccount,
 	backplanev1.HyperShift,
 }


### PR DESCRIPTION
Since the console plugin is only a preview in Openshift we will not set it in MCE by default. Instead MCH will enable the MCE plugin for it with https://github.com/stolostron/multiclusterhub-operator/pull/773. If MCE is installed standalone the customer will need to be instructed on how to configure the plugin manually.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>