### PR TITLE
[ACM-8576] Updated MCE status response for resource applying

### DIFF
--- a/api/v1/multiclusterengine_types.go
+++ b/api/v1/multiclusterengine_types.go
@@ -148,6 +148,7 @@ const (
 	MultiClusterEnginePhaseUninstalling  PhaseType = "Uninstalling"
 	MultiClusterEnginePhaseError         PhaseType = "Error"
 	MultiClusterEnginePhaseUnimplemented PhaseType = "Unimplemented"
+	MultiClusterEnginePhaseUpdating      PhaseType = "Updating"
 )
 
 type MultiClusterEngineConditionType string

--- a/api/v1/multiclusterengine_types.go
+++ b/api/v1/multiclusterengine_types.go
@@ -154,17 +154,23 @@ type MultiClusterEngineConditionType string
 
 // These are valid conditions of the multiclusterengine.
 const (
-	// Available means the deployment is available, ie. at least the minimum available
-	// replicas required are up and running for at least minReadySeconds.
+	/*
+		Available means the deployment is available, ie. at least the minimum available
+		replicas required are up and running for at least minReadySeconds.
+	*/
 	MultiClusterEngineAvailable MultiClusterEngineConditionType = "Available"
-	// Progressing means the deployment is progressing. Progress for a deployment is
-	// considered when a new replica set is created or adopted, and when new pods scale
-	// up or old pods scale down. Progress is not estimated for paused deployments or
-	// when progressDeadlineSeconds is not specified.
+	/*
+		Progressing means the deployment is progressing. Progress for a deployment is
+		considered when a new replica set is created or adopted, and when new pods scale
+		up or old pods scale down. Progress is not estimated for paused deployments or
+		when progressDeadlineSeconds is not specified.
+	*/
 	MultiClusterEngineProgressing MultiClusterEngineConditionType = "Progressing"
-	// Failure is added in a deployment when one of its pods fails to be created
-	// or deleted.
-	MultiClusterEngineFailure MultiClusterEngineConditionType = "MultiClusterEngineFailure"
+	/*
+		Failure is added in a deployment when one of its pods fails to be created
+		or deleted.
+	*/
+	MultiClusterEngineFailure MultiClusterEngineConditionType = "Failure"
 )
 
 type MultiClusterEngineCondition struct {

--- a/api/v1/multiclusterengine_types.go
+++ b/api/v1/multiclusterengine_types.go
@@ -167,6 +167,11 @@ const (
 	*/
 	MultiClusterEngineProgressing MultiClusterEngineConditionType = "Progressing"
 	/*
+		ComponentFailure is added in a deployment when one of its pods fails to be created
+		or deleted.
+	*/
+	MultiClusterEngineComponentFailure MultiClusterEngineConditionType = "ComponentFailure"
+	/*
 		Failure is added in a deployment when one of its pods fails to be created
 		or deleted.
 	*/

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -988,13 +988,6 @@ func (r *MultiClusterEngineReconciler) applyTemplate(ctx context.Context, backpl
 				backplanev1.MultiClusterEngineFailure, metav1.ConditionTrue,
 				status.ApplyFailedReason, errMessage.Error()))
 
-			if apierrors.IsInvalid(err) {
-				r.StatusManager.AddCondition(status.NewCondition(
-					backplanev1.MultiClusterEngineProgressing, metav1.ConditionFalse,
-					status.UnsupportedConfigReason, "operator cannot progress due to invalid configuration",
-				))
-			}
-
 			return ctrl.Result{}, errMessage
 		}
 	}

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -989,7 +989,9 @@ func (r *MultiClusterEngineReconciler) applyTemplate(ctx context.Context, backpl
 			errMessage := fmt.Errorf(
 				"error applying object Name: %s Kind: %s Error: %w", template.GetName(), template.GetKind(), err)
 
-			condType := fmt.Sprintf("%v: %v", backplanev1.MultiClusterEngineComponentFailure, template.GetName())
+			condType := fmt.Sprintf("%v: %v (Kind:%v)", backplanev1.MultiClusterEngineComponentFailure,
+				template.GetName(), template.GetKind())
+
 			r.StatusManager.AddCondition(
 				status.NewCondition(
 					backplanev1.MultiClusterEngineConditionType(condType), metav1.ConditionTrue,

--- a/pkg/status/condition.go
+++ b/pkg/status/condition.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	// ApplyFailedReason is added when the hub fails to apply a resource
+	ApplyFailedReason = "FailedApplyingComponent"
 	// ComponentsAvailableReason is when all desired components are running successfully
 	ComponentsAvailableReason = "ComponentsAvailable"
 	// ComponentsUnavailableReason is when one or more components are in an unready state

--- a/pkg/status/condition.go
+++ b/pkg/status/condition.go
@@ -2,6 +2,8 @@
 package status
 
 import (
+	"strings"
+
 	v1 "github.com/stolostron/backplane-operator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -89,4 +91,29 @@ func filterOutCondition(conditions []v1.MultiClusterEngineCondition, condType v1
 		newConditions = append(newConditions, c)
 	}
 	return newConditions
+}
+
+// FilterOutConditionWithSubString returns a new slice of hub conditions without conditions with the provided type.
+func FilterOutConditionWithSubString(conditions []v1.MultiClusterEngineCondition, condType v1.MultiClusterEngineConditionType) []v1.MultiClusterEngineCondition {
+	var newConditions []v1.MultiClusterEngineCondition
+	for _, c := range conditions {
+		if strings.Contains(string(c.Type), string(condType)) {
+			continue
+		}
+		newConditions = append(newConditions, c)
+	}
+	return newConditions
+}
+
+/*
+ConditionPresentWithSubstring returns true or false if a MultiClusterEngineCondition is
+present with a target substring.
+*/
+func ConditionPresentWithSubstring(conditions []v1.MultiClusterEngineCondition, substring string) bool {
+	for _, c := range conditions {
+		if strings.Contains(string(c.Type), substring) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/status/condition_test.go
+++ b/pkg/status/condition_test.go
@@ -1,0 +1,333 @@
+// Copyright Contributors to the Open Cluster Management project
+package status
+
+import (
+	"fmt"
+	"testing"
+
+	bpv1 "github.com/stolostron/backplane-operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_NewCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		condType bpv1.MultiClusterEngineConditionType
+		status   metav1.ConditionStatus
+		reason   string
+		message  string
+		want     bool
+	}{
+		{
+			name:     "added new multiclusterengine condition",
+			condType: bpv1.MultiClusterEngineAvailable,
+			status:   metav1.ConditionTrue,
+			reason:   DeploySuccessReason,
+			message:  "All components deployed",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := NewCondition(tt.condType, tt.status, tt.reason, tt.message)
+
+			if got := cond.Type != tt.condType; got {
+				t.Errorf("%s: expected condition condType: %v to equal: %v, got %v", tt.name, cond.Type, tt.condType, got)
+			}
+
+			if got := cond.Status != tt.status; got {
+				t.Errorf("%s: expected condition status: %v to equal: %v, got %v", tt.name, cond.Status, tt.status, got)
+			}
+
+			if got := cond.Reason != tt.reason; got {
+				t.Errorf("%s: expected condition reason: %v to equal: %v, got %v", tt.name, cond.Reason, tt.reason, got)
+			}
+
+			if got := cond.Message != tt.message; got {
+				t.Errorf("%s: expected condition message: %v to equal: %v, got %v", tt.name, cond.Message, tt.message, got)
+			}
+		})
+	}
+}
+
+func Test_setCondition(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []bpv1.MultiClusterEngineCondition
+		want       int
+	}{
+		{
+			name: "set single multiclusterengine condition",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Reason:             DeploySuccessReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineProgressing,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "set multiple multiclusterengine conditions",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Reason:             DeploySuccessReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineProgressing,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Message:            "All components deployed",
+					Reason:             ComponentsAvailableReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineAvailable,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "set duplicate multiclusterengine conditions",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Reason:             DeploySuccessReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineProgressing,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Message:            "All components deployed",
+					Reason:             ComponentsAvailableReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineAvailable,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newCond := bpv1.MultiClusterEngineCondition{
+				Reason:             DeploySuccessReason,
+				Status:             metav1.ConditionUnknown,
+				Type:               bpv1.MultiClusterEngineProgressing,
+				LastUpdateTime:     metav1.Now(),
+				LastTransitionTime: metav1.Now(),
+			}
+
+			cond := setCondition(tt.conditions, newCond)
+
+			if len(cond) != tt.want {
+				t.Errorf("%s: expected condition to exist: %d, got %v", tt.name, tt.want, len(cond))
+			}
+		})
+	}
+}
+
+func Test_getCondition(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []bpv1.MultiClusterEngineCondition
+		condType   bpv1.MultiClusterEngineConditionType
+		want       bool
+	}{
+		{
+			name: "get multiclusterengine condition",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Message:            "failed to create typed patch object (mutlicluster-engine/foo; apps/v1, Kind=Deployment)",
+					Reason:             ApplyFailedReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineComponentFailure,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Message:            "setting up operator",
+					Reason:             ComponentsUnavailableReason,
+					Status:             metav1.ConditionFalse,
+					Type:               bpv1.MultiClusterEngineProgressing,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			condType: bpv1.MultiClusterEngineComponentFailure,
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := getCondition(tt.conditions, tt.condType)
+
+			exists := cond != nil
+			if exists != tt.want {
+				t.Errorf("%s: expected condition to exist: %t, got %v", tt.name, tt.want, exists)
+			}
+		})
+	}
+}
+
+func Test_filterOutCondition(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []bpv1.MultiClusterEngineCondition
+		condType   bpv1.MultiClusterEngineConditionType
+		want       int
+	}{
+		{
+			name: "filter out multiclusterengine condition",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Message:            "failed to create typed patch object (mutlicluster-engine/foo; apps/v1, Kind=Deployment)",
+					Reason:             ApplyFailedReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineComponentFailure,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Message:            "setting up operator",
+					Reason:             ComponentsUnavailableReason,
+					Status:             metav1.ConditionFalse,
+					Type:               bpv1.MultiClusterEngineProgressing,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			condType: bpv1.MultiClusterEngineComponentFailure,
+			want:     1,
+		},
+		{
+			name: "filter out no multiclusterengine condition",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Message:            "failed to create typed patch object (mutlicluster-engine/foo; apps/v1, Kind=Deployment)",
+					Reason:             ApplyFailedReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineComponentFailure,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Message:            "setting up operator",
+					Reason:             ComponentsUnavailableReason,
+					Status:             metav1.ConditionFalse,
+					Type:               bpv1.MultiClusterEngineProgressing,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			condType: bpv1.MultiClusterEngineAvailable,
+			want:     2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := filterOutCondition(tt.conditions, tt.condType)
+
+			if len(cond) != tt.want {
+				t.Errorf("%s: expected condition to exist: %v, got %v", tt.name, tt.want, len(cond))
+			}
+		})
+	}
+}
+
+func Test_FilterOutConditionWithSubString(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []bpv1.MultiClusterEngineCondition
+		condType   bpv1.MultiClusterEngineConditionType
+		subString  string
+		want       int
+	}{
+		{
+			name: "filter out multiclusterengine condition by substring",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Message:            "failed to create typed patch object (mutlicluster-engine/foo; apps/v1, Kind=Deployment)",
+					Reason:             ApplyFailedReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineConditionType(fmt.Sprintf("%v: %v (Kind: %v)", bpv1.MultiClusterEngineComponentFailure, "foo", "Deployment")),
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			condType:  bpv1.MultiClusterEngineComponentFailure,
+			subString: string(bpv1.MultiClusterEngineComponentFailure),
+			want:      0,
+		},
+		{
+			name: "filter out no multiclusterengine condition",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Message:            "failed to create typed patch object (mutlicluster-engine/foo; apps/v1, Kind=Deployment)",
+					Reason:             ApplyFailedReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineComponentFailure,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+				{
+					Message:            "setting up operator",
+					Reason:             ComponentsUnavailableReason,
+					Status:             metav1.ConditionFalse,
+					Type:               bpv1.MultiClusterEngineProgressing,
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			condType:  bpv1.MultiClusterEngineAvailable,
+			subString: string(bpv1.MultiClusterEngineAvailable),
+			want:      2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := FilterOutConditionWithSubString(tt.conditions, tt.condType)
+
+			if len(cond) != tt.want {
+				t.Errorf("%s: expected condition to exist: %v, got %v", tt.name, tt.want, len(cond))
+			}
+		})
+	}
+}
+
+func Test_ConditionPresentWithSubstring(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []bpv1.MultiClusterEngineCondition
+		subString  string
+		want       bool
+	}{
+		{
+			name: "check if multiclusterengine condition contains substring",
+			conditions: []bpv1.MultiClusterEngineCondition{
+				{
+					Message:            "failed to create typed patch object (mutlicluster-engine/foo; apps/v1, Kind=Deployment)",
+					Reason:             ApplyFailedReason,
+					Status:             metav1.ConditionTrue,
+					Type:               bpv1.MultiClusterEngineConditionType(fmt.Sprintf("%v: %v (Kind: %v)", bpv1.MultiClusterEngineComponentFailure, "foo", "Deployment")),
+					LastUpdateTime:     metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			subString: string(bpv1.MultiClusterEngineComponentFailure),
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if ok := ConditionPresentWithSubstring(tt.conditions, tt.subString); !ok {
+				t.Errorf("%s: expected condition to exist: %v, got %v", tt.name, tt.want, ok)
+			}
+		})
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -103,7 +103,7 @@ func (sm *StatusTracker) reportPhase(mce bpv1.MultiClusterEngine, components []b
 	}
 
 	// If operator isn't progressing show error phase
-	if (progress != nil && progress.Status == metav1.ConditionFalse) || failure.Status == metav1.ConditionTrue {
+	if (progress != nil && progress.Status == metav1.ConditionFalse) || (failure != nil && failure.Status == metav1.ConditionTrue) {
 		return bpv1.MultiClusterEnginePhaseError
 	}
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -94,6 +94,7 @@ func (sm *StatusTracker) reportConditions() []bpv1.MultiClusterEngineCondition {
 
 func (sm *StatusTracker) reportPhase(mce bpv1.MultiClusterEngine, components []bpv1.ComponentCondition, conditions []bpv1.MultiClusterEngineCondition) bpv1.PhaseType {
 	progress := getCondition(conditions, bpv1.MultiClusterEngineProgressing)
+	failure := getCondition(conditions, bpv1.MultiClusterEngineFailure)
 
 	for _, condition := range conditions {
 		if condition.Reason == PausedReason {
@@ -102,7 +103,7 @@ func (sm *StatusTracker) reportPhase(mce bpv1.MultiClusterEngine, components []b
 	}
 
 	// If operator isn't progressing show error phase
-	if progress != nil && progress.Status == metav1.ConditionFalse {
+	if (progress != nil && progress.Status == metav1.ConditionFalse) || failure.Status == metav1.ConditionTrue {
 		return bpv1.MultiClusterEnginePhaseError
 	}
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -94,7 +94,6 @@ func (sm *StatusTracker) reportConditions() []bpv1.MultiClusterEngineCondition {
 
 func (sm *StatusTracker) reportPhase(mce bpv1.MultiClusterEngine, components []bpv1.ComponentCondition, conditions []bpv1.MultiClusterEngineCondition) bpv1.PhaseType {
 	progress := getCondition(conditions, bpv1.MultiClusterEngineProgressing)
-	failure := getCondition(conditions, bpv1.MultiClusterEngineFailure)
 
 	for _, condition := range conditions {
 		if condition.Reason == PausedReason {
@@ -103,7 +102,7 @@ func (sm *StatusTracker) reportPhase(mce bpv1.MultiClusterEngine, components []b
 	}
 
 	// If operator isn't progressing show error phase
-	if (progress != nil && progress.Status == metav1.ConditionFalse) || (failure != nil && failure.Status == metav1.ConditionTrue) {
+	if progress != nil && progress.Status == metav1.ConditionFalse {
 		return bpv1.MultiClusterEnginePhaseError
 	}
 
@@ -114,6 +113,11 @@ func (sm *StatusTracker) reportPhase(mce bpv1.MultiClusterEngine, components []b
 
 	// If status isn't tracking anything show error phase
 	if len(components) == 0 {
+		return bpv1.MultiClusterEnginePhaseError
+	}
+
+	// If status contains failure status return error
+	if ok := ConditionPresentWithSubstring(conditions, string(bpv1.MultiClusterEngineComponentFailure)); ok {
 		return bpv1.MultiClusterEnginePhaseError
 	}
 


### PR DESCRIPTION
# Description

Enhanced the MCE operator to capture and display status for when resources apply to fail within MCE.

## Related Issue

https://issues.redhat.com/browse/ACM-8576

## Changes Made

Updated the MCE status condition to include a reference to the failed resource and updated the status phase to reflect `error` when an issue arises.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @ngraham20 @cameronmwall 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
