### PR TITLE
Delete global set namespace

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -726,6 +726,17 @@ func (r *MultiClusterEngineReconciler) finalizeBackplaneConfig(ctx context.Conte
 		return err
 	}
 
+	globalSetNamespace := &corev1.Namespace{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management-global-set"}, globalSetNamespace)
+	if err == nil {
+		err := r.Client.Delete(ctx, globalSetNamespace)
+		if err != nil {
+			return err
+		}
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: ldpliu <daliu@redhat.com>
https://github.com/stolostron/backlog/issues/24532

We create a namespace for global clusterset by default in https://github.com/stolostron/multicloud-operators-foundation/blob/80908de299379974ecbbd68a7452ec18b34f6a6b/pkg/controllers/clusterset/globalclusterset/globalset_controller.go#L150

And it's difficult to delete it in multicloud-operators-foundation part, the only way is deleting it in this repo.
 
