### PR TITLE
Update generate bundles script

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -12,7 +12,7 @@
   operators:
     - name: "assisted-service"
       channel: "ocm-2.9"
-      package-yml: "operators/assisted-service-operator/assisted-service.package.yaml"
+      bundles-directory: "operators/assisted-service-operator/"
       imageMappings:
         assisted-service: assisted_service
         postgresql-12-centos7: postgresql_12


### PR DESCRIPTION
Assisted-service-operator was converted from packagemanifest to bundle format so the automated scripting has to update. It will now look through all annotation metadata files to find the latest bundle on the desired channel.

Jira: [ACM-6264](https://issues.redhat.com/browse/ACM-6264)