### PR TITLE
Manual bundle-to-charts update for backplane-2.3

### DIFF
--- a/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
@@ -114,6 +114,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: assisted-service
       terminationGracePeriodSeconds: 10
 {{- with .Values.hubconfig.tolerations }}

--- a/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager.yaml
@@ -88,6 +88,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: cluster-manager
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/discovery-operator/templates/discovery-operator.yaml
+++ b/pkg/templates/charts/toggle/discovery-operator/templates/discovery-operator.yaml
@@ -97,6 +97,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: discovery-operator
       terminationGracePeriodSeconds: 10
 {{- with .Values.hubconfig.tolerations }}

--- a/pkg/templates/charts/toggle/hive-operator/templates/hive-operator.yaml
+++ b/pkg/templates/charts/toggle/hive-operator/templates/hive-operator.yaml
@@ -101,6 +101,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: hive-operator
       terminationGracePeriodSeconds: 10
 {{- with .Values.hubconfig.tolerations }}


### PR DESCRIPTION
This PR is the result of a manual bundle-to-chart run on the backplane-2.3 branch after the changes made by PRs #451 and #453 were merged into this branch.

This is *not* a cherry pick from a similar update done to the `main` branch since the `main` branch now already represetns the `backplane-2.4` release.