### PR TITLE
Fix: cluster-proxy doesn't work in OCP proxy environment.

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml
@@ -90,7 +90,7 @@ spec:
           - "/cluster-proxy"
         args:
           - "user-server"
-          - "--host=proxy-entrypoint.{{ .Values.global.namespace }}"
+          - "--host=proxy-entrypoint.{{ .Values.global.namespace }}.svc"
           - "--port=8090"
           - "--proxy-ca-cert=/proxy-ca/ca.crt"
           - "--proxy-cert=/proxy-client-tls/tls.crt"


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>

Fixes: https://issues.redhat.com/browse/ACM-2829