### PR TITLE
Add console ServiceMonitor for metric collection

### DIFF
--- a/pkg/templates/charts/toggle/console-mce/templates/console-metrics-monitor-role.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-metrics-monitor-role.yaml
@@ -1,0 +1,15 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-metrics-monitor
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints

--- a/pkg/templates/charts/toggle/console-mce/templates/console-metrics-monitor-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-metrics-monitor-rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-metrics-monitor
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: console-metrics-monitor

--- a/pkg/templates/charts/toggle/console-mce/templates/console-service.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-service.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: console-mce-console-certs
   name: console-mce-console
+  labels:
+    app: console-mce
 spec:
   ports:
     - port: 3000

--- a/pkg/templates/charts/toggle/console-mce/templates/console-servicemonitor.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: console-mce-monitor
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 60s
+      port: http
+      scheme: https
+      scrapeTimeout: 10s
+      tlsConfig:
+        ca: {}
+        cert: {}
+        insecureSkipVerify: true
+  jobLabel: console-mce-console
+  namespaceSelector:
+    matchNames:
+      - multicluster-engine
+  selector:
+    matchLabels:
+      app: console-mce

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -41,6 +41,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=pods;pods/log,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;update;watch


### PR DESCRIPTION
# Description

The addition of the console ServiceMonitor will allow us to track a new metric added by console frontend to track user interactions with the various RHACM pages. This will increase transparency into how customers are interacting with the product.

## Related Issue

https://issues.redhat.com/browse/ACM-6797

## Changes Made

This PR adds a SerivceMonitor, Role & RoleBinding to the console-mce chart

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
