### PR TITLE
increase the mem limit to fix the ocm-proxyserver oom in 2k clusters

### DIFF
--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver.yaml
@@ -81,7 +81,7 @@ spec:
             cpu: 100m
             memory: 256Mi
           limits:
-            memory: 2Gi
+            memory: 4Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Signed-off-by: Zhiwei Yin <zyin@redhat.com>
fix issue: https://github.com/stolostron/backlog/issues/22335