### PR TITLE
[ACM-3133] Removed MCE subcomponent adoption code

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,13 +3,13 @@ approvers:
 - eemurphy
 - JakobGray
 - joeg-pro
-- ray-harris
-- zkayyali812
+- dislbenn
+- ngraham20
 
 reviewers:
 - cameronmwall
 - eemurphy
 - JakobGray
 - joeg-pro
-- ray-harris
-- zkayyali812
+- dislbenn
+- ngraham20


### PR DESCRIPTION
In MCE 2.0, the sub-components were required to be adopted by the `MultiClusterEngine`, so those resources wouldn't be removed when MCH was deleted. These changes are no longer in the latest MCE versions.