### PR TITLE
add lease rbac for work-manger addon agent in ocp 311 case

### DIFF
--- a/pkg/templates/charts/toggle/server-foundation/templates/clusterrole-foundation-agent.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/clusterrole-foundation-agent.yaml
@@ -27,3 +27,6 @@ rules:
   - apiGroups: ["proxy.open-cluster-management.io"]
     resources: ["clusterstatuses/aggregator"]
     verbs: ["get", "create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "update","create","patch"]


### PR DESCRIPTION
fix the issue: https://github.com/stolostron/backlog/issues/21190

only update the yaml in chart because the lease rabc has been in backplaneconfig_controler.go.
Signed-off-by: Zhiwei Yin <zyin@redhat.com>