### PR TITLE
Hypershift deployment controller needs clusterset and setbinding permissions when the cluster security flag is enabled

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershiftDeployment_clusterrole.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershiftDeployment_clusterrole.yaml
@@ -78,6 +78,8 @@ rules:
   - cluster.open-cluster-management.io
   resources:
   - managedclusters
+  - managedclustersets
+  - managedclustersetbindings
   verbs:
   - create
   - delete


### PR DESCRIPTION
for https://github.com/stolostron/backlog/issues/24465

Signed-off-by: Mike Ng <ming@redhat.com>