### PR TITLE
Update Cluster Curator to add optional HookType field to support Ansible Workflow Job invocation

### DIFF
--- a/pkg/templates/crds/cluster-lifecycle/cluster.open-cluster-management.io_clustercurators.yaml
+++ b/pkg/templates/crds/cluster-lifecycle/cluster.open-cluster-management.io_clustercurators.yaml
@@ -61,6 +61,13 @@ spec:
                         name:
                           description: Name of the Ansible Template to run in Tower as a job
                           type: string
+                        type:
+                          default: Job
+                          description: Type of the Hook. For Job type, Ansible job template will be used. For Workflow type, Ansible workflow template will be used. If omitted, default to Job type.
+                          enum:
+                          - Job
+                          - Workflow
+                          type: string
                       required:
                       - name
                       type: object
@@ -75,6 +82,13 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         name:
                           description: Name of the Ansible Template to run in Tower as a job
+                          type: string
+                        type:
+                          default: Job
+                          description: Type of the Hook. For Job type, Ansible job template will be used. For Workflow type, Ansible workflow template will be used. If omitted, default to Job type.
+                          enum:
+                          - Job
+                          - Workflow
                           type: string
                       required:
                       - name
@@ -102,6 +116,13 @@ spec:
                         name:
                           description: Name of the Ansible Template to run in Tower as a job
                           type: string
+                        type:
+                          default: Job
+                          description: Type of the Hook. For Job type, Ansible job template will be used. For Workflow type, Ansible workflow template will be used. If omitted, default to Job type.
+                          enum:
+                          - Job
+                          - Workflow
+                          type: string
                       required:
                       - name
                       type: object
@@ -116,6 +137,13 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         name:
                           description: Name of the Ansible Template to run in Tower as a job
+                          type: string
+                        type:
+                          default: Job
+                          description: Type of the Hook. For Job type, Ansible job template will be used. For Workflow type, Ansible workflow template will be used. If omitted, default to Job type.
+                          enum:
+                          - Job
+                          - Workflow
                           type: string
                       required:
                       - name
@@ -149,6 +177,13 @@ spec:
                         name:
                           description: Name of the Ansible Template to run in Tower as a job
                           type: string
+                        type:
+                          default: Job
+                          description: Type of the Hook. For Job type, Ansible job template will be used. For Workflow type, Ansible workflow template will be used. If omitted, default to Job type.
+                          enum:
+                          - Job
+                          - Workflow
+                          type: string
                       required:
                       - name
                       type: object
@@ -163,6 +198,13 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         name:
                           description: Name of the Ansible Template to run in Tower as a job
+                          type: string
+                        type:
+                          default: Job
+                          description: Type of the Hook. For Job type, Ansible job template will be used. For Workflow type, Ansible workflow template will be used. If omitted, default to Job type.
+                          enum:
+                          - Job
+                          - Workflow
                           type: string
                       required:
                       - name
@@ -196,6 +238,13 @@ spec:
                         name:
                           description: Name of the Ansible Template to run in Tower as a job
                           type: string
+                        type:
+                          default: Job
+                          description: Type of the Hook. For Job type, Ansible job template will be used. For Workflow type, Ansible workflow template will be used. If omitted, default to Job type.
+                          enum:
+                          - Job
+                          - Workflow
+                          type: string
                       required:
                       - name
                       type: object
@@ -210,6 +259,13 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         name:
                           description: Name of the Ansible Template to run in Tower as a job
+                          type: string
+                        type:
+                          default: Job
+                          description: Type of the Hook. For Job type, Ansible job template will be used. For Workflow type, Ansible workflow template will be used. If omitted, default to Job type.
+                          enum:
+                          - Job
+                          - Workflow
                           type: string
                       required:
                       - name


### PR DESCRIPTION
For https://issues.redhat.com/browse/ACM-1260 https://github.com/stolostron/backlog/issues/26872

This PR should be merged ahead of https://github.com/stolostron/cluster-curator-controller/pull/137
because the API change is optional so it will not impact MCE during the run but the controller relies on the API to be there.

Signed-off-by: Mike Ng <ming@redhat.com>