### PR TITLE
[ACM-8548] Added service and servicemonitor to collect MCE operator metrics

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -71,14 +71,14 @@ var MCEComponents = []string{
 
 var LegacyPrometheusKind = []string{"PrometheusRule", "ServiceMonitor"}
 
-// MCEPrometheusRules is a map that associates certain component names with their corresponding prometheus rules.
-var MCEPrometheusRules = map[string]string{
+// MCELegacyPrometheusRules is a map that associates certain component names with their corresponding prometheus rules.
+var MCELegacyPrometheusRules = map[string]string{
 	ConsoleMCE: "acm-console-prometheus-rules",
 	// Add other components here when PrometheusRules is required.
 }
 
-// MCEServiceMonitors is a map that associates certain component names with their corresponding service monitors.
-var MCEServiceMonitors = map[string]string{
+// MCELegacyServiceMonitors is a map that associates certain component names with their corresponding service monitors.
+var MCELegacyServiceMonitors = map[string]string{
 	ClusterLifecycle: "clusterlifecycle-state-metrics-v2",
 	ConsoleMCE:       "console-mce-monitor",
 	// Add other components here when ServiceMonitors is required.
@@ -217,18 +217,18 @@ func GetLegacyPrometheusKind() []string {
 	return LegacyPrometheusKind
 }
 
-// GetPrometheusRulesName returns the name of the PrometheusRules based on the provided component name.
-func GetPrometheusRulesName(component string) (string, error) {
-	if val, ok := MCEPrometheusRules[component]; !ok {
+// GetLegacyPrometheusRulesName returns the name of the PrometheusRules based on the provided component name.
+func GetLegacyPrometheusRulesName(component string) (string, error) {
+	if val, ok := MCELegacyPrometheusRules[component]; !ok {
 		return val, fmt.Errorf("failed to find PrometheusRules name for: %s component", component)
 	} else {
 		return val, nil
 	}
 }
 
-// GetServiceMonitorName returns the name of the ServiceMonitors based on the provided component name.
-func GetServiceMonitorName(component string) (string, error) {
-	if val, ok := MCEServiceMonitors[component]; !ok {
+// GetLegacyServiceMonitorName returns the name of the ServiceMonitors based on the provided component name.
+func GetLegacyServiceMonitorName(component string) (string, error) {
+	if val, ok := MCELegacyServiceMonitors[component]; !ok {
 		return val, fmt.Errorf("failed to find ServiceMonitors name for: %s component", component)
 	} else {
 		return val, nil

--- a/api/v1/multiclusterengine_methods_test.go
+++ b/api/v1/multiclusterengine_methods_test.go
@@ -109,7 +109,7 @@ func TestGetLegacyPrometheusKind(t *testing.T) {
 	}
 }
 
-func TestGetPrometheusRulesName(t *testing.T) {
+func TestGetLegacyPrometheusRulesName(t *testing.T) {
 	tests := []struct {
 		name      string
 		component string
@@ -118,30 +118,30 @@ func TestGetPrometheusRulesName(t *testing.T) {
 		{
 			name:      "console PrometheusRule",
 			component: api.ConsoleMCE,
-			want:      api.MCEPrometheusRules[api.ConsoleMCE],
+			want:      api.MCELegacyPrometheusRules[api.ConsoleMCE],
 		},
 		{
 			name:      "unknown PrometheusRule",
 			component: "unknown",
-			want:      api.MCEPrometheusRules["unknown"],
+			want:      api.MCELegacyPrometheusRules["unknown"],
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := api.GetPrometheusRulesName(tt.component)
+			got, err := api.GetLegacyPrometheusRulesName(tt.component)
 			if err != nil && tt.component != "unknown" {
-				t.Errorf("GetPrometheusRulesName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+				t.Errorf("GetLegacyPrometheusRulesName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
 			}
 
 			if got != tt.want {
-				t.Errorf("GetPrometheusRulesName(%v) = %v, want: %v", tt.component, got, tt.want)
+				t.Errorf("GetLegacyPrometheusRulesName(%v) = %v, want: %v", tt.component, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestGetServiceMonitorName(t *testing.T) {
+func TestGetLegacyServiceMonitorName(t *testing.T) {
 	tests := []struct {
 		name      string
 		component string
@@ -150,24 +150,24 @@ func TestGetServiceMonitorName(t *testing.T) {
 		{
 			name:      "console ServiceMonitor",
 			component: api.ConsoleMCE,
-			want:      api.MCEServiceMonitors[api.ConsoleMCE],
+			want:      api.MCELegacyServiceMonitors[api.ConsoleMCE],
 		},
 		{
 			name:      "unknown ServiceMonitor",
 			component: "unknown",
-			want:      api.MCEServiceMonitors["unknown"],
+			want:      api.MCELegacyServiceMonitors["unknown"],
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := api.GetServiceMonitorName(tt.component)
+			got, err := api.GetLegacyServiceMonitorName(tt.component)
 			if err != nil && tt.component != "unknown" {
-				t.Errorf("GetServiceMonitorName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+				t.Errorf("GetLegacyServiceMonitorName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
 			}
 
 			if got != tt.want {
-				t.Errorf("GetServiceMonitorName(%v) = %v, want: %v", tt.component, got, tt.want)
+				t.Errorf("GetLegacyServiceMonitorName(%v) = %v, want: %v", tt.component, got, tt.want)
 			}
 		})
 	}

--- a/controllers/uninstall.go
+++ b/controllers/uninstall.go
@@ -167,9 +167,9 @@ func (r *MultiClusterEngineReconciler) removeLegacyPrometheusConfigurations(ctx 
 	for _, c := range backplanev1.MCEComponents {
 		res, err := func() (string, error) {
 			if configType == "PrometheusRule" {
-				return backplanev1.GetPrometheusRulesName(c)
+				return backplanev1.GetLegacyPrometheusRulesName(c)
 			}
-			return backplanev1.GetServiceMonitorName(c)
+			return backplanev1.GetLegacyServiceMonitorName(c)
 		}()
 
 		if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,6 +20,20 @@ const (
 	OpenShiftClusterMonitoringLabel = "openshift.io/cluster-monitoring"
 )
 
+const (
+	/*
+	   MCEOperatorMetricsServiceName is the name of the service used to expose the metrics
+	   endpoint for the multicluster-engine-operator.
+	*/
+	MCEOperatorMetricsServiceName = "multicluster-engine-operator-metrics"
+
+	/*
+	   MCEOperatorMetricsServiceMonitorName is the name of the service monitor used to expose
+	   the metrics for the multicluster-engine-operator.
+	*/
+	MCEOperatorMetricsServiceMonitorName = "multicluster-engine-operator-metrics"
+)
+
 var onComponents = []string{
 	backplanev1.AssistedService,
 	backplanev1.ClusterLifecycle,


### PR DESCRIPTION
# Description

Updated MCE operator to create a service and servicemonitor to allow OCP to begin collecting controller-runtime metrics for the operator.

## Related Issue

https://issues.redhat.com/browse/ACM-8548

## Changes Made

Updated MCE operator to deploy metrics service and servicemonitor to collect controller-runtime metrics.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @ngraham20 @cameronmwall 

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [x] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

/hold