### PR TITLE
chore: Increase frequency of regenerate-operator-bundle runs

### DIFF
--- a/.github/workflows/regenerate-operator-bundles.yml
+++ b/.github/workflows/regenerate-operator-bundles.yml
@@ -6,7 +6,8 @@ name: Regenerate Operator Bundles
 on:
   # Runs every day
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 11,13,15,17,19,21,23 * * *"
+      # Time is in UTC, so this runs every two hours from 6AM to 6PM EST 
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION

Our regenerate-bundles workflow for the main branch (i.e. the active dev branch) is configured to run only once a day. That pace seems fine for branches that are shipped and in maintenance/support as bundle changes happen very infrequently (hopefully not at all) in the Z-Stream. But this pace seems way to slow for the in-dev branch, especially as we deal with end-of-sprint deadlines where changes show up.

This PR changes the main-branch frequency to every 2 hours from 6AM to 6PM EST.  If that proves too expensive re action-run quotas, we can consider backing off.
