### PR TITLE
Commit bundle RBAC change not committed as part of PR 511

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-09-06T09:25:25Z"
+    createdAt: "2023-09-26T20:15:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-engine.v0.0.1
@@ -964,6 +964,7 @@ spec:
           - channels
           - gitopsclusters
           - helmreleases
+          - multiclusterapplicationsetreports
           - placementbindings
           - placementrules
           - policies


### PR DESCRIPTION
# Description

PR #511 made a change to `config/rbac/roles.yaml` to add permission for the `multiclusterapplicationsetreports` kind.  It committed some other files as well, but did not commit a change to the operator CSV in the  'bundle/manifests' directory.  This update is make if you run `make bundle` and is needed to ensure that the operator has the new permission when deployed by OLM.

This PR commits the bundle/manifest CSV change missed by PR #511.  If the ACM-7389 issue has been tested and found to be resolved its a mystery to me how things are working, as usually an operator can't provide permission downstream that it doesn't have itself.