### PR TITLE
Fix: cluster-proxy-addon install namespace on agent should be `open-cluster-management-agent-addon`

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
@@ -80,6 +80,7 @@ spec:
             - --leader-elect=true
             - --signer-secret-namespace={{ .Values.global.namespace }}
             - --agent-image-name={{ .Values.global.imageOverrides.cluster_proxy }}
+            - --agent-install-namespace=open-cluster-management-agent-addon
         {{- if .Values.global.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.pullSecret }}


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>
https://github.com/stolostron/backlog/issues/24807