### PR TITLE
Hypershift deployment controller needs additional clusterset and setbinding permissions

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -1213,6 +1213,18 @@ spec:
           - cluster.open-cluster-management.io
           resources:
           - managedclusters
+          - managedclustersetbindings
+          - managedclustersets
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters
           - managedclustersets
           - placementdecisions
           - placementdecisions/status

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1145,6 +1145,18 @@ rules:
   - cluster.open-cluster-management.io
   resources:
   - managedclusters
+  - managedclustersetbindings
+  - managedclustersets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
   - managedclustersets
   - placementdecisions
   - placementdecisions/status

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager_clusterrole.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager_clusterrole.yaml
@@ -24,7 +24,7 @@ rules:
   - kubernetes.io/kube-apiserver-client
   verbs: ["approve"]
 - apiGroups: ["cluster.open-cluster-management.io"]
-  resources: ["managedclusters"]
+  resources: ["managedclusters", "managedclustersets", "managedclustersetbindings"]
   verbs: ["get", "list", "watch", "patch", "update"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -153,9 +153,9 @@ package main
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
-//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch;patch;update
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters/status,verbs=patch;update
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters;managedclusters/status;managedclusters/finalizers,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters;managedclustersets;managedclustersetbindings,verbs=get;list;watch;patch;update
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters;managedclustersets;managedclustersetbindings;clustercurators;placements;placementdecisions,verbs=list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters;managedclustersets;placementdecisions;placementdecisions/status,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersetbindings,verbs=create;update;get;list;watch;delete;deletecollection;patch


### PR DESCRIPTION
When the cluster security flag is enabled (which is off by default), Hypershift deployment controller needs additional clusterset and setbinding permissions.

for https://github.com/stolostron/backlog/issues/24472

Signed-off-by: Mike Ng <ming@redhat.com>