### PR TITLE
fix the incorrect json field name of KlusterletConfig

### DIFF
--- a/pkg/templates/crds/foundation/config.open-cluster-management.io_klusterletconfigs_crd.yaml
+++ b/pkg/templates/crds/foundation/config.open-cluster-management.io_klusterletconfigs_crd.yaml
@@ -45,12 +45,6 @@ spec:
                   ConfigMap in the cluster namespace;'
                 format: byte
                 type: string
-              hubKubeAPIServerEndpoint:
-                description: HubKubeAPIServerURL is the URL of the hub Kube API server.
-                  If not present, the .status.apiServerURL of Infrastructure/cluster
-                  will be used as the default value. e.g. `oc get infrastructure cluster
-                  -o jsonpath='{.status.apiServerURL}'`
-                type: string
               hubKubeAPIServerProxyConfig:
                 description: HubKubeAPIServerProxyConfig holds proxy settings for
                   connections between klusterlet/add-on agents on the managed cluster
@@ -73,6 +67,12 @@ spec:
                       set.
                     type: string
                 type: object
+              hubKubeAPIServerURL:
+                description: HubKubeAPIServerURL is the URL of the hub Kube API server.
+                  If not present, the .status.apiServerURL of Infrastructure/cluster
+                  will be used as the default value. e.g. `oc get infrastructure cluster
+                  -o jsonpath='{.status.apiServerURL}'`
+                type: string
               nodePlacement:
                 description: NodePlacement enables explicit control over the scheduling
                   of the agent components. If the placement is nil, the placement


### PR DESCRIPTION
# Description

This PR fixes the incorrect JSON field name of HubKubeAPIServerURL in KlusterletConfig CRD.

## Related Issue

https://issues.redhat.com/browse/ACM-9711

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
