### PR TITLE
Remove service monitor from openshift-monitoring ns

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -306,6 +306,11 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return result, err
 	}
 
+	err = r.removeLegacyCLCPrometheusConfig(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	result, err = r.ensureToggleableComponents(ctx, backplaneConfig)
 	if err != nil {
 		return result, err


### PR DESCRIPTION
# Description

We have changed the location of the Service Monitor resource from `openshift-monitoring` to the mce namespace so the old resource needed to be removed on

## Related Issue

[ACM-7676](https://issues.redhat.com/browse/ACM-7676)

## Changes Made

In the reconcile loop we use a hardcoded delete to remove the resources from `openshift-monitoring`

## Screenshots (if applicable)



## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

