### PR TITLE
ACM-10734: Remove obsolete hypershift related image references

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-configmap.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-configmap.yaml
@@ -13,18 +13,6 @@ data:
       lookupPolicy:
         local: false
       tags:
-      - name: apiserver-network-proxy
-        annotations:
-          io.openshift.build.source-location: https://github.com/openshift/apiserver-network-proxy
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.apiserver_network_proxy }}
-      - name: aws-encryption-provider
-        annotations:
-          io.openshift.build.source-location: https://github.com/openshift/aws-encryption-provider
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.aws_encryption_provider }}
       - name: cluster-api
         annotations:
           io.openshift.build.commit.id: e09ed61cc9ba8bd37b0760291c833b4da744a985
@@ -39,20 +27,6 @@ data:
         from:
           kind: DockerImage
           name: {{ .Values.global.imageOverrides.cluster_api_provider_agent }}
-      - name: cluster-api-provider-aws
-        annotations:
-          io.openshift.build.commit.id: 0b2e34680d117b1d8146965f3123c04709d37951
-          io.openshift.build.source-location: https://github.com/openshift/cluster-api-provider-aws
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.cluster_api_provider_aws }}
-      - name: cluster-api-provider-azure
-        annotations:
-          io.openshift.build.commit.id: e17ba23dd8ff1b2698d80499a416917c2084a0c1
-          io.openshift.build.source-location: https://github.com/openshift/cluster-api-provider-azure
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.cluster_api_provider_azure }}
       - name: cluster-api-provider-kubevirt
         annotations:
           io.openshift.build.commit.id: 'dbdc825088513dc962ba2103efe2c1a4eb3cf524'

--- a/pkg/templates/charts/toggle/hypershift/values.yaml
+++ b/pkg/templates/charts/toggle/hypershift/values.yaml
@@ -1,12 +1,8 @@
 global:
   imageOverrides:
     hypershift_addon_operator: ""
-    apiserver_network_proxy: ""
-    aws_encryption_provider: ""
     cluster_api: ""
     cluster_api_provider_agent: ""
-    cluster_api_provider_aws: ""
-    cluster_api_provider_azure: ""
     hypershift_operator: ""
     cluster_api_provider_kubevirt: ""
     kube_rbac_proxy_mce: "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10"


### PR DESCRIPTION
# Description

With https://issues.redhat.com/browse/HYPBLD-249, the following MCE container images are no longer built and packaged in MCE. This PR is to remove references to those images from the hypershift addon installation chart.

## Related Issue

https://issues.redhat.com/browse/HYPBLD-249

## Changes Made

With https://issues.redhat.com/browse/HYPBLD-249, the following MCE container images are no longer built and packaged in MCE. This PR is to remove references to those images from the hypershift addon installation char

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
