### PR TITLE
Console PrometheusRule for page visit counts

### DIFF
--- a/pkg/templates/charts/toggle/console-mce/templates/console-prometheus-rules.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-prometheus-rules.yaml
@@ -1,0 +1,12 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: acm-console-prometheus-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: acm-console.rules
+      rules:
+        - expr: sum by (page) (acm_console_page_count)
+          record: 'acm_console_page_count:sum'

--- a/pkg/templates/charts/toggle/console-mce/templates/console-prometheus-rules.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-prometheus-rules.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: acm-console-prometheus-rules
-  namespace: openshift-monitoring
+  namespace: {{ .Values.global.namespace }}
 spec:
   groups:
     - name: acm-console.rules

--- a/pkg/templates/rbac.go
+++ b/pkg/templates/rbac.go
@@ -56,6 +56,7 @@ var resources = []string{
 	"ManagedProxyConfiguration",
 	"ManagedProxyServiceResolver",
 	"MutatingWebhookConfiguration",
+	"PrometheusRule",
 	"Role",
 	"RoleBinding",
 	"Route",


### PR DESCRIPTION
# Description

Includes a PrometheusRule resource that exposes a metric: `acm_console_page_count:sum`. This metric sums all page visits across the ACM Console, and reduces the cardinality of the original metric so we can upload to Telemetry.

## Related Issue

https://issues.redhat.com/browse/ACM-7492

## Changes Made

The PR adds a PrometheusRule resource for the acm console. The PromRule resource will include one rule that sums page count visits across the console pods (running and previous).

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
