### PR TITLE
Extend bundle automation to allow generation of input bundle via a tool

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -1,12 +1,14 @@
 
+- repo_name: generate-hive-bundle
+  gen_command: ./hack/bundle-automation/gen-hive-bundle.sh
+  branch: 52ff9fde3e9272015ff66c809503f14c38bb9889
+  bundlePath: /tmp/hive-operator-manifests
+  name: hive-operator
+  imageMappings:
+     hive: openshift_hive
 - repo_name: "community-operators-prod"
   github_ref: "https://github.com/redhat-openshift-ecosystem/community-operators-prod.git"
   operators:
-    - name: "hive-operator"
-      channel: "alpha"
-      package-yml: "operators/hive-operator/hive.package.yaml"
-      imageMappings:
-        hive: openshift_hive
     - name: "assisted-service"
       channel: "ocm-2.6"
       package-yml: "operators/assisted-service-operator/assisted-service.package.yaml"

--- a/hack/bundle-automation/gen-hive-bundle.sh
+++ b/hack/bundle-automation/gen-hive-bundle.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Generates the Hive bundle using a script in the Hive operator repo.
+#
+# Arguments:
+#
+# $1 = Name of branch of commit SHA to use for the tool, and the bundle input.
+# $2 = Pathname of the directory to contain the resulting Hive bundle.
+#
+# Note: The output directory is removed at the start of each run to ensure
+#       a clean/consistent result.
+
+me=$(basename "$0")
+
+commit_ish="$1"
+output_dir="$2"
+if [[ -z "$output_dir" ]]; then
+   >&2 echo "Syntax: $me <commit_ish> <output_path>"
+   exit 5
+fi
+
+hive_repo="https://github.com/openshift/hive.git"
+gen_tool="hack/bundle-gen.py"  # Path within Hive's repo.
+
+tmp_dir=$(mktemp -td "$me.XXXXXXXX")
+
+start_cwd="$PWD"
+rm -rf "$output_dir"
+
+cd "$tmp_dir"
+
+# Clone the Hive operator repo at specified commit/branch.
+
+echo "Cloning/checking out HIve repo at branch/commit ($commit_ish)."
+hive_repo_spot="$PWD/hive"
+git clone --no-progress "$hive_repo" "hive"
+rc=$?
+if [[ $rc -ne 0 ]]; then
+   >&2 echo "Error: Could not clone openshift/hive (rc: $rc)."
+   exit 3
+fi
+cd hive
+git -c advice.detachedHead=false checkout "$commit_ish"
+rc=$?
+if [[ $rc -ne 0 ]]; then
+   >&2 echo "Error: Could not checkout branch/commit $ommit_ish (rc: $rc)."
+   exit 3
+fi
+cd ..
+
+# Run Hive's bundle generation tool.  It puts its output in a subdirectory of $PWD
+# named with pattern "hive-operator-bundle-*" so run it from a clean directory so
+# we sure there will only ever be one such-named subdirectory.
+
+if [[ ! -f "./hive/$gen_tool" ]]; then
+   >&2 echo "Error: Hive's bundle_gen tool ($gen_tool) not found."
+   exit 3
+fi
+
+mkdir bundle
+cd bundle
+echo "Running Hive bundle-gen tool ($gen_tool)."
+python3 ../hive/$gen_tool --hive-repo "$hive_repo_spot" --dummy-bundle "$commit_ish"
+# Note: We point the bundle-gen tool at the local repo we already checked out
+# since we know that it contains the Git SHA we are using for input.
+rc=$?
+if [[ $rc -ne 0 ]]; then
+   >&2 echo "Error: Hive's bundle_gen script failed (rc: $rc)."
+   exit 3
+fi
+
+# Check that an output directory was created, and copy the results into
+# the output directory specified to us.
+
+generated_bundle_dir="$PWD/hive-operator-bundle-*"
+
+if ! ls $generated_bundle_dir > /dev/null 2>&1; then
+   >&2 echo "Error: Hive's bundle_gen script didn't generate expected output directory."
+   exit 3
+fi
+
+cd "$start_cwd"
+mkdir -p "$output_dir"
+echo "Copying generated bundle manifests to output directory."
+cp -p $generated_bundle_dir/* $output_dir
+rc=$?
+if [[ $rc -ne 0 ]]; then
+   >&2 echo "Error: Error copying generated bundle manifests(rc: $rc)."
+   exit 3
+fi
+
+echo "Hive bundle copied to $output_dir."
+
+rm -rf "$tmp_dir"
+

--- a/hack/bundle-automation/requirements.txt
+++ b/hack/bundle-automation/requirements.txt
@@ -1,2 +1,4 @@
 pyyaml
 gitpython
+requests
+urllib3


### PR DESCRIPTION
Over time, we have been gradually moving away from the approach of getting bundle input from the `community-operators` repo, and instead getting it from other sources.   The initial rationale behind using `community-operators` as the source of truth never fully panned out (namely, that all parts of the productized ACM would be posted as individual piece parts to `community-operators` to allow a "assemble it yourself" approach).  And getting input from other places  can improve turnaround time on component updates and eliminates the burden of posting to `community-operators` as a required step.

This PR moves our approach for Hive away from "use community operators" approach to one where instead we will get Hive input material by generating their bundle using a tool the Hive team maintains.  (Its necessary to use a generation tool because the Hive team does not commit any of the OLM bundle artifacts to their dev repo).

Co-requisite updates to Hive's bundle-gen tool were made to allow for this use case via Hive PR openshift/hive#1813.

This PR doesn't include a change to `config.yal` to exploit the new approach yet because we are still sorting out sync-up for the Hive component in MCE 2.1, but an example entry might look like this:
```
- repo_name: generate-hive-bundle
  gen_command: ./gen-hive-bundle.sh
  branch: 52ff9fde3e9272015ff66c809503f14c38bb9889
  bundlePath: /tmp/hive-operator-manifests
  name: hive-operator
  imageMappings:
     hive: openshift_hive
```

Note that the `branch` property can take either a branch name or a Git SHA, but we will likely use a Git SHA because we generally handle a component that we embed by using/managing pinned SHA references.