### PR TITLE
temporary change to assisted service bundle channel

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -11,7 +11,7 @@
   github_ref: "https://github.com/redhat-openshift-ecosystem/community-operators-prod.git"
   operators:
     - name: "assisted-service"
-      channel: "ocm-2.9"
+      channel: "ocm-2.10"
       bundles-directory: "operators/assisted-service-operator/"
       imageMappings:
         assisted-service: assisted_service


### PR DESCRIPTION
# Description

Our `regenerate-bundles` script was not pulling changes from assisted installer because the channels were not matched. Installer believes that `ocm-2.9` is the correct channel but we are changing to assisted installer's `ocm-2.10` to solve the issue until we come to a conclusion with assisted installer on what the proper channel should be

## Related Issue

[ACM-7763](https://issues.redhat.com/browse/ACM-7736)

