### PR TITLE
Updated hive image-repo ref in hack config

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -6,9 +6,7 @@
   name: hive-operator
   imageMappings:
     hive: openshift_hive
-    stolostron: openshift_hive
-  imageRepoOverride: stolostron
-  imageTagOverride: 2.4-local-30c82d3f1a0ef1edaedcbed9d92b840732ad2e75
+    disable-image-validation: openshift_hive
 
 - repo_name: "community-operators-prod"
   github_ref: "https://github.com/redhat-openshift-ecosystem/community-operators-prod.git"

--- a/hack/bundle-automation/gen-hive-bundle.sh
+++ b/hack/bundle-automation/gen-hive-bundle.sh
@@ -16,8 +16,7 @@ me=$(basename "$0")
 branch="$1"
 commit_ish="$2"
 output_dir="$3"
-image_repo="$4"
-image_tag_override="$5"
+
 if [[ -z "$output_dir" ]]; then
    >&2 echo "Syntax: $me <commit_ish> <output_path>"
    exit 5
@@ -66,7 +65,9 @@ fi
 mkdir bundle
 cd bundle
 echo "Running Hive bundle-gen tool ($gen_tool)."
-python3 ../hive/$gen_tool --hive-repo "$hive_repo_spot" --commit "$commit_ish" --dummy-bundle "$branch" --image-repo "$image_repo" --image-tag-override "$image_tag_override"
+python3 ../hive/$gen_tool --hive-repo "$hive_repo_spot" --commit "$commit_ish" --dummy-bundle "$branch" \
+   --image-repo disable-image-validation
+
 # Note: We point the bundle-gen tool at the local repo we already checked out
 # since we know that it contains the Git SHA we are using for input.
 rc=$?

--- a/hack/bundle-automation/generate-bundles.py
+++ b/hack/bundle-automation/generate-bundles.py
@@ -723,13 +723,11 @@ def main():
                 branch = repo["branch"]
                 sha = repo["sha"]
                 bundlePath = repo["bundlePath"]
-                imageRepoOverride = repo["imageRepoOverride"]
-                imageTagOverride = repo["imageTagOverride"]
 
             except KeyError:
                 logging.critical("branch and bundlePath are required for tool-generated bundles")
                 exit(1)
-            cmd = "%s %s %s %s %s %s" % (repo["gen_command"], branch, sha, bundlePath, imageRepoOverride, imageTagOverride)
+            cmd = "%s %s %s %s" % (repo["gen_command"], branch, sha, bundlePath)
 
             logging.info("Running bundle-gen tool: %s", cmd)
             rc = os.system(cmd)


### PR DESCRIPTION
# Description

Updated hive config to use the `image-repo` reference instead of passing the `image-repo` and `image-tags` overrides.

## Related Issue

N/A

## Changes Made

Updated hive reference in `hack/bundle-automation/config.yaml`

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @joeg-pro 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
