### PR TITLE
[ACM-7674] Updated MCE operand namespace to support openshift.io/cluster-monitor…

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -846,6 +846,10 @@ func (r *MultiClusterEngineReconciler) ensureOpenShiftNamespaceLabel(ctx context
 		return ctrl.Result{Requeue: true}, err
 	}
 
+	if existingNs.Labels == nil || len(existingNs.Labels) == 0 {
+		existingNs.Labels = make(map[string]string)
+	}
+
 	if _, ok := existingNs.Labels[utils.OpenShiftClusterMonitoringLabel]; !ok {
 		log.Info(fmt.Sprintf("Adding label: %s to namespace: %s", utils.OpenShiftClusterMonitoringLabel,
 			backplaneConfig.Spec.TargetNamespace))

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -127,7 +127,8 @@ var _ = Describe("BackplaneConfig controller", func() {
 		// Create target namespace
 		err = k8sClient.Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: DestinationNamespace,
+				Name:   DestinationNamespace,
+				Labels: map[string]string{},
 			},
 			Spec: corev1.NamespaceSpec{},
 		})

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -379,7 +380,6 @@ var _ = Describe("BackplaneConfig controller", func() {
 		Context("and no image pull policy is specified", func() {
 			It("should deploy sub components", func() {
 				createCtx := context.Background()
-				By("creating the backplane config")
 				backplaneConfig := &v1.MultiClusterEngine{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "multicluster.openshift.io/v1",
@@ -393,6 +393,12 @@ var _ = Describe("BackplaneConfig controller", func() {
 						ImagePullSecret: "testsecret",
 					},
 				}
+
+				By("ensuring that no openshift.io/cluster-monitoring label is enabled if MCE does not exist")
+				res, _ := reconciler.ensureOpenShiftNamespaceLabel(createCtx, backplaneConfig)
+				Expect(res).To(Equal(ctrl.Result{Requeue: true}))
+
+				By("creating the backplane config")
 				Expect(k8sClient.Create(createCtx, backplaneConfig)).Should(Succeed())
 
 				By("ensuring each deployment and config is created")
@@ -978,7 +984,6 @@ var _ = Describe("BackplaneConfig controller", func() {
 
 					g.Expect(existingMCE.Status.Phase).To(Not(Equal(v1.MultiClusterEnginePhaseError)))
 				}, timeout, interval).Should(Succeed())
-
 			})
 		})
 
@@ -1033,6 +1038,5 @@ var _ = Describe("BackplaneConfig controller", func() {
 
 			})
 		})
-
 	})
 })

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -127,8 +127,7 @@ var _ = Describe("BackplaneConfig controller", func() {
 		// Create target namespace
 		err = k8sClient.Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   DestinationNamespace,
-				Labels: make(map[string]string),
+				Name: DestinationNamespace,
 			},
 			Spec: corev1.NamespaceSpec{},
 		})

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -128,7 +128,7 @@ var _ = Describe("BackplaneConfig controller", func() {
 		err = k8sClient.Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   DestinationNamespace,
-				Labels: map[string]string{},
+				Labels: make(map[string]string),
 			},
 			Spec: corev1.NamespaceSpec{},
 		})

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -394,12 +394,25 @@ var _ = Describe("BackplaneConfig controller", func() {
 					},
 				}
 
-				By("ensuring that no openshift.io/cluster-monitoring label is enabled if MCE does not exist")
-				res, _ := reconciler.ensureOpenShiftNamespaceLabel(createCtx, backplaneConfig)
-				Expect(res).To(Equal(ctrl.Result{Requeue: true}))
-
 				By("creating the backplane config")
 				Expect(k8sClient.Create(createCtx, backplaneConfig)).Should(Succeed())
+
+				By("ensuring that no openshift.io/cluster-monitoring label is enabled if MCE does not exist")
+				backplaneConfig2 := &v1.MultiClusterEngine{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "multicluster.openshift.io/v1",
+						Kind:       "MultiClusterEngine",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: BackplaneConfigName,
+					},
+					Spec: v1.MultiClusterEngineSpec{
+						TargetNamespace: "test-n2",
+					},
+				}
+
+				res, _ := reconciler.ensureOpenShiftNamespaceLabel(createCtx, backplaneConfig2)
+				Expect(res).To(Equal(ctrl.Result{Requeue: true}))
 
 				By("ensuring each deployment and config is created")
 				for _, test := range tests {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,6 +15,9 @@ import (
 
 const (
 	UnitTestEnvVar = "UNIT_TEST"
+
+	// OpenShiftClusterMonitoringLabel is the label for OpenShift cluster monitoring.
+	OpenShiftClusterMonitoringLabel = "openshift.io/cluster-monitoring"
 )
 
 var onComponents = []string{


### PR DESCRIPTION
# Description

Update the MCE operator to add the `openshift.io/cluster-monitoring` label to the namespace where the MCE resources are deployed. The label will be added during the operator reconciling phase.

## Related Issue

https://issues.redhat.com/browse/ACM-7674

## Changes Made

Updated MCE operator to update the namespace object where MCE's operands are deployed with the `openshift.io/cluster-monitoring` label. This will allow OpenShift to detect the namespace where the PrometheusRules and ServiceMonitors will now be deployed.

## Screenshots (if applicable)

<img width="970" alt="Screenshot 2023-09-26 at 12 32 02 PM" src="https://github.com/stolostron/backplane-operator/assets/28898909/8db7322a-1fe8-4146-a028-20685bfb151b">

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
