### PR TITLE
Add rbac requirements for consolequickstarts resource

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -167,6 +167,7 @@ spec:
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch
@@ -208,6 +209,8 @@ spec:
           - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - apiextensions.k8s.io
@@ -305,6 +308,7 @@ spec:
           - console.openshift.io
           resources:
           - consoleplugins
+          - consolequickstarts
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -241,6 +241,7 @@ rules:
   - console.openshift.io
   resources:
   - consoleplugins
+  - consolequickstarts
   verbs:
   - create
   - delete

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -83,7 +83,7 @@ const (
 //+kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs,verbs=list
 //+kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs;discoveredclusters,verbs=create;get;list;watch;update;delete;deletecollection;patch;approve;escalate;bind
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch;
-//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update;patch
 
 // AgentServiceConfig webhook delete check


### PR DESCRIPTION
Resolves error after merging https://github.com/stolostron/backplane-operator/pull/151

```
"error": ": error ensuring console-mce: error applying object Name: multicluster-switcher Kind: ConsoleQuickStart: consolequickstarts.console.openshift.io \"multicluster-switcher\" is forbidden: User \"system:serviceaccount:multicluster-engine:multicluster-engine-operator\" cannot patch resource \"consolequickstarts\" in API group \"console.openshift.io\" at the cluster scope"
```

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>