### PR TITLE
[ACM-9006] Updated multiclusterengine phase status to Paused when the operator is paused

### DIFF
--- a/api/v1/multiclusterengine_types.go
+++ b/api/v1/multiclusterengine_types.go
@@ -143,6 +143,7 @@ type PhaseType string
 
 const (
 	MultiClusterEnginePhaseProgressing   PhaseType = "Progressing"
+	MultiClusterEnginePhasePaused        PhaseType = "Paused"
 	MultiClusterEnginePhaseAvailable     PhaseType = "Available"
 	MultiClusterEnginePhaseUninstalling  PhaseType = "Uninstalling"
 	MultiClusterEnginePhaseError         PhaseType = "Error"

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -95,6 +95,12 @@ func (sm *StatusTracker) reportConditions() []bpv1.MultiClusterEngineCondition {
 func (sm *StatusTracker) reportPhase(mce bpv1.MultiClusterEngine, components []bpv1.ComponentCondition, conditions []bpv1.MultiClusterEngineCondition) bpv1.PhaseType {
 	progress := getCondition(conditions, bpv1.MultiClusterEngineProgressing)
 
+	for _, condition := range conditions {
+		if condition.Reason == PausedReason {
+			return bpv1.MultiClusterEnginePhasePaused
+		}
+	}
+
 	// If operator isn't progressing show error phase
 	if progress != nil && progress.Status == metav1.ConditionFalse {
 		return bpv1.MultiClusterEnginePhaseError


### PR DESCRIPTION
# Description

Updated MCE operator to show `Pending` status when the MCE CR has the `pause` annotation set to `true`.

## Related Issue

https://issues.redhat.com/browse/ACM-9006

## Changes Made

Updated MCE CR to show a Pending status when the MCE operator is paused.

## Screenshots (if applicable)

<img width="679" alt="Screenshot 2023-12-13 at 3 50 29 PM" src="https://github.com/stolostron/backplane-operator/assets/28898909/b22ded71-6f2a-4e7c-be59-792262cf9aec">

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
