### PR TITLE
Fix: image pull secret on agent should be `open-cluster-management-im…

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/managedproxyconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/managedproxyconfiguration.yaml
@@ -39,5 +39,5 @@ spec:
     replicas: {{ .Values.hubconfig.replicaCount }}
     {{- if .Values.global.pullSecret }}
     imagePullSecrets:
-    - "{{ .Values.global.pullSecret }}"
+    - "open-cluster-management-image-pull-credentials"
     {{- end }}


### PR DESCRIPTION
…age-pull-credentials`

Signed-off-by: xuezhaojun <zxue@redhat.com>

https://github.com/stolostron/backlog/issues/24807