### PR TITLE
Fix not-valid-tip-of-branch errors when running gen-bundle for Hive

### DIFF
--- a/hack/bundle-automation/gen-hive-bundle.sh
+++ b/hack/bundle-automation/gen-hive-bundle.sh
@@ -5,7 +5,8 @@
 # Arguments:
 #
 # $1 = Name of branch of commit SHA to use for the tool, and the bundle input.
-# $2 = Pathname of the directory to contain the resulting Hive bundle.
+# $2 = Commit SHA (or HEAD) on branch named in $1
+# $3 = Pathname of the directory to contain the resulting Hive bundle.
 #
 # Note: The output directory is removed at the start of each run to ensure
 #       a clean/consistent result.
@@ -63,7 +64,7 @@ fi
 mkdir bundle
 cd bundle
 echo "Running Hive bundle-gen tool ($gen_tool)."
-python3 ../hive/$gen_tool --hive-repo "$hive_repo_spot" --dummy-bundle "$commit_ish"
+python3 ../hive/$gen_tool --hive-repo "$hive_repo_spot" --commit "$commit_ish" --dummy-bundle "$branch"
 # Note: We point the bundle-gen tool at the local repo we already checked out
 # since we know that it contains the Git SHA we are using for input.
 rc=$?


### PR DESCRIPTION
Starting some time ago, our Generate Charts From Bundle (aka Zatch Technology(tm)) automation started failing when run for the Hive operator, with errors symptoms like this:
```
INFO:root:Running bundle-gen tool: ./hack/bundle-automation/gen-hive-bundle.sh mce-2.3 acfdebfb192b5f566562474f691e15259f87e794 /tmp/hive-operator-manifests
Cloning/checking out HIve repo at branch/commit (acfdebfb192b5f566562474f691e15259f87e794).
Cloning into 'hive'...
Updating files: 100% (31317/31317), done.
From https://github.com/openshift/hive
 * branch                mce-2.3    -> FETCH_HEAD
Branch 'mce-2.3' set up to track remote branch 'mce-2.3' from 'origin'.
Switched to a new branch 'mce-2.3'
HEAD is now at acfdebfb1 Merge pull request #2027 from 2uasimojo/re-enable-autoscale
Running Hive bundle-gen tool (hack/bundle-gen.py).
Cloning /tmp/gen-hive-bundle.sh.wIFAP4FH/hive to /tmp/hive-repo-baarz0wp
Trying to find acfdebfb192b5f566562474f691e15259f87e794 at acfdebfb192b5f566562474f691e15259f87e794
Found acfdebfb192b5f566562474f691e15259f87e794 at `acfdebfb192b5f566562474f691e15259f87e794`
Error: branch arg acfdebfb192b5f566562474f691e15259f87e794 is not a valid tip of mce-* branch or master branch

                Consider using the `--commit acfdebfb192b5f566562474f691e15259f87e794` argument if this commit is an ancestor of a valid
                mce-* or master branch
Error: Hive's bundle_gen script failed (rc: 1).
CRITICAL:root:Bundle-generation script exited with errors.
```

It appears that the Hive team did a major rewrite of the their underlying bundle-generation script that we call as part of this, with those changes breaking our invocation pattern (where the commit we are going after is not necessarily the head of an MCE branch, since we pin to SHAs).  The changes were introduced with commits  introduced on 2023-04-25ish that reference JIRA HIVE-2202.

I *think* this PR fixes our invocation of their underlying tool to work as expected again.