### PR TITLE
Hypershift deployment controller needs clusterset and setbinding permissions when the cluster security flag is enabled

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager_clusterrole.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager_clusterrole.yaml
@@ -24,7 +24,7 @@ rules:
   - kubernetes.io/kube-apiserver-client
   verbs: ["approve"]
 - apiGroups: ["cluster.open-cluster-management.io"]
-  resources: ["managedclusters"]
+  resources: ["managedclusters", "managedclustersets", "managedclustersetbindings"]
   verbs: ["get", "list", "watch", "patch", "update"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]


### PR DESCRIPTION
for https://github.com/stolostron/backlog/issues/24465

Signed-off-by: Mike Ng <ming@redhat.com>