### PR TITLE
make spec.infrastructure.cloudProvider optional

### DIFF
--- a/pkg/templates/crds/hypershift/cluster.open-cluster-management.io_hypershiftdeployments.yaml
+++ b/pkg/templates/crds/hypershift/cluster.open-cluster-management.io_hypershiftdeployments.yaml
@@ -1265,7 +1265,6 @@ spec:
                         type: object
                     type: object
                 required:
-                - cloudProvider
                 - configure
                 type: object
               nodePoolReferences:


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

Make spec.infrastructure.cloudProvider optional

https://github.com/stolostron/backlog/issues/22814

https://issues.redhat.com/browse/ACM-1407