### PR TITLE
add RBAC to list multiclusterengines to fix ACM-4230

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager_clusterrole.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager_clusterrole.yaml
@@ -56,3 +56,6 @@ rules:
 - apiGroups: ["route.openshift.io"]
   resources: ["routes"]
   verbs: ["get", "list", "create", "delete", "update", "patch"]
+- apiGroups: ["multicluster.openshift.io"]
+  resources: ["multiclusterengines"]
+  verbs: ["list"]

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -256,6 +256,7 @@ package main
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
+//+kubebuilder:rbac:groups=multicluster.openshift.io,resources=multiclusterengines,verbs=list
 //+kubebuilder:rbac:groups=multicluster.openshift.io,resources=multiclusterengines,verbs=list;watch
 //+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=clustermanagers,verbs=get;list;watch;update;delete
 //+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=clustermanagers/status,verbs=update;patch


### PR DESCRIPTION
Add a cluster role rule to list multiclusterengines to fix https://issues.redhat.com/browse/ACM-4230 and https://github.com/stolostron/backlog/issues/27211