### PR TITLE
Add manifests for the new cluster imageset controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1546,8 +1546,12 @@ rules:
   resources:
   - clusterimagesets
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - hive.openshift.io

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-image-set-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-image-set-clusterrole.yaml
@@ -1,0 +1,61 @@
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}.cluster-lifecycle.cluster-image-set
+rules:
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterimagesets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-image-set-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-image-set-deployment.yaml
@@ -1,0 +1,117 @@
+
+# Copyright Contributors to the Open Cluster Management project.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-image-set-controller
+spec:
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      name: cluster-image-set-controller
+  template:
+    metadata:
+      labels:
+        name: cluster-image-set-controller
+        ocm-antiaffinity-selector: "cluster-image-set-controller"
+    spec:
+      {{- if .Values.global.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.pullSecret }}
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+                - arm64
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - cluster-image-set-controller
+          - weight: 35
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - cluster-image-set-controller
+      serviceAccountName: cluster-image-set
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: tmp-vol
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+          - "./clusterimageset"
+          - sync
+        image: "{{ .Values.global.imageOverrides.cluster_image_set_controller }}"
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-vol
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: IMAGE_URI
+          value: "{{ .Values.global.imageOverrides.cluster_image_set_controller }}"
+{{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+{{- end }}
+        imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+        name: cluster-image-set-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        resources:
+          limits:
+            cpu: "10m"
+            memory: "128Mi"
+          requests:
+            cpu: "3m"        # Runs < 2m most of the time
+            memory: "25Mi"   # Runs between 25-28Mi
+{{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+        {{- end }}
+{{- end }}

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-image-set-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-image-set-rolebinding.yaml
@@ -1,0 +1,15 @@
+
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.org }}.cluster-lifecycle.cluster-image-set
+subjects:
+- kind: ServiceAccount
+  name: cluster-image-set
+  namespace: {{ .Values.global.namespace }}       ## CHANGE: ACM namespace
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.org }}.cluster-lifecycle.cluster-image-set
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-image-set-service_account.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-image-set-service_account.yaml
@@ -1,0 +1,6 @@
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-image-set

--- a/pkg/templates/charts/toggle/cluster-lifecycle/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/values.yaml
@@ -1,6 +1,7 @@
 global:
   imageOverrides:
     cluster_curator_controller: quay.io/test/test:test
+    cluster_image_set_controller: quay.io/test/test:test
     clusterclaims_controller: quay.io/test/test:test
     clusterlifecycle_state_metrics: quay.io/test/test:test
     provider_credential_controller: quay.io/test/test:test

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -11,7 +11,9 @@ package main
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;update;delete
+//+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
@@ -21,6 +23,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=*
 //+kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=*
 //+kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=*
+//+kubebuilder:rbac:groups="",resources=events,verbs=create
 //+kubebuilder:rbac:groups="",resources=events,verbs=create
 //+kubebuilder:rbac:groups="",resources=events,verbs=create
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
@@ -43,6 +46,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;update;watch;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;watch;list;create
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=list;get;watch
 //+kubebuilder:rbac:groups="",resources=secrets;configmaps;events,verbs=get;list;watch;create;update;delete;deletecollection;patch
 //+kubebuilder:rbac:groups="",resources=secrets;events,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="",resources=secrets;namespaces,verbs=list;get;watch;delete
@@ -183,6 +187,7 @@ package main
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update;patch
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
@@ -216,6 +221,7 @@ package main
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments;clusterpools;clusterclaims;machinepools,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments;syncsets;selectorsyncsets,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterimagesets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterimagesets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=hiveinternal.openshift.io,resources=*,verbs=*
 //+kubebuilder:rbac:groups=hiveinternal.openshift.io,resources=clustersyncs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters;nodepools,verbs=list;watch

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -169,7 +169,7 @@ func GetTestImages() []string {
 		"assisted_service", "assisted_image_service", "postgresql_12", "assisted_installer_agent", "assisted_installer_controller",
 		"assisted_installer", "console_mce", "hypershift_addon_operator", "hypershift_operator",
 		"apiserver_network_proxy", "aws_encryption_provider", "cluster_api", "cluster_api_provider_agent", "cluster_api_provider_aws",
-		"cluster_api_provider_azure", "cluster_api_provider_kubevirt", "cluster_proxy_addon", "cluster_proxy"}
+		"cluster_api_provider_azure", "cluster_api_provider_kubevirt", "cluster_proxy_addon", "cluster_proxy", "cluster_image_set_controller"}
 }
 
 func IsUnitTest() bool {


### PR DESCRIPTION
This PR replaces https://github.com/stolostron/backplane-operator/pull/334 because I could update the message to a merge to include the signoff, which is required by the dco task.

Signed-off-by: Philip Wu <phwu@redhat.com>