### PR TITLE
Switch lint-operator-bundles target to use generate-shell.py script

### DIFF
--- a/Makefile.dev
+++ b/Makefile.dev
@@ -21,7 +21,7 @@ upstream-install: ## Installs the upstream Backplane Operator by deploying a Cat
 
 lint-operator-bundles: ## Lints the operator bundles
 	pip install -r hack/bundle-automation/requirements.txt
-	python ./hack/bundle-automation/generate-bundles.py --lint
+	python3 ./hack/bundle-automation/generate-shell.py --lint
 
 regenerate-operator-bundles: ## Regenerates the operator bundles
 	pip install -r hack/bundle-automation/requirements.txt


### PR DESCRIPTION
# Description

Update `Makefile.dev` linter job to use latest `installer-dev-tools` script.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
