### PR TITLE
update chart for managed-serviceaccount

### DIFF
--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/addontemplate.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/addontemplate.yaml
@@ -1,7 +1,7 @@
 apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: AddOnTemplate
 metadata:
-  name: managed-serviceaccount-0.4.0
+  name: managed-serviceaccount-2.4
 spec:
   addonName: managed-serviceaccount
   agentSpec:

--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/clustermanagementaddon.yaml
@@ -20,4 +20,4 @@ spec:
   - group: addon.open-cluster-management.io
     resource: addontemplates
     defaultConfig:
-      name: managed-serviceaccount-0.4.0
+      name: managed-serviceaccount-2.4

--- a/pkg/templates/managed-serviceaccount/crds/authentication.open-cluster-management.io_managedserviceaccounts.yaml
+++ b/pkg/templates/managed-serviceaccount/crds/authentication.open-cluster-management.io_managedserviceaccounts.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: managedserviceaccounts.authentication.open-cluster-management.io
 spec:
@@ -78,13 +78,14 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -167,6 +168,160 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ManagedServiceAccount is the Schema for the managedserviceaccounts
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedServiceAccountSpec defines the desired state of ManagedServiceAccount
+            properties:
+              rotation:
+                description: Rotation is the policy for rotation the credentials.
+                properties:
+                  enabled:
+                    default: true
+                    description: Enabled prescribes whether the ServiceAccount token
+                      will be rotated from the upstream
+                    type: boolean
+                  validity:
+                    default: 8640h0m0s
+                    description: Validity is the duration for which the signed ServiceAccount
+                      token is valid.
+                    type: string
+                type: object
+              ttlSecondsAfterCreation:
+                description: ttlSecondsAfterCreation limits the lifetime of a ManagedServiceAccount.
+                  If the ttlSecondsAfterCreation field is set, the ManagedServiceAccount
+                  will be automatically deleted regardless of the ManagedServiceAccount's
+                  status. When the ManagedServiceAccount is deleted, its lifecycle
+                  guarantees (e.g. finalizers) will be honored. If this field is unset,
+                  the ManagedServiceAccount won't be automatically deleted. If this
+                  field is set to zero, the ManagedServiceAccount becomes eligible
+                  for deletion immediately after its creation. In order to use ttlSecondsAfterCreation,
+                  the EphemeralIdentity feature gate must be enabled.
+                exclusiveMinimum: true
+                format: int32
+                minimum: 0
+                type: integer
+            required:
+            - rotation
+            type: object
+          status:
+            description: ManagedServiceAccountStatus defines the observed state of
+              ManagedServiceAccount
+            properties:
+              conditions:
+                description: Conditions is the condition list.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              expirationTimestamp:
+                description: ExpirationTimestamp is the time when the token will expire.
+                format: date-time
+                type: string
+              tokenSecretRef:
+                description: TokenSecretRef is a reference to the corresponding ServiceAccount's
+                  Secret, which stores the CA certficate and token from the managed
+                  cluster.
+                properties:
+                  lastRefreshTimestamp:
+                    description: LastRefreshTimestamp is the timestamp indicating
+                      when the token in the Secret is refreshed.
+                    format: date-time
+                    type: string
+                  name:
+                    description: Name is the name of the referenced secret.
+                    type: string
+                required:
+                - lastRefreshTimestamp
+                - name
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
     subresources:
       status: {}
 status:


### PR DESCRIPTION
# Description

1. update the managedServiceAccount CRD
2. update the chart generate script to update chart version before rendering templates, this can make the generated addontemplate name with ACM version prefix.

## Related Issue

https://issues.redhat.com/browse/ACM-7072

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
