### PR TITLE
ACM-2940 Setup cluster-manager webhook proxying in hosted-mode MCE

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -850,6 +850,17 @@ spec:
           - patch
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - agent-install.openshift.io
           resources:
           - nmstateconfigs

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1379,6 +1379,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - discovery.open-cluster-management.io
   resources:
   - discoveredclusters
@@ -1789,6 +1797,18 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - operator.open-cluster-management.io
   resources:
   - clustermanagers
@@ -2064,6 +2084,32 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
+  - searches
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
+  - searches/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
+  - searches/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1379,14 +1379,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - discovery.open-cluster-management.io
   resources:
   - discoveredclusters
@@ -2076,18 +2068,6 @@ rules:
   - route.openshift.io
   resources:
   - routes/custom-host
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - search.open-cluster-management.io
-  resources:
-  - searches
   verbs:
   - create
   - delete

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -115,6 +115,7 @@ const (
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets/join,verbs=create
 //+kubebuilder:rbac:groups=migration.k8s.io,resources=storageversionmigrations,verbs=create;get;list;update;patch;watch;delete
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;get;list;update;patch;watch;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;get;list;update;patch;watch;delete
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons;clustermanagementaddons/finalizers;managedclusteraddons;managedclusteraddons/finalizers;managedclusteraddons/status,verbs=create;get;list;update;patch;watch;delete;deletecollection
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=addonplacementscores,verbs=create;get;list;update;patch;watch;delete;deletecollection

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -933,7 +933,7 @@ var _ = Describe("BackplaneConfig controller", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        BackplaneConfigName,
-						Annotations: map[string]string{"deploymentmode": string(v1.ModeHosted), "mce-kubeconfig": "test"},
+						Annotations: map[string]string{"deploymentmode": string(v1.ModeHosted), "mce-kubeconfig": "test", "hosted-cluster-name": "test", "hosted-cluster-namespace": "test2", "hyper-shift-control-plane-namespace": "test3"},
 					},
 					Spec: v1.MultiClusterEngineSpec{
 						TargetNamespace: DestinationNamespace,

--- a/pkg/foundation/hosted_cluster_manager.go
+++ b/pkg/foundation/hosted_cluster_manager.go
@@ -21,7 +21,7 @@ func hostedName(m *v1.MultiClusterEngine) string {
 }
 
 // HostedClusterManager returns the ClusterManager in hosted mode
-func HostedClusterManager(m *v1.MultiClusterEngine, overrides map[string]string) *unstructured.Unstructured {
+func HostedClusterManager(m *v1.MultiClusterEngine, overrides map[string]string, registrationWebhookServiceAddr string, workWebhookServiceAddr string) *unstructured.Unstructured {
 	log := log.FromContext(context.Background())
 
 	cmTolerations := []corev1.Toleration{}
@@ -51,11 +51,11 @@ func HostedClusterManager(m *v1.MultiClusterEngine, overrides map[string]string)
 				Mode: ocmapiv1.InstallModeHosted,
 				Hosted: &ocmapiv1.HostedClusterManagerConfiguration{
 					RegistrationWebhookConfiguration: ocmapiv1.WebhookConfiguration{
-						Address: "192.168.218.1",
+						Address: registrationWebhookServiceAddr,
 						Port:    443,
 					},
 					WorkWebhookConfiguration: ocmapiv1.WebhookConfiguration{
-						Address: "192.168.218.2",
+						Address: workWebhookServiceAddr,
 						Port:    443,
 					},
 				},

--- a/pkg/templates/charts/hosting/cluster-manager/Chart.yaml
+++ b/pkg/templates/charts/hosting/cluster-manager/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: konnectivity-cm-webhook-agent
+version: 0.0.0

--- a/pkg/templates/charts/hosting/cluster-manager/templates/registration-webhook-svc.yaml
+++ b/pkg/templates/charts/hosting/cluster-manager/templates/registration-webhook-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-manager-registration-webhook
+  namespace: {{ .Values.global.namespace }}
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: cluster-manager-registration-webhook
+  sessionAffinity: None
+  type: ClusterIP

--- a/pkg/templates/charts/hosting/cluster-manager/templates/work-webhook-svc.yaml
+++ b/pkg/templates/charts/hosting/cluster-manager/templates/work-webhook-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-manager-work-webhook
+  namespace: {{ .Values.global.namespace }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: cluster-manager-work-webhook
+  sessionAffinity: None
+  type: ClusterIP
+

--- a/pkg/templates/charts/hosting/cluster-manager/values.yaml
+++ b/pkg/templates/charts/hosting/cluster-manager/values.yaml
@@ -1,0 +1,12 @@
+global:
+    imageOverrides:
+    pullSecret: ""
+    namespace: default
+    proxyAddr: []
+    name: ""
+hubconfig:
+    nodeSelector: {}
+    proxyConfigs: {}
+    replicaCount: 1
+    tolerations: []
+org: open-cluster-management

--- a/pkg/templates/charts/hosting/konnectivity/Chart.yaml
+++ b/pkg/templates/charts/hosting/konnectivity/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: konnectivity-cm-webhook-agent
+version: 0.0.0

--- a/pkg/templates/charts/hosting/konnectivity/templates/cm-network-policy.yaml
+++ b/pkg/templates/charts/hosting/konnectivity/templates/cm-network-policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    hypershift.openshift.io/cluster: {{ .Values.global.hostedClusterNS }}/{{ .Values.global.hostedClusterName }}
+  name: konnectivity-server-from-hub-ns
+  namespace: {{ .Values.global.hyperShiftCPNS }}
+spec:
+  policyTypes:
+  - Ingress
+  podSelector:
+    matchLabels:
+      app: konnectivity-server
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          installer.open-cluster-management.io/hosted-engine: {{ .Values.global.name }}
+  - ports:
+    - port: 8091
+      protocol: TCP

--- a/pkg/templates/charts/hosting/konnectivity/templates/cm-webhook-agent.yaml
+++ b/pkg/templates/charts/hosting/konnectivity/templates/cm-webhook-agent.yaml
@@ -67,7 +67,7 @@ spec:
         command:
         - /usr/bin/proxy-agent
         # MCE has an external image entry for the proxy agent image.  SHould we use that?
-        image: quay.io/stolostron/apiserver-network-proxy:latest
+        image: {{ .Values.global.imageOverrides.apiserver_network_policy }}
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3

--- a/pkg/templates/charts/hosting/konnectivity/templates/cm-webhook-agent.yaml
+++ b/pkg/templates/charts/hosting/konnectivity/templates/cm-webhook-agent.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-manager-webhook-konnectivity-agent
+  namespace: {{ .Values.global.namespace }}
+spec:
+  # progressDeadlineSeconds: 600
+  # replicas: 1
+  # revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      installer.open-cluster-management.io/mce-component: cluster-manager-webhooks-konnectivity-agent
+      installer.open-cluster-management.io/hosted-engine: {{ .Values.global.name }}
+  # strategy:
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
+  #   type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        # XXX:
+        # Is there some best practice that says we should set an "app" label?
+        # If not, delete this as this deployment spec does not oatherwise depened on
+        # having such a (redundant) label.
+        #
+        # If we need to specify it, in order to be a unique thing (is that necessary?)
+        # maybe we use the form <mce-instance-name>-webhooks-konnectivity-agent-work?
+        #
+        ## app: hh-1-cluster-manager-webhooks-konnectivity-agent
+
+        installer.open-cluster-management.io/mce-component: cluster-manager-webhooks-konnectivity-agent
+        installer.open-cluster-management.io/hosted-engine: {{ .Values.global.name }}
+    spec:
+      # XXX: Need to analyze and settle on any node or pod affinity we sould specify here.
+      #      For now, we just leave ourselves open to the whims of the kube scheduler.
+      # affinity:
+      #   <deferred for now>
+
+      automountServiceAccountToken: false
+
+      containers:
+      - args:
+        - --proxy-server-host
+        - konnectivity-server.{{ .Values.global.hyperShiftCPNS }}.svc
+        - --agent-identifiers
+        - {{ range $i,$v :=.Values.global.proxyAddr }}{{ if $i }}&{{ end }}ipv4={{ $v }}{{ end }}
+        - --logtostderr=true
+        - --ca-cert
+        - /etc/konnectivity/agent/ca.crt
+        - --agent-cert
+        - /etc/konnectivity/agent/tls.crt
+        - --agent-key
+        - /etc/konnectivity/agent/tls.key
+        - --proxy-server-port
+        - "8091"
+        - --health-server-port
+        - "2041"
+        - --keepalive-time
+        - 30s
+        - --probe-interval
+        - 30s
+        - --sync-interval
+        - 1m
+        - --sync-interval-cap
+        - 5m
+        command:
+        - /usr/bin/proxy-agent
+        # MCE has an external image entry for the proxy agent image.  SHould we use that?
+        image: quay.io/stolostron/apiserver-network-proxy:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: healthz
+            port: 2041
+            scheme: HTTP
+          initialDelaySeconds: 120
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 30
+        name: konnectivity-agent
+        resources:
+          requests:
+            cpu: 40m
+            memory: 50Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/konnectivity/agent
+          name: agent-certs
+      dnsPolicy: ClusterFirst
+      priorityClassName: hypershift-control-plane
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      # XXX: What kind of nodes get corresponding taints?
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/control-plane
+        operator: Equal
+        value: "true"
+      - effect: NoSchedule
+        key: hypershift.openshift.io/cluster
+        operator: Equal
+        value: {{ .Values.global.hyperShiftCPNS }}
+      volumes:
+      - name: agent-certs
+        secret:
+          defaultMode: 420
+          # This secret is copied into the hosted MCE operand namespace.
+          secretName: konnectivity-agent

--- a/pkg/templates/charts/hosting/konnectivity/values.yaml
+++ b/pkg/templates/charts/hosting/konnectivity/values.yaml
@@ -1,0 +1,15 @@
+global:
+    imageOverrides:
+    pullSecret: ""
+    namespace: default
+    proxyAddr: []
+    hyperShiftCPNS: ""
+    hostedClusterName: ""
+    hostedClusterNS: ""
+    name: ""
+hubconfig:
+    nodeSelector: {}
+    proxyConfigs: {}
+    replicaCount: 1
+    tolerations: []
+org: open-cluster-management

--- a/pkg/templates/charts/hosting/konnectivity/values.yaml
+++ b/pkg/templates/charts/hosting/konnectivity/values.yaml
@@ -1,5 +1,6 @@
 global:
     imageOverrides:
+        apiserver_network_policy: quay.io/test/test:test him
     pullSecret: ""
     namespace: default
     proxyAddr: []

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -24,6 +24,8 @@ const (
 
 	DiscoveryChartDir        = "pkg/templates/charts/toggle/discovery-operator"
 	HostedImportChartDir     = "pkg/templates/charts/hosted/server-foundation"
+	HostedKonnectivityDir    = "pkg/templates/charts/hosting/konnectivity"
+	HostedCMDir              = "pkg/templates/charts/hosting/cluster-manager"
 	HostingImportChartDir    = "pkg/templates/charts/hosting/server-foundation"
 	HiveChartDir             = "pkg/templates/charts/toggle/hive-operator"
 	AssistedServiceChartDir  = "pkg/templates/charts/toggle/assisted-service"

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -26,6 +26,10 @@ var (
 
 	// AnnotationKubeconfig is the secret name residing in targetcontaining the kubeconfig to access the remote cluster
 	AnnotationKubeconfig = "mce-kubeconfig"
+
+	AnnotationHostedClusterName      = "hosted-cluster-name"
+	AnnotationHostedClusterNamespace = "hosted-cluster-namespace"
+	AnnotationHyperShiftNamespace    = "hyper-shift-control-plane-namespace"
 )
 
 // IsPaused returns true if the multiclusterengine instance is labeled as paused, and false otherwise
@@ -110,4 +114,43 @@ func GetHostedCredentialsSecret(mce *backplanev1.MultiClusterEngine) (types.Name
 		nn.Namespace = backplanev1.DefaultTargetNamespace
 	}
 	return nn, nil
+}
+
+func GetKonnectivitySecret(mce *backplanev1.MultiClusterEngine) (types.NamespacedName, error) {
+	nn := types.NamespacedName{}
+	if mce.Annotations == nil || mce.Annotations[AnnotationHyperShiftNamespace] == "" {
+		return nn, fmt.Errorf("no kubeconfig secret annotation defined in %s", mce.Name)
+	}
+	nn.Name = "konnectivity-agent"
+
+	nn.Namespace = mce.Annotations[AnnotationHyperShiftNamespace]
+	return nn, nil
+}
+
+func GetHostedClusterNamespace(mce *backplanev1.MultiClusterEngine) (string, error) {
+	var ns string
+	if mce.Annotations == nil || mce.Annotations[AnnotationHostedClusterNamespace] == "" {
+		return ns, fmt.Errorf("no hosted cluster namespace annotation defined in %s", mce.Name)
+	}
+
+	ns = mce.Annotations[AnnotationHostedClusterNamespace]
+	return ns, nil
+}
+func GetHyperShiftNamespace(mce *backplanev1.MultiClusterEngine) (string, error) {
+	var ns string
+	if mce.Annotations == nil || mce.Annotations[AnnotationHyperShiftNamespace] == "" {
+		return ns, fmt.Errorf("no hyper shift conntrol plane namespace annotation defined in %s", mce.Name)
+	}
+
+	ns = mce.Annotations[AnnotationHyperShiftNamespace]
+	return ns, nil
+}
+func GetHostedClusterName(mce *backplanev1.MultiClusterEngine) (string, error) {
+	var ns string
+	if mce.Annotations == nil || mce.Annotations[AnnotationHostedClusterName] == "" {
+		return ns, fmt.Errorf("no hosted cluster name annotation defined in %s", mce.Name)
+	}
+
+	ns = mce.Annotations[AnnotationHostedClusterName]
+	return ns, nil
 }

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -23,7 +23,6 @@ var (
 	AnnotationImageRepo = "imageRepository"
 	// AnnotationImageOverridesCM identifies a configmap name containing an image override mapping
 	AnnotationImageOverridesCM = "imageOverridesCM"
-
 	// AnnotationKubeconfig is the secret name residing in targetcontaining the kubeconfig to access the remote cluster
 	AnnotationKubeconfig = "mce-kubeconfig"
 
@@ -119,7 +118,7 @@ func GetHostedCredentialsSecret(mce *backplanev1.MultiClusterEngine) (types.Name
 func GetKonnectivitySecret(mce *backplanev1.MultiClusterEngine) (types.NamespacedName, error) {
 	nn := types.NamespacedName{}
 	if mce.Annotations == nil || mce.Annotations[AnnotationHyperShiftNamespace] == "" {
-		return nn, fmt.Errorf("no kubeconfig secret annotation defined in %s", mce.Name)
+		return nn, fmt.Errorf("no konnectivity secret annotation defined in %s", mce.Name)
 	}
 	nn.Name = "konnectivity-agent"
 


### PR DESCRIPTION
The PR create several new resources when enabling cluster manager so as to allow proxying for the web hooks. The most important of these is the konnectivity deployment which takes in the addresses of the two web hook services. These addresses are also added to be cluster manager itself. When this deployment is up and running in the MCE target namespace, proxying should be working. In order to test this I get a oc api-resources on the hosted cluster which was expected to complete successfully

Issue: https://issues.redhat.com/browse/ACM-2940