### PR TITLE
adding local-cluster status to false when detaching

### DIFF
--- a/pkg/status/local_cluster.go
+++ b/pkg/status/local_cluster.go
@@ -117,6 +117,21 @@ func (s *LocalClusterStatus) enabledStatus(mc *unstructured.Unstructured) bpv1.C
 		}
 	}
 
+	// correct the user's change of the local-cluster in mce when it is owned by mch
+	if detaching := mc.GetDeletionTimestamp(); detaching != nil {
+		return bpv1.ComponentCondition{
+			Name:               s.GetName(),
+			Kind:               s.GetKind(),
+			Available:          false,
+			Type:               latest["type"].(string),
+			Status:             metav1.ConditionStatus(latest["status"].(string)),
+			LastUpdateTime:     metav1.Now(),
+			LastTransitionTime: metav1.Now(),
+			Reason:             latest["reason"].(string),
+			Message:            "Local-Cluster is currently being detached",
+		}
+	}
+
 	return bpv1.ComponentCondition{
 		Name:               s.GetName(),
 		Kind:               s.GetKind(),


### PR DESCRIPTION
Fix the bug that when user messes with mce toggle of local-cluster when it is owned by mch, it gets detached before the watch can correct the change. Add the status of detaching and set local-cluster available boolean to false to trigger mce to reconcile and reimport the local-cluster.