### PR TITLE
Manual bundle-to-charts update for main branch

### DIFF
--- a/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
@@ -114,6 +114,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: assisted-service
       terminationGracePeriodSeconds: 10
 {{- with .Values.hubconfig.tolerations }}

--- a/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager.yaml
@@ -88,6 +88,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: cluster-manager
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/discovery-operator/templates/discovery-operator.yaml
+++ b/pkg/templates/charts/toggle/discovery-operator/templates/discovery-operator.yaml
@@ -97,6 +97,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: discovery-operator
       terminationGracePeriodSeconds: 10
 {{- with .Values.hubconfig.tolerations }}

--- a/pkg/templates/charts/toggle/hive-operator/templates/hive-operator.yaml
+++ b/pkg/templates/charts/toggle/hive-operator/templates/hive-operator.yaml
@@ -101,6 +101,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: hive-operator
       terminationGracePeriodSeconds: 10
 {{- with .Values.hubconfig.tolerations }}


### PR DESCRIPTION
DO NOT CHERRY PICK INTO BACKPLANE-2.3

This PR is the result of a manual bundle-to-chart run on the main branch after the changes made by PRs #450 and #452 were merged into this branch.

This is a main-branch counterpart to already-merged PR #454.  It should NOT be cherry picked into the backplane-2.3 branch as that update has already been done.  (It is necessary to do separate updates since the main branch has moved to representing the next-release (2.4) of MCE and the config for doing the bundle-to-chart generation will now differ between the branches).
