### PR TITLE
remove context from logs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -106,7 +106,6 @@ rules:
   resources:
   - configmaps
   - namespaces
-  - pods
   - serviceaccounts
   - services
   verbs:
@@ -256,6 +255,7 @@ rules:
   resources:
   - pods
   verbs:
+  - get
   - list
 - apiGroups:
   - ""

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -145,7 +145,7 @@ const (
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (retRes ctrl.Result, retErr error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	// Fetch the BackplaneConfig instance
 	backplaneConfig, err := r.getBackplaneConfig(ctx, req)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -455,7 +455,7 @@ func (r *MultiClusterEngineReconciler) SetupWithManager(mgr ctrl.Manager) error 
 // trusted CA bundle for use with the OCP cluster wide proxy
 func (r *MultiClusterEngineReconciler) createTrustBundleConfigmap(ctx context.Context,
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	// Get Trusted Bundle configmap name
 	trustBundleName := defaultTrustBundleName
@@ -510,7 +510,7 @@ func (r *MultiClusterEngineReconciler) createTrustBundleConfigmap(ctx context.Co
 
 func (r *MultiClusterEngineReconciler) createMetricsService(ctx context.Context,
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	const Port = 8080
 
@@ -575,7 +575,7 @@ func (r *MultiClusterEngineReconciler) createMetricsService(ctx context.Context,
 
 func (r *MultiClusterEngineReconciler) createMetricsServiceMonitor(ctx context.Context,
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	smName := utils.MCEOperatorMetricsServiceMonitorName
 	smNamespace := mce.Spec.TargetNamespace
@@ -645,7 +645,7 @@ func (r *MultiClusterEngineReconciler) createMetricsServiceMonitor(ctx context.C
 
 // DeployAlwaysSubcomponents ensures all subcomponents exist
 func (r *MultiClusterEngineReconciler) DeployAlwaysSubcomponents(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	chartsDir := renderer.AlwaysChartsDir
 	// Renders all templates from charts
@@ -898,7 +898,7 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 			errorMessages = append(errorMessages, fmt.Sprintf("error ensuring %s: %s", k, v.Error()))
 		}
 		combinedError := fmt.Sprintf(": %s", strings.Join(errorMessages, "; "))
-		log.FromContext(ctx).Error(errors.New("Errors applying components"), combinedError)
+		log.Log.WithName("reconcile").Error(errors.New("Errors applying components"), combinedError)
 		return ctrl.Result{RequeueAfter: requeuePeriod}, errors.New(combinedError)
 	}
 	if requeue {
@@ -936,7 +936,7 @@ func (r *MultiClusterEngineReconciler) applyTemplate(ctx context.Context, backpl
 // deleteTemplate return true if resource does not exist and returns an error if a GET or DELETE errors unexpectedly. A false response without error
 // means the resource is in the process of deleting.
 func (r *MultiClusterEngineReconciler) deleteTemplate(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine, template *unstructured.Unstructured) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	err := r.Client.Get(ctx, types.NamespacedName{Name: template.GetName(), Namespace: template.GetNamespace()}, template)
 
 	if err != nil && (apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err)) {
@@ -960,7 +960,7 @@ func (r *MultiClusterEngineReconciler) deleteTemplate(ctx context.Context, backp
 }
 
 func (r *MultiClusterEngineReconciler) ensureCustomResources(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	if foundation.CanInstallAddons(ctx, r.Client) {
 		addonTemplates, err := foundation.GetAddons()
@@ -989,7 +989,7 @@ func (r *MultiClusterEngineReconciler) ensureCustomResources(ctx context.Context
 func (r *MultiClusterEngineReconciler) ensureOpenShiftNamespaceLabel(ctx context.Context,
 	backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	existingNs := &corev1.Namespace{}
 
 	err := r.Client.Get(ctx, types.NamespacedName{Name: backplaneConfig.Spec.TargetNamespace}, existingNs)
@@ -1020,7 +1020,7 @@ func (r *MultiClusterEngineReconciler) ensureOpenShiftNamespaceLabel(ctx context
 }
 
 func (r *MultiClusterEngineReconciler) finalizeBackplaneConfig(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) error {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	ocpConsole, err := r.CheckConsole(ctx)
 	if err != nil {
@@ -1159,7 +1159,7 @@ func (r *MultiClusterEngineReconciler) finalizeBackplaneConfig(ctx context.Conte
 }
 
 func (r *MultiClusterEngineReconciler) getBackplaneConfig(ctx context.Context, req ctrl.Request) (*backplanev1.MultiClusterEngine, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	backplaneConfig := &backplanev1.MultiClusterEngine{}
 	err := r.Client.Get(ctx, req.NamespacedName, backplaneConfig)
 	if err != nil {
@@ -1178,7 +1178,7 @@ func (r *MultiClusterEngineReconciler) getBackplaneConfig(ctx context.Context, r
 
 // ensureUnstructuredResource ensures that the unstructured resource is applied in the cluster properly
 func (r *MultiClusterEngineReconciler) ensureUnstructuredResource(ctx context.Context, bpc *backplanev1.MultiClusterEngine, u *unstructured.Unstructured) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	found := &unstructured.Unstructured{}
 	found.SetGroupVersionKind(u.GroupVersionKind())
@@ -1214,7 +1214,7 @@ func (r *MultiClusterEngineReconciler) ensureUnstructuredResource(ctx context.Co
 }
 
 func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	updateNecessary := false
 	if !utils.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig) {
@@ -1315,7 +1315,7 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 }
 
 func (r *MultiClusterEngineReconciler) validateNamespace(ctx context.Context, m *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	newNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: m.Spec.TargetNamespace,
@@ -1366,7 +1366,7 @@ func (r *MultiClusterEngineReconciler) validateImagePullSecret(ctx context.Conte
 }
 
 func (r *MultiClusterEngineReconciler) getClusterVersion(ctx context.Context) (string, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	// If Unit test
 	if val, ok := os.LookupEnv("UNIT_TEST"); ok && val == "true" {
 		if _, exists := os.LookupEnv("ACM_HUB_OCP_VERSION"); exists {
@@ -1392,7 +1392,7 @@ func (r *MultiClusterEngineReconciler) getClusterVersion(ctx context.Context) (s
 //+kubebuilder:rbac:groups="config.openshift.io",resources="ingresses",verbs=get;list;watch
 
 func (r *MultiClusterEngineReconciler) getClusterIngressDomain(ctx context.Context, mce *backplanev1.MultiClusterEngine) (string, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	// If Unit test
 	if val, ok := os.LookupEnv("UNIT_TEST"); ok && val == "true" {
 		return "apps.installer-test-cluster.dev00.red-chesterfield.com", nil

--- a/controllers/hosted.go
+++ b/controllers/hosted.go
@@ -32,7 +32,7 @@ import (
 var ErrBadFormat = errors.New("bad format")
 
 func (r *MultiClusterEngineReconciler) HostedReconcile(ctx context.Context, mce *backplanev1.MultiClusterEngine) (retRes ctrl.Result, retErr error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	defer func() {
 		mce.Status = r.StatusManager.ReportStatus(*mce)
@@ -226,7 +226,7 @@ func parseKubeCreds(secret *corev1.Secret) ([]byte, error) {
 
 func (r *MultiClusterEngineReconciler) ensureHostedImport(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine, hostedClient client.Client) (ctrl.Result, error) {
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	r.StatusManager.AddComponent(toggle.EnabledStatus(types.NamespacedName{Name: "managedcluster-import-controller-v2", Namespace: backplaneConfig.Spec.TargetNamespace}))
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(types.NamespacedName{Name: "managedcluster-import-controller-v2", Namespace: backplaneConfig.Spec.TargetNamespace}, []*unstructured.Unstructured{}))
@@ -267,7 +267,7 @@ func (r *MultiClusterEngineReconciler) ensureHostedImport(ctx context.Context, b
 
 func (r *MultiClusterEngineReconciler) ensureNoHostedImport(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine, hostedClient client.Client) (ctrl.Result, error) {
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	r.StatusManager.RemoveComponent(toggle.EnabledStatus(types.NamespacedName{Name: "managedcluster-import-controller-v2", Namespace: backplaneConfig.Spec.TargetNamespace}))
 	r.StatusManager.AddComponent(toggle.DisabledStatus(types.NamespacedName{Name: "managedcluster-import-controller-v2", Namespace: backplaneConfig.Spec.TargetNamespace}, []*unstructured.Unstructured{}))
 	templates, errs := renderer.RenderChart(toggle.HostingImportChartDir, backplaneConfig, r.Images)
@@ -306,7 +306,7 @@ func (r *MultiClusterEngineReconciler) ensureNoHostedImport(ctx context.Context,
 }
 
 func (r *MultiClusterEngineReconciler) ensureHostedClusterManager(ctx context.Context, mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	cmName := fmt.Sprintf("%s-cluster-manager", mce.Name)
 
 	r.StatusManager.AddComponent(status.ClusterManagerStatus{
@@ -421,7 +421,7 @@ func (r *MultiClusterEngineReconciler) ensureNoHostedClusterManager(ctx context.
 
 // setHostedDefaults configures the MCE with default values and updates
 func (r *MultiClusterEngineReconciler) setHostedDefaults(ctx context.Context, m *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	updateNecessary := false
 	if !utils.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig) {
@@ -495,7 +495,7 @@ func (r *MultiClusterEngineReconciler) hostedApplyTemplate(ctx context.Context, 
 // deleteTemplate return true if resource does not exist and returns an error if a GET or DELETE errors unexpectedly. A false response without error
 // means the resource is in the process of deleting.
 func (r *MultiClusterEngineReconciler) hostedDeleteTemplate(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine, template *unstructured.Unstructured, hostedClient client.Client) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	err := hostedClient.Get(ctx, types.NamespacedName{Name: template.GetName(), Namespace: template.GetNamespace()}, template)
 
 	if err != nil && apierrors.IsNotFound(err) {

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -45,7 +45,7 @@ func (r *MultiClusterEngineReconciler) ensureConsoleMCE(ctx context.Context, bac
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	templates, errs := renderer.RenderChart(toggle.ConsoleMCEChartsDir, backplaneConfig, r.Images)
 	if len(errs) > 0 {
 		for _, err := range errs {
@@ -81,7 +81,7 @@ func (r *MultiClusterEngineReconciler) ensureConsoleMCE(ctx context.Context, bac
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoConsoleMCE(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine, ocpConsole bool) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	namespacedName := types.NamespacedName{Name: "console-mce-console", Namespace: backplaneConfig.Spec.TargetNamespace}
 	r.StatusManager.RemoveComponent(toggle.EnabledStatus(namespacedName))
 	if !ocpConsole {
@@ -125,7 +125,7 @@ func (r *MultiClusterEngineReconciler) ensureManagedServiceAccount(ctx context.C
 	// r.StatusManager.AddComponent(toggle.EnabledStatus(types.NamespacedName{Name: "managed-serviceaccount-addon-manager", Namespace: backplaneConfig.Spec.TargetNamespace}))
 	r.StatusManager.AddComponent(status.NewPresentStatus(types.NamespacedName{Name: "managed-serviceaccount"}, clusterManagementAddOnGVK))
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	// Render CRD templates
 	crdPath := toggle.ManagedServiceAccountCRDPath
@@ -180,7 +180,7 @@ func (r *MultiClusterEngineReconciler) ensureManagedServiceAccount(ctx context.C
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoManagedServiceAccount(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	// Renders all templates from charts
 	chartPath := toggle.ManagedServiceAccountChartDir
@@ -233,7 +233,7 @@ func (r *MultiClusterEngineReconciler) ensureNoManagedServiceAccount(ctx context
 
 // addPluginToConsoleResource ...
 func (r *MultiClusterEngineReconciler) addPluginToConsoleResource(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	console := &operatorv1.Console{}
 	// If trying to check this resource from the CLI run - `oc get consoles.operator.openshift.io cluster`.
 	// The default `console` is not the correct resource
@@ -269,7 +269,7 @@ func (r *MultiClusterEngineReconciler) removePluginFromConsoleResource(ctx conte
 		return ctrl.Result{}, nil
 	}
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	console := &operatorv1.Console{}
 	// If trying to check this resource from the CLI run - `oc get consoles.operator.openshift.io cluster`.
 	// The default `console` is not the correct resource
@@ -304,7 +304,7 @@ func (r *MultiClusterEngineReconciler) ensureDiscovery(ctx context.Context, back
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	templates, errs := renderer.RenderChart(toggle.DiscoveryChartDir, backplaneConfig, r.Images)
 	if len(errs) > 0 {
@@ -327,7 +327,7 @@ func (r *MultiClusterEngineReconciler) ensureDiscovery(ctx context.Context, back
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoDiscovery(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	namespacedName := types.NamespacedName{Name: "discovery-operator", Namespace: backplaneConfig.Spec.TargetNamespace}
 
 	// Renders all templates from charts
@@ -358,7 +358,7 @@ func (r *MultiClusterEngineReconciler) ensureHive(ctx context.Context, backplane
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	templates, errs := renderer.RenderChart(toggle.HiveChartDir, backplaneConfig, r.Images)
 	if len(errs) > 0 {
@@ -391,7 +391,7 @@ func (r *MultiClusterEngineReconciler) ensureHive(ctx context.Context, backplane
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoHive(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	namespacedName := types.NamespacedName{Name: "hive-operator", Namespace: backplaneConfig.Spec.TargetNamespace}
 
 	// Renders all templates from charts
@@ -439,7 +439,7 @@ func (r *MultiClusterEngineReconciler) ensureAssistedService(ctx context.Context
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	templates, errs := renderer.RenderChartWithNamespace(toggle.AssistedServiceChartDir, backplaneConfig, r.Images, targetNamespace)
 	if len(errs) > 0 {
@@ -468,7 +468,7 @@ func (r *MultiClusterEngineReconciler) ensureNoAssistedService(ctx context.Conte
 	}
 	namespacedName := types.NamespacedName{Name: "infrastructure-operator", Namespace: targetNamespace}
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	// Renders all templates from charts
 	templates, errs := renderer.RenderChartWithNamespace(toggle.AssistedServiceChartDir, backplaneConfig, r.Images, targetNamespace)
@@ -504,7 +504,7 @@ func (r *MultiClusterEngineReconciler) ensureServerFoundation(ctx context.Contex
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	templates, errs := renderer.RenderChart(toggle.ServerFoundationChartDir, backplaneConfig, r.Images)
 	if len(errs) > 0 {
@@ -527,7 +527,7 @@ func (r *MultiClusterEngineReconciler) ensureServerFoundation(ctx context.Contex
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoServerFoundation(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	// Renders all templates from charts
 	templates, errs := renderer.RenderChart(toggle.ServerFoundationChartDir, backplaneConfig, r.Images)
@@ -576,7 +576,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterLifecycle(ctx context.Contex
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	templates, errs := renderer.RenderChart(toggle.ClusterLifecycleChartDir, backplaneConfig, r.Images)
 	if len(errs) > 0 {
@@ -599,7 +599,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterLifecycle(ctx context.Contex
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoClusterLifecycle(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	// Renders all templates from charts
 	templates, errs := renderer.RenderChart(toggle.ClusterLifecycleChartDir, backplaneConfig, r.Images)
@@ -642,7 +642,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterManager(ctx context.Context,
 		NamespacedName: types.NamespacedName{Name: "cluster-manager"},
 	})
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	templates, errs := renderer.RenderChart(toggle.ClusterManagerChartDir, backplaneConfig, r.Images)
 	if len(errs) > 0 {
@@ -676,7 +676,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterManager(ctx context.Context,
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoClusterManager(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	namespacedName := types.NamespacedName{Name: "cluster-manager", Namespace: backplaneConfig.Spec.TargetNamespace}
 
 	// Renders all templates from charts
@@ -740,7 +740,7 @@ func (r *MultiClusterEngineReconciler) ensureHyperShift(ctx context.Context, bac
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 	r.StatusManager.AddComponent(status.NewPresentStatus(types.NamespacedName{Name: "hypershift-addon"}, clusterManagementAddOnGVK))
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	templates, errs := renderer.RenderChart(toggle.HyperShiftChartDir, backplaneConfig, r.Images)
 	if len(errs) > 0 {
@@ -775,7 +775,7 @@ func (r *MultiClusterEngineReconciler) ensureHyperShift(ctx context.Context, bac
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoHyperShift(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	namespacedName := types.NamespacedName{Name: "hypershift-addon-manager", Namespace: backplaneConfig.Spec.TargetNamespace}
 
 	// Ensure hypershift-addon is removed first
@@ -883,7 +883,7 @@ func (r *MultiClusterEngineReconciler) reconcileHypershiftLocalHosting(ctx conte
 				Message:   "Waiting for namespace 'local-cluster'",
 			},
 		})
-		log.FromContext(ctx).Info("Can't apply hypershift-addon, waiting for local-cluster namespace")
+		log.Log.WithName("reconcile").Info("Can't apply hypershift-addon, waiting for local-cluster namespace")
 		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
 	}
 	r.StatusManager.AddComponent(status.ManagedClusterAddOnStatus{
@@ -902,7 +902,7 @@ func (r *MultiClusterEngineReconciler) applyHypershiftLocalHosting(ctx context.C
 	if err != nil {
 		if apimeta.IsNoMatchError(errors.Unwrap(err)) || apierrors.IsNotFound(errors.Unwrap(err)) {
 			// addon CRD does not yet exist. Replace status.
-			log.FromContext(ctx).Info("Couldn't apply template for hypershiftlocalhosting due to missing CRD", "error is", err.Error())
+			log.Log.WithName("reconcile").Info("Couldn't apply template for hypershiftlocalhosting due to missing CRD", "error is", err.Error())
 
 			r.StatusManager.RemoveComponent(status.ManagedClusterAddOnStatus{
 				NamespacedName: types.NamespacedName{Name: addon.GetName(), Namespace: addon.GetNamespace()},
@@ -924,7 +924,7 @@ func (r *MultiClusterEngineReconciler) applyHypershiftLocalHosting(ctx context.C
 		}
 		if apierrors.IsInternalError(errors.Unwrap(err)) {
 			// likely failed to call webhook
-			log.FromContext(ctx).Info("Couldn't apply template for hypershiftlocalhosting likely due to webhook not ready", "error is", err.Error())
+			log.Log.WithName("reconcile").Info("Couldn't apply template for hypershiftlocalhosting likely due to webhook not ready", "error is", err.Error())
 
 			r.StatusManager.RemoveComponent(status.ManagedClusterAddOnStatus{
 				NamespacedName: types.NamespacedName{Name: addon.GetName(), Namespace: addon.GetNamespace()},
@@ -962,7 +962,7 @@ func (r *MultiClusterEngineReconciler) removeHypershiftLocalHosting(ctx context.
 }
 
 func (r *MultiClusterEngineReconciler) ensureClusterProxyAddon(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	namespacedName := types.NamespacedName{Name: "cluster-proxy-addon-manager", Namespace: backplaneConfig.Spec.TargetNamespace}
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
@@ -1002,7 +1002,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterProxyAddon(ctx context.Conte
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoClusterProxyAddon(ctx context.Context, backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	namespacedName := types.NamespacedName{Name: "cluster-proxy-addon-manager", Namespace: backplaneConfig.Spec.TargetNamespace}
 	r.StatusManager.RemoveComponent(toggle.EnabledStatus(namespacedName))
 	r.StatusManager.AddComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
@@ -1067,7 +1067,7 @@ func (r *MultiClusterEngineReconciler) CheckConsole(ctx context.Context) (bool, 
 }
 
 func (r *MultiClusterEngineReconciler) ensureLocalCluster(ctx context.Context, mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	if utils.IsUnitTest() {
 		log.Info("skipping local cluster creation in unit tests")
@@ -1197,7 +1197,7 @@ func (r *MultiClusterEngineReconciler) ensureLocalCluster(ctx context.Context, m
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoLocalCluster(ctx context.Context, mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	if utils.IsUnitTest() {
 		log.Info("skipping local cluster removal in unit tests")

--- a/controllers/uninstall.go
+++ b/controllers/uninstall.go
@@ -143,7 +143,7 @@ instead.
 */
 func (r *MultiClusterEngineReconciler) removeLegacyPrometheusConfigurations(ctx context.Context,
 	targetNamespace string, kind string) error {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{

--- a/hack/prereqs/oc.yaml
+++ b/hack/prereqs/oc.yaml
@@ -1,5 +1,5 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorCondition
 metadata:
-  name: multicluster-engine.v2.3.0 
+  name: multicluster-engine.v2.5.0 
   namespace: backplane-operator-system 

--- a/pkg/foundation/cluster_manager.go
+++ b/pkg/foundation/cluster_manager.go
@@ -59,7 +59,7 @@ func AddonManagerImage(overrides map[string]string) string {
 }
 
 func ClusterManager(m *v1.MultiClusterEngine, overrides map[string]string) *unstructured.Unstructured {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 
 	cmTolerations := []corev1.Toleration{}
 	if m.Spec.Tolerations != nil {

--- a/pkg/foundation/hosted_cluster_manager.go
+++ b/pkg/foundation/hosted_cluster_manager.go
@@ -3,7 +3,6 @@
 package foundation
 
 import (
-	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +21,7 @@ func hostedName(m *v1.MultiClusterEngine) string {
 
 // HostedClusterManager returns the ClusterManager in hosted mode
 func HostedClusterManager(m *v1.MultiClusterEngine, overrides map[string]string) *unstructured.Unstructured {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 
 	cmTolerations := []corev1.Toleration{}
 	if m.Spec.Tolerations != nil {

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -3,7 +3,6 @@
 package renderer
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -183,7 +182,7 @@ func RenderCRDs(crdDir string) ([]*unstructured.Unstructured, []error) {
 }
 
 func RenderCharts(chartDir string, backplaneConfig *v1.MultiClusterEngine, images map[string]string) ([]*unstructured.Unstructured, []error) {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 	var templates []*unstructured.Unstructured
 	errs := []error{}
 	if val, ok := os.LookupEnv("DIRECTORY_OVERRIDE"); ok {
@@ -208,7 +207,7 @@ func RenderCharts(chartDir string, backplaneConfig *v1.MultiClusterEngine, image
 }
 
 func RenderChart(chartPath string, backplaneConfig *v1.MultiClusterEngine, images map[string]string) ([]*unstructured.Unstructured, []error) {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 	errs := []error{}
 	if val, ok := os.LookupEnv("DIRECTORY_OVERRIDE"); ok {
 		chartPath = path.Join(val, chartPath)
@@ -232,7 +231,7 @@ func RenderChartWithNamespace(chartPath string, backplaneConfig *v1.MultiCluster
 }
 
 func renderTemplates(chartPath string, backplaneConfig *v1.MultiClusterEngine, images map[string]string) ([]*unstructured.Unstructured, []error) {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 	var templates []*unstructured.Unstructured
 	errs := []error{}
 	chart, err := loader.Load(chartPath)

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -20,7 +20,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps;jobs;namespaces;pods;secrets,verbs=list;watch
-//+kubebuilder:rbac:groups="",resources=configmaps;namespaces;serviceaccounts;services;pods,verbs=create;get;list;update;watch;patch;delete;deletecollection
+//+kubebuilder:rbac:groups="",resources=configmaps;namespaces;serviceaccounts;services,verbs=create;get;list;update;watch;patch;delete;deletecollection
 //+kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=*
 //+kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=*
 //+kubebuilder:rbac:groups="",resources=events,verbs=create
@@ -36,6 +36,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=nodes;pods;endpoints;services;secrets,verbs=get;watch;list
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get
 //+kubebuilder:rbac:groups="",resources=pods,verbs=list
 //+kubebuilder:rbac:groups="",resources=pods;nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods;pods/log,verbs=get;list;watch


### PR DESCRIPTION
# Description

There was excess information in all logging statements. This has been removed

## Related Issue

https://issues.redhat.com/browse/ACM-8351

## Changes Made

Change the log function from `log.FromContext()` to `log.Log.WithName()`
