### PR TITLE
Don't add ownerreference to hypershift-addon ManagedClusterAddOn

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2022-12-13T17:48:24Z"
+    createdAt: "2022-12-20T16:54:44Z"
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-engine.v0.0.1

--- a/pkg/status/condition.go
+++ b/pkg/status/condition.go
@@ -52,7 +52,7 @@ func NewCondition(condType v1.MultiClusterEngineConditionType, status metav1.Con
 // SetCondition sets the status condition. It either overwrites the existing one or creates a new one.
 func setCondition(conditions []v1.MultiClusterEngineCondition, c v1.MultiClusterEngineCondition) []v1.MultiClusterEngineCondition {
 	currentCond := getCondition(conditions, c.Type)
-	if currentCond != nil && currentCond.Status == c.Status && currentCond.Reason == c.Reason {
+	if currentCond != nil && currentCond.Status == c.Status && currentCond.Reason == c.Reason && currentCond.Message == c.Message {
 		// Condition already present
 		return conditions
 	}


### PR DESCRIPTION
Cleans up hypershift-addon directly in finalizer function.

Jira: https://issues.redhat.com/browse/ACM-2289 

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>