### PR TITLE
Enable managed service account addon by default

### DIFF
--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -16,3 +16,4 @@
         - "CLUSTER_NAME"
         - "HUB_KUBECONFIG"
         - "INSTALL_NAMESPACE"
+      auto-install-for-all-clusters: true

--- a/hack/unit-test-crds/clustermanagementaddons.addon.open-cluster-management.io.yaml
+++ b/hack/unit-test-crds/clustermanagementaddons.addon.open-cluster-management.io.yaml
@@ -8,95 +8,668 @@ spec:
     kind: ClusterManagementAddOn
     listKind: ClusterManagementAddOnList
     plural: clustermanagementaddons
+    shortNames:
+    - cma
+    - cmas
     singular: clustermanagementaddon
-  scope: Cluster
   preserveUnknownFields: false
+  scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.addOnMeta.displayName
-          name: DISPLAY NAME
-          type: string
-        - jsonPath: .spec.addOnConfiguration.crdName
-          name: CRD NAME
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ClusterManagementAddOn represents the registration of an add-on to the cluster manager. This resource allows the user to discover which add-on is available for the cluster manager and also provides metadata information about the add-on. This resource also provides a linkage to ManagedClusterAddOn, the name of the ClusterManagementAddOn resource will be used for the namespace-scoped ManagedClusterAddOn resource. ClusterManagementAddOn is a cluster-scoped resource.
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec represents a desired configuration for the agent on the cluster management add-on.
-              type: object
-              properties:
-                addOnConfiguration:
-                  description: 'Deprecated: Use supportedConfigs filed instead addOnConfiguration is a reference to configuration information for the add-on. In scenario where a multiple add-ons share the same add-on CRD, multiple ClusterManagementAddOn resources need to be created and reference the same AddOnConfiguration.'
-                  type: object
+  - additionalPrinterColumns:
+    - jsonPath: .spec.addOnMeta.displayName
+      name: DISPLAY NAME
+      type: string
+    - jsonPath: .spec.addOnConfiguration.crdName
+      name: CRD NAME
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterManagementAddOn represents the registration of an add-on
+          to the cluster manager. This resource allows the user to discover which
+          add-on is available for the cluster manager and also provides metadata information
+          about the add-on. This resource also provides a linkage to ManagedClusterAddOn,
+          the name of the ClusterManagementAddOn resource will be used for the namespace-scoped
+          ManagedClusterAddOn resource. ClusterManagementAddOn is a cluster-scoped
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec represents a desired configuration for the agent on
+              the cluster management add-on.
+            properties:
+              addOnConfiguration:
+                description: 'Deprecated: Use supportedConfigs filed instead addOnConfiguration
+                  is a reference to configuration information for the add-on. In scenario
+                  where a multiple add-ons share the same add-on CRD, multiple ClusterManagementAddOn
+                  resources need to be created and reference the same AddOnConfiguration.'
+                properties:
+                  crName:
+                    description: crName is the name of the CR used to configure instances
+                      of the managed add-on. This field should be configured if add-on
+                      CR have a consistent name across the all of the ManagedCluster
+                      instaces.
+                    type: string
+                  crdName:
+                    description: crdName is the name of the CRD used to configure
+                      instances of the managed add-on. This field should be configured
+                      if the add-on have a CRD that controls the configuration of
+                      the add-on.
+                    type: string
+                  lastObservedGeneration:
+                    description: lastObservedGeneration is the observed generation
+                      of the custom resource for the configuration of the addon.
+                    format: int64
+                    type: integer
+                type: object
+              addOnMeta:
+                description: addOnMeta is a reference to the metadata information
+                  for the add-on.
+                properties:
+                  description:
+                    description: description represents the detailed description of
+                      the add-on.
+                    type: string
+                  displayName:
+                    description: displayName represents the name of add-on that will
+                      be displayed.
+                    type: string
+                type: object
+              installStrategy:
+                default:
+                  type: Manual
+                description: InstallStrategy represents that related ManagedClusterAddOns
+                  should be installed on certain clusters.
+                properties:
+                  placements:
+                    description: Placements is a list of placement references honored
+                      when install strategy type is Placements. All clusters selected
+                      by these placements will install the addon If one cluster belongs
+                      to multiple placements, it will only apply the strategy defined
+                      later in the order. That is to say, The latter strategy overrides
+                      the previous one.
+                    items:
+                      properties:
+                        configs:
+                          description: Configs is the configuration of managedClusterAddon
+                            during installation. User can override the configuration
+                            by updating the managedClusterAddon directly.
+                          items:
+                            properties:
+                              group:
+                                default: ""
+                                description: group of the add-on configuration.
+                                type: string
+                              name:
+                                description: name of the add-on configuration.
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: namespace of the add-on configuration.
+                                  If this field is not set, the configuration is in
+                                  the cluster scope.
+                                type: string
+                              resource:
+                                description: resource of the add-on configuration.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - resource
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the name of the placement
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the placement
+                          minLength: 1
+                          type: string
+                        rolloutStrategy:
+                          default:
+                            type: All
+                          description: The rollout strategy to apply addon configurations
+                            change. The rollout strategy only watches the addon configurations
+                            defined in ClusterManagementAddOn.
+                          properties:
+                            all:
+                              description: All defines required fields for RolloutStrategy
+                                type All
+                              properties:
+                                maxFailures:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  default: 0
+                                  description: MaxFailures is a percentage or number
+                                    of clusters in the current rollout that can fail
+                                    before proceeding to the next rollout. Fail means
+                                    the cluster has a failed status or timeout status
+                                    (does not reach successful status after ProgressDeadline).
+                                    Once the MaxFailures is breached, the rollout
+                                    will stop. MaxFailures is only considered for
+                                    rollout types Progressive and ProgressivePerGroup.
+                                    For Progressive, this is considered over the total
+                                    number of clusters. For ProgressivePerGroup, this
+                                    is considered according to the size of the current
+                                    group. For both Progressive and ProgressivePerGroup,
+                                    the MaxFailures does not apply for MandatoryDecisionGroups,
+                                    which tolerate no failures. Default is that no
+                                    failures are tolerated.
+                                  pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                                  x-kubernetes-int-or-string: true
+                                minSuccessTime:
+                                  default: "0"
+                                  description: MinSuccessTime is a "soak" time. In
+                                    other words, the minimum amount of time the workload
+                                    applier controller will wait from the start of
+                                    each rollout before proceeding (assuming a successful
+                                    state has been reached and MaxFailures wasn't
+                                    breached). MinSuccessTime is only considered for
+                                    rollout types Progressive and ProgressivePerGroup.
+                                    The default value is 0 meaning the workload applier
+                                    proceeds immediately after a successful state
+                                    is reached. MinSuccessTime must be defined in
+                                    [0-9h]|[0-9m]|[0-9s] format examples; 2h , 90m
+                                    , 360s
+                                  type: string
+                                progressDeadline:
+                                  default: None
+                                  description: ProgressDeadline defines how long workload
+                                    applier controller will wait for the workload
+                                    to reach a successful state in the cluster. If
+                                    the workload does not reach a successful state
+                                    after ProgressDeadline, will stop waiting and
+                                    workload will be treated as "timeout" and be counted
+                                    into MaxFailures. Once the MaxFailures is breached,
+                                    the rollout will stop. ProgressDeadline default
+                                    value is "None", meaning the workload applier
+                                    will wait for a successful state indefinitely.
+                                    ProgressDeadline must be defined in [0-9h]|[0-9m]|[0-9s]
+                                    format examples; 2h , 90m , 360s
+                                  pattern: ^(([0-9])+[h|m|s])|None$
+                                  type: string
+                              type: object
+                            progressive:
+                              description: Progressive defines required fields for
+                                RolloutStrategy type Progressive
+                              properties:
+                                mandatoryDecisionGroups:
+                                  description: List of the decision groups names or
+                                    indexes to apply the workload first and fail if
+                                    workload did not reach successful state. GroupName
+                                    or GroupIndex must match with the decisionGroups
+                                    defined in the placement's decisionStrategy
+                                  items:
+                                    description: MandatoryDecisionGroup set the decision
+                                      group name or group index. GroupName is considered
+                                      first to select the decisionGroups then GroupIndex.
+                                    properties:
+                                      groupIndex:
+                                        description: GroupIndex of the decision group
+                                          should match the placementDecisions label
+                                          value with label key cluster.open-cluster-management.io/decision-group-index
+                                        format: int32
+                                        type: integer
+                                      groupName:
+                                        description: GroupName of the decision group
+                                          should match the placementDecisions label
+                                          value with label key cluster.open-cluster-management.io/decision-group-name
+                                        type: string
+                                    type: object
+                                  type: array
+                                maxConcurrency:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: MaxConcurrency is the max number of
+                                    clusters to deploy workload concurrently. The
+                                    default value for MaxConcurrency is determined
+                                    from the clustersPerDecisionGroup defined in the
+                                    placement->DecisionStrategy.
+                                  pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                                  x-kubernetes-int-or-string: true
+                                maxFailures:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  default: 0
+                                  description: MaxFailures is a percentage or number
+                                    of clusters in the current rollout that can fail
+                                    before proceeding to the next rollout. Fail means
+                                    the cluster has a failed status or timeout status
+                                    (does not reach successful status after ProgressDeadline).
+                                    Once the MaxFailures is breached, the rollout
+                                    will stop. MaxFailures is only considered for
+                                    rollout types Progressive and ProgressivePerGroup.
+                                    For Progressive, this is considered over the total
+                                    number of clusters. For ProgressivePerGroup, this
+                                    is considered according to the size of the current
+                                    group. For both Progressive and ProgressivePerGroup,
+                                    the MaxFailures does not apply for MandatoryDecisionGroups,
+                                    which tolerate no failures. Default is that no
+                                    failures are tolerated.
+                                  pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                                  x-kubernetes-int-or-string: true
+                                minSuccessTime:
+                                  default: "0"
+                                  description: MinSuccessTime is a "soak" time. In
+                                    other words, the minimum amount of time the workload
+                                    applier controller will wait from the start of
+                                    each rollout before proceeding (assuming a successful
+                                    state has been reached and MaxFailures wasn't
+                                    breached). MinSuccessTime is only considered for
+                                    rollout types Progressive and ProgressivePerGroup.
+                                    The default value is 0 meaning the workload applier
+                                    proceeds immediately after a successful state
+                                    is reached. MinSuccessTime must be defined in
+                                    [0-9h]|[0-9m]|[0-9s] format examples; 2h , 90m
+                                    , 360s
+                                  type: string
+                                progressDeadline:
+                                  default: None
+                                  description: ProgressDeadline defines how long workload
+                                    applier controller will wait for the workload
+                                    to reach a successful state in the cluster. If
+                                    the workload does not reach a successful state
+                                    after ProgressDeadline, will stop waiting and
+                                    workload will be treated as "timeout" and be counted
+                                    into MaxFailures. Once the MaxFailures is breached,
+                                    the rollout will stop. ProgressDeadline default
+                                    value is "None", meaning the workload applier
+                                    will wait for a successful state indefinitely.
+                                    ProgressDeadline must be defined in [0-9h]|[0-9m]|[0-9s]
+                                    format examples; 2h , 90m , 360s
+                                  pattern: ^(([0-9])+[h|m|s])|None$
+                                  type: string
+                              type: object
+                            progressivePerGroup:
+                              description: ProgressivePerGroup defines required fields
+                                for RolloutStrategy type ProgressivePerGroup
+                              properties:
+                                mandatoryDecisionGroups:
+                                  description: List of the decision groups names or
+                                    indexes to apply the workload first and fail if
+                                    workload did not reach successful state. GroupName
+                                    or GroupIndex must match with the decisionGroups
+                                    defined in the placement's decisionStrategy
+                                  items:
+                                    description: MandatoryDecisionGroup set the decision
+                                      group name or group index. GroupName is considered
+                                      first to select the decisionGroups then GroupIndex.
+                                    properties:
+                                      groupIndex:
+                                        description: GroupIndex of the decision group
+                                          should match the placementDecisions label
+                                          value with label key cluster.open-cluster-management.io/decision-group-index
+                                        format: int32
+                                        type: integer
+                                      groupName:
+                                        description: GroupName of the decision group
+                                          should match the placementDecisions label
+                                          value with label key cluster.open-cluster-management.io/decision-group-name
+                                        type: string
+                                    type: object
+                                  type: array
+                                maxFailures:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  default: 0
+                                  description: MaxFailures is a percentage or number
+                                    of clusters in the current rollout that can fail
+                                    before proceeding to the next rollout. Fail means
+                                    the cluster has a failed status or timeout status
+                                    (does not reach successful status after ProgressDeadline).
+                                    Once the MaxFailures is breached, the rollout
+                                    will stop. MaxFailures is only considered for
+                                    rollout types Progressive and ProgressivePerGroup.
+                                    For Progressive, this is considered over the total
+                                    number of clusters. For ProgressivePerGroup, this
+                                    is considered according to the size of the current
+                                    group. For both Progressive and ProgressivePerGroup,
+                                    the MaxFailures does not apply for MandatoryDecisionGroups,
+                                    which tolerate no failures. Default is that no
+                                    failures are tolerated.
+                                  pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                                  x-kubernetes-int-or-string: true
+                                minSuccessTime:
+                                  default: "0"
+                                  description: MinSuccessTime is a "soak" time. In
+                                    other words, the minimum amount of time the workload
+                                    applier controller will wait from the start of
+                                    each rollout before proceeding (assuming a successful
+                                    state has been reached and MaxFailures wasn't
+                                    breached). MinSuccessTime is only considered for
+                                    rollout types Progressive and ProgressivePerGroup.
+                                    The default value is 0 meaning the workload applier
+                                    proceeds immediately after a successful state
+                                    is reached. MinSuccessTime must be defined in
+                                    [0-9h]|[0-9m]|[0-9s] format examples; 2h , 90m
+                                    , 360s
+                                  type: string
+                                progressDeadline:
+                                  default: None
+                                  description: ProgressDeadline defines how long workload
+                                    applier controller will wait for the workload
+                                    to reach a successful state in the cluster. If
+                                    the workload does not reach a successful state
+                                    after ProgressDeadline, will stop waiting and
+                                    workload will be treated as "timeout" and be counted
+                                    into MaxFailures. Once the MaxFailures is breached,
+                                    the rollout will stop. ProgressDeadline default
+                                    value is "None", meaning the workload applier
+                                    will wait for a successful state indefinitely.
+                                    ProgressDeadline must be defined in [0-9h]|[0-9m]|[0-9s]
+                                    format examples; 2h , 90m , 360s
+                                  pattern: ^(([0-9])+[h|m|s])|None$
+                                  type: string
+                              type: object
+                            type:
+                              default: All
+                              enum:
+                              - All
+                              - Progressive
+                              - ProgressivePerGroup
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - namespace
+                    - name
+                    x-kubernetes-list-type: map
+                  type:
+                    default: Manual
+                    description: 'Type is the type of the install strategy, it can
+                      be: - Manual: no automatic install - Placements: install to
+                      clusters selected by placements.'
+                    enum:
+                    - Manual
+                    - Placements
+                    type: string
+                type: object
+              supportedConfigs:
+                description: supportedConfigs is a list of configuration types supported
+                  by add-on. An empty list means the add-on does not require configurations.
+                  The default is an empty list
+                items:
+                  description: ConfigMeta represents a collection of metadata information
+                    for add-on configuration.
                   properties:
-                    crName:
-                      description: crName is the name of the CR used to configure instances of the managed add-on. This field should be configured if add-on CR have a consistent name across the all of the ManagedCluster instaces.
+                    defaultConfig:
+                      description: defaultConfig represents the namespace and name
+                        of the default add-on configuration. In scenario where all
+                        add-ons have a same configuration.
+                      properties:
+                        name:
+                          description: name of the add-on configuration.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: namespace of the add-on configuration. If this
+                            field is not set, the configuration is in the cluster
+                            scope.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    group:
+                      default: ""
+                      description: group of the add-on configuration.
                       type: string
-                    crdName:
-                      description: crdName is the name of the CRD used to configure instances of the managed add-on. This field should be configured if the add-on have a CRD that controls the configuration of the add-on.
+                    resource:
+                      description: resource of the add-on configuration.
+                      minLength: 1
                       type: string
-                    lastObservedGeneration:
-                      description: lastObservedGeneration is the observed generation of the custom resource for the configuration of the addon.
-                      type: integer
-                      format: int64
-                addOnMeta:
-                  description: addOnMeta is a reference to the metadata information for the add-on.
+                  required:
+                  - resource
                   type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: status represents the current status of cluster management
+              add-on.
+            properties:
+              defaultconfigReferences:
+                description: defaultconfigReferences is a list of current add-on default
+                  configuration references.
+                items:
+                  description: DefaultConfigReference is a reference to the current
+                    add-on configuration. This resource is used to record the configuration
+                    resource for the current add-on.
                   properties:
-                    description:
-                      description: description represents the detailed description of the add-on.
+                    desiredConfig:
+                      description: desiredConfig record the desired config spec hash.
+                      properties:
+                        name:
+                          description: name of the add-on configuration.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: namespace of the add-on configuration. If this
+                            field is not set, the configuration is in the cluster
+                            scope.
+                          type: string
+                        specHash:
+                          description: spec hash for an add-on configuration.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    group:
+                      default: ""
+                      description: group of the add-on configuration.
                       type: string
-                    displayName:
-                      description: displayName represents the name of add-on that will be displayed.
+                    resource:
+                      description: resource of the add-on configuration.
+                      minLength: 1
                       type: string
-                supportedConfigs:
-                  description: supportedConfigs is a list of configuration types supported by add-on. An empty list means the add-on does not require configurations. The default is an empty list
-                  type: array
-                  items:
-                    description: ConfigMeta represents a collection of metadata information for add-on configuration.
-                    type: object
-                    required:
-                      - resource
-                    properties:
-                      defaultConfig:
-                        description: defaultConfig represents the namespace and name of the default add-on configuration. In scenario where all add-ons have a same configuration.
-                        type: object
-                        required:
-                          - name
+                  required:
+                  - resource
+                  type: object
+                type: array
+              installProgressions:
+                description: installProgression is a list of current add-on configuration
+                  references per placement.
+                items:
+                  properties:
+                    conditions:
+                      description: conditions describe the state of the managed and
+                        monitored components for the operator.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
                         properties:
-                          name:
-                            description: name of the add-on configuration.
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
                             type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
                             minLength: 1
-                          namespace:
-                            description: namespace of the add-on configuration. If this field is not set, the configuration is in the cluster scope.
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
-                      group:
-                        description: group of the add-on configuration.
-                        type: string
-                      resource:
-                        description: resource of the add-on configuration.
-                        type: string
-                        minLength: 1
-            status:
-              description: status represents the current status of cluster management add-on.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    configReferences:
+                      description: configReferences is a list of current add-on configuration
+                        references.
+                      items:
+                        description: InstallConfigReference is a reference to the
+                          current add-on configuration. This resource is used to record
+                          the configuration resource for the current add-on.
+                        properties:
+                          desiredConfig:
+                            description: desiredConfig record the desired config name
+                              and spec hash.
+                            properties:
+                              name:
+                                description: name of the add-on configuration.
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: namespace of the add-on configuration.
+                                  If this field is not set, the configuration is in
+                                  the cluster scope.
+                                type: string
+                              specHash:
+                                description: spec hash for an add-on configuration.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          group:
+                            default: ""
+                            description: group of the add-on configuration.
+                            type: string
+                          lastAppliedConfig:
+                            description: lastAppliedConfig records the config spec
+                              hash when the all the corresponding ManagedClusterAddOn
+                              are applied successfully.
+                            properties:
+                              name:
+                                description: name of the add-on configuration.
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: namespace of the add-on configuration.
+                                  If this field is not set, the configuration is in
+                                  the cluster scope.
+                                type: string
+                              specHash:
+                                description: spec hash for an add-on configuration.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          lastKnownGoodConfig:
+                            description: lastKnownGoodConfig records the last known
+                              good config spec hash. For fresh install or rollout
+                              with type UpdateAll or RollingUpdate, the lastKnownGoodConfig
+                              is the same as lastAppliedConfig. For rollout with type
+                              RollingUpdateWithCanary, the lastKnownGoodConfig is
+                              the last successfully applied config spec hash of the
+                              canary placement.
+                            properties:
+                              name:
+                                description: name of the add-on configuration.
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: namespace of the add-on configuration.
+                                  If this field is not set, the configuration is in
+                                  the cluster scope.
+                                type: string
+                              specHash:
+                                description: spec hash for an add-on configuration.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          resource:
+                            description: resource of the add-on configuration.
+                            minLength: 1
+                            type: string
+                        required:
+                        - resource
+                        type: object
+                      type: array
+                    name:
+                      description: Name is the name of the placement
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the placement
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/clustermanagementaddon.yaml
@@ -8,6 +8,13 @@ spec:
   addOnMeta:
     description: managed-serviceaccount
     displayName: managed-serviceaccount
+  installStrategy:
+    placements:
+    - name: global
+      namespace: open-cluster-management-global-set
+      rolloutStrategy:
+        type: All
+    type: Placements
   supportedConfigs:
   - defaultConfig:
       name: managed-serviceaccount-addon-deploy-config

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -45,12 +45,11 @@ var onComponents = []string{
 	backplanev1.LocalCluster,
 	backplanev1.HypershiftLocalHosting,
 	backplanev1.HyperShift,
+	backplanev1.ManagedServiceAccount,
 	// backplanev1.ConsoleMCE, // determined by OCP version
 }
 
-var offComponents = []string{
-	backplanev1.ManagedServiceAccount,
-}
+var offComponents = []string{}
 
 // SetDefaultComponents returns true if changes are made
 func SetDefaultComponents(m *backplanev1.MultiClusterEngine) bool {


### PR DESCRIPTION
# Description

this PR will:
- Use install strategy to install managedserviceaccount addon(create managedclusteraddon CR) for all clusters
- Set the default value of maangedserviceaccount in the muilticlusterengine CR to true

## Related Issue

https://issues.redhat.com/browse/ACM-9655

## Changes Made

- update the `generate-charts.py` python script to inject install strategy into clustermanagementaddon for the managedserviceaccount addon
- move the managedserviceaccount from `offComponents` into `onComponents`
- update the `hack/unit-test-crds/clustermanagementaddons.addon.open-cluster-management.io.yaml` to make the e2e pass

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
