### PR TITLE
[ACM-7676] Removed addition promrules and servicemonitors from openshift-monitor…

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -306,9 +306,8 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return result, err
 	}
 
-	err = r.removeLegacyCLCPrometheusConfig(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
+	for _, kind := range backplanev1.GetLegacyPrometheusKind() {
+		err = r.removeLegacyPrometheusConfigurations(ctx, "openshift-monitoring", kind)
 	}
 
 	result, err = r.ensureToggleableComponents(ctx, backplaneConfig)

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -31,6 +31,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
+	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	v1 "github.com/stolostron/backplane-operator/api/v1"
 	"github.com/stolostron/backplane-operator/pkg/utils"
 
@@ -1097,17 +1098,24 @@ var _ = Describe("BackplaneConfig controller", func() {
 				err := k8sClient.Create(context.TODO(), sm)
 				Expect(err).To(BeNil())
 
+				legacyResourceKind := backplanev1.GetLegacyPrometheusKind()
+				ns := "openshift-monitoring"
+
 				By("Running the cleanup of the legacy Prometheus configuration")
-				err = reconciler.removeLegacyCLCPrometheusConfig(context.TODO())
-				Expect(err).To(BeNil())
+				for _, kind := range legacyResourceKind {
+					err = reconciler.removeLegacyPrometheusConfigurations(context.TODO(), ns, kind)
+					Expect(err).To(BeNil())
+				}
 
 				By("Verifying that the legacy CLC ServiceMonitor is deleted")
 				err = k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(sm), sm)
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 
 				By("Running the cleanup of the legacy Prometheus configuration again should do nothing")
-				err = reconciler.removeLegacyCLCPrometheusConfig(context.TODO())
-				Expect(err).To(BeNil())
+				for _, kind := range legacyResourceKind {
+					err = reconciler.removeLegacyPrometheusConfigurations(context.TODO(), ns, kind)
+					Expect(err).To(BeNil())
+				}
 			})
 		})
 	})

--- a/pkg/templates/charts/toggle/console-mce/templates/console-servicemonitor.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: console-mce-monitor
-  namespace: openshift-monitoring
+  namespace: {{ .Values.global.namespace }}
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -17,7 +17,7 @@ spec:
   jobLabel: console-mce-console
   namespaceSelector:
     matchNames:
-      - multicluster-engine
+      - {{ .Values.global.namespace }}
   selector:
     matchLabels:
       app: console-mce


### PR DESCRIPTION
…ing ns

# Description

Updating MCE operator to remove additional legacy `PrometheusRules` and `ServiceMonitors`

## Related Issue

https://issues.redhat.com/browse/ACM-7676

## Changes Made

MCE operator will now remove the console-mce `PrometheusRule` and `ServiceMonitor` from `openshift-monitoring` namespace.

## Screenshots (if applicable)

N/A

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
