### PR TITLE
Revert "Update webhook server tls min version to 1.3 (#427)"

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "797f9276.open-cluster-management.io",
-		WebhookServer:          &webhook.Server{TLSMinVersion: "1.3"},
+		WebhookServer:          &webhook.Server{TLSMinVersion: "1.2"},
 		LeaseDuration:          &leaseDuration,
 		RenewDeadline:          &renewDeadline,
 		RetryPeriod:            &retryPeriod,


### PR DESCRIPTION
This reverts commit 8948288b0b4e82269d83a06543c946b31123ab50.

Jira: https://issues.redhat.com/browse/ACM-5997