### PR TITLE
[ACM-6981] Added olmv1alpha1 to scheme

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,6 +90,8 @@ func init() {
 
 	utilruntime.Must(apiregistrationv1.AddToScheme(scheme))
 
+	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
+
 	utilruntime.Must(admissionregistration.AddToScheme(scheme))
 
 	utilruntime.Must(apixv1.AddToScheme(scheme))


### PR DESCRIPTION
Adding `olmv1alpha1` to scheme to register the kind for `ClusterServiceVersion`. Since this was missing, when `DISABLE_CLIENT_CACHE` is enabled, this will cause the `multicluster-engine-operator` pod to fail.

```
1.6934115950189047e+09 ERROR setup unable to start manager {"error": "no kind is registered for the type v1alpha1.ClusterServiceVersion in scheme \"pkg/runtime/scheme.go:100\""}
```
