### PR TITLE
Update cluster manager bundle automation.

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -21,7 +21,7 @@
         assisted-installer: assisted_installer
         assisted-image-service: assisted_image_service
 - repo_name: registration-operator
-  github_ref: "https://github.com/stolostron/registration-operator.git"
+  github_ref: "https://github.com/stolostron/ocm.git"
   branch: "backplane-2.4"
   operators:
     - name: cluster-manager
@@ -37,4 +37,4 @@
     - name: discovery-operator
       bundlePath: "bundle/manifests/"
       imageMappings:
-        discovery-operator: discovery_operator 
+        discovery-operator: discovery_operator

--- a/pkg/templates/crds/cluster-manager/operator.open-cluster-management.io_clustermanagers.yaml
+++ b/pkg/templates/crds/cluster-manager/operator.open-cluster-management.io_clustermanagers.yaml
@@ -147,6 +147,11 @@ spec:
               registrationConfiguration:
                 description: RegistrationConfiguration contains the configuration of registration
                 properties:
+                  autoApproveUsers:
+                    description: AutoApproveUser represents a list of users that can auto approve CSR and accept client. If the credential of the bootstrap-hub-kubeconfig matches to the users, the cluster created by the bootstrap-hub-kubeconfig will be auto-registered into the hub cluster. This takes effect only when ManagedClusterAutoApproval feature gate is enabled.
+                    items:
+                      type: string
+                    type: array
                   featureGates:
                     description: 'FeatureGates represents the list of feature gates for registration If it is set empty, default feature gates will be used. If it is set, featuregate/Foo is an example of one item in FeatureGates: 1. If featuregate/Foo does not exist, registration-operator will discard it 2. If featuregate/Foo exists and is false by default. It is now possible to set featuregate/Foo=[false|true] 3. If featuregate/Foo exists and is true by default. If a cluster-admin upgrading from 1 to 2 wants to continue having featuregate/Foo=false, he can set featuregate/Foo=false before upgrading. Let''s say the cluster-admin wants featuregate/Foo=false.'
                     items:


### PR DESCRIPTION
The PR is for: https://issues.redhat.com/browse/ACM-5551

We consolidate server foundation code into one new repo - [the ocm repo](https://github.com/stolostron/ocm)

So the automation script must be updated as well.