### PR TITLE
[ACM-10803] Deprecate and update MCE annotations

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -69,15 +69,15 @@ import (
 
 // MultiClusterEngineReconciler reconciles a MultiClusterEngine object
 type MultiClusterEngineReconciler struct {
-	Client               client.Client
-	UncachedClient       client.Client
-	CacheSpec            CacheSpec
-	Scheme               *runtime.Scheme
-	Images               map[string]string
-	StatusManager        *status.StatusTracker
-	Log                  logr.Logger
-	UpgradeableCond      utils.Condition
-	DeprecatedSpecFields map[string]bool
+	Client           client.Client
+	UncachedClient   client.Client
+	CacheSpec        CacheSpec
+	Scheme           *runtime.Scheme
+	Images           map[string]string
+	StatusManager    *status.StatusTracker
+	Log              logr.Logger
+	UpgradeableCond  utils.Condition
+	DeprecatedFields map[string]bool
 }
 
 const (
@@ -1660,19 +1660,26 @@ func (r *MultiClusterEngineReconciler) StopScheduleOperatorControllerResync() {
 }
 
 func (r *MultiClusterEngineReconciler) CheckDeprecatedFieldUsage(m *backplanev1.MultiClusterEngine) {
-	deprecatedSpecFields := []struct {
+	a := m.GetAnnotations()
+	df := []struct {
 		name      string
 		isPresent bool
-	}{}
-
-	if r.DeprecatedSpecFields == nil {
-		r.DeprecatedSpecFields = make(map[string]bool)
+	}{
+		{utils.DeprecatedAnnotationIgnoreOCPVersion, a[utils.DeprecatedAnnotationIgnoreOCPVersion] != ""},
+		{utils.DeprecatedAnnotationImageOverridesCM, a[utils.DeprecatedAnnotationImageOverridesCM] != ""},
+		{utils.DeprecatedAnnotationImageRepo, a[utils.DeprecatedAnnotationImageRepo] != ""},
+		{utils.DeprecatedAnnotationKubeconfig, a[utils.DeprecatedAnnotationKubeconfig] != ""},
+		{utils.DeprecatedAnnotationMCEPause, a[utils.DeprecatedAnnotationMCEPause] != ""},
 	}
 
-	for _, f := range deprecatedSpecFields {
-		if f.isPresent && !r.DeprecatedSpecFields[f.name] {
+	if r.DeprecatedFields == nil {
+		r.DeprecatedFields = make(map[string]bool)
+	}
+
+	for _, f := range df {
+		if f.isPresent && !r.DeprecatedFields[f.name] {
 			r.Log.Info(fmt.Sprintf("Warning: %s field usage is deprecated in operator.", f.name))
-			r.DeprecatedSpecFields[f.name] = true
+			r.DeprecatedFields[f.name] = true
 		}
 	}
 }

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -29,7 +29,7 @@ var (
 		AnnotationImageOverridesCM is an annotation used in multiclusterengine to specify a custom ConfigMap containing
 		image overrides.
 	*/
-	AnnotationImageOverridesCM           = "multicluster.openshift.io/imageOverridesCM"
+	AnnotationImageOverridesCM           = "multicluster.openshift.io/image-overrides-configmap"
 	DeprecatedAnnotationImageOverridesCM = "imageOverridesCM"
 
 	/*

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -14,12 +14,6 @@ import (
 
 var (
 	/*
-		AnnotationMCEPause is an annotation used in multiclusterengine to identify if the multiclusterengine is
-		paused or not.
-	*/
-	AnnotationMCEPause = "pause"
-
-	/*
 		AnnotationMCEIgnore labels a resource as something the operator should ignore and not update.
 	*/
 	AnnotationMCEIgnore = "multiclusterengine.openshift.io/ignore"
@@ -28,70 +22,80 @@ var (
 		AnnotationIgnoreOCPVersion is an annotation used to indicate the operator should not check the OpenShift
 		Container Platform (OCP) version before proceeding when set.
 	*/
-	AnnotationIgnoreOCPVersion = "ignoreOCPVersion"
-
-	/*
-		AnnotationImageRepo is an annotation used in multiclusterengine to specify a custom image repository to use.
-	*/
-	AnnotationImageRepo = "imageRepository"
+	AnnotationIgnoreOCPVersion           = "multicluster.openshift.io/ignore-ocp-version"
+	DeprecatedAnnotationIgnoreOCPVersion = "ignoreOCPVersion"
 
 	/*
 		AnnotationImageOverridesCM is an annotation used in multiclusterengine to specify a custom ConfigMap containing
 		image overrides.
 	*/
-	AnnotationImageOverridesCM = "imageOverridesCM"
+	AnnotationImageOverridesCM           = "multicluster.openshift.io/imageOverridesCM"
+	DeprecatedAnnotationImageOverridesCM = "imageOverridesCM"
 
 	/*
-		AnnotationTemplateOverridesCM is an annotation used in multiclusterengine to specify a custom ConfigMap
-		containing resource template overrides.
+		AnnotationImageRepo is an annotation used in multiclusterengine to specify a custom image repository to use.
 	*/
-	AnnotationTemplateOverridesCM = "operator.multicluster.openshift.io/template-override-cm"
+	AnnotationImageRepo           = "multicluster.openshift.io/image-repository"
+	DeprecatedAnnotationImageRepo = "imageRepository"
 
 	/*
 		AnnotationKubeconfig is an annotation used to specify the secret name residing in target containing the
 		kubeconfig to access the remote cluster.
 	*/
-	AnnotationKubeconfig = "mce-kubeconfig"
+	AnnotationKubeconfig           = "multicluster.openshift.io/kubeconfig"
+	DeprecatedAnnotationKubeconfig = "mce-kubeconfig"
+
+	/*
+		AnnotationMCEPause is an annotation used in multiclusterengine to identify if the multiclusterengine is
+		paused or not.
+	*/
+	AnnotationMCEPause           = "multicluster.openshift.io/pause"
+	DeprecatedAnnotationMCEPause = "pause"
 
 	/*
 		AnnotationReleaseVersion is an annotation used to indicate the release version that should be applied to all
 		resources managed by the backplane operator.
 	*/
 	AnnotationReleaseVersion = "installer.multicluster.openshift.io/release-version"
+
+	/*
+		AnnotationTemplateOverridesCM is an annotation used in multiclusterengine to specify a custom ConfigMap
+		containing resource template overrides.
+	*/
+	AnnotationTemplateOverridesCM = "operator.multicluster.openshift.io/template-override-cm"
 )
 
-// IsPaused returns true if the multiclusterengine instance is labeled as paused, and false otherwise
+/*
+IsPaused checks if the MultiClusterHub instance is labeled as paused.
+It returns true if the instance is paused, otherwise false.
+*/
 func IsPaused(instance *backplanev1.MultiClusterEngine) bool {
+	return IsAnnotationTrue(instance, AnnotationMCEPause) || IsAnnotationTrue(instance, DeprecatedAnnotationMCEPause)
+}
+
+/*
+IsAnnotationTrue checks if a specific annotation key in the given instance is set to "true".
+*/
+func IsAnnotationTrue(instance *backplanev1.MultiClusterEngine, annotationKey string) bool {
 	a := instance.GetAnnotations()
 	if a == nil {
 		return false
 	}
 
-	if a[AnnotationMCEPause] != "" && strings.EqualFold(a[AnnotationMCEPause], "true") {
-		return true
-	}
-
-	return false
+	value := strings.EqualFold(a[annotationKey], "true")
+	return value
 }
 
-// ShouldIgnoreOCPVersion returns true if the multiclusterengine instance is annotated to skip
-// the minimum OCP version requirement
-func ShouldIgnoreOCPVersion(instance *backplanev1.MultiClusterEngine) bool {
-	a := instance.GetAnnotations()
-	if a == nil {
-		return false
-	}
-
-	if _, ok := a[AnnotationIgnoreOCPVersion]; ok {
-		return true
-	}
-	return false
-}
-
-// AnnotationsMatch returns true if all annotation values used by the operator match
+/*
+AnnotationsMatch checks if all specified annotations in the 'old' map match the corresponding ones in the 'new' map.
+It returns true if all annotations match, otherwise false.
+*/
 func AnnotationsMatch(old, new map[string]string) bool {
-	return old[AnnotationMCEPause] == new[AnnotationMCEPause] &&
-		old[AnnotationImageRepo] == new[AnnotationImageRepo]
+	return getAnnotationOrDefaultForMap(old, new, AnnotationMCEPause, DeprecatedAnnotationMCEPause) &&
+		getAnnotationOrDefaultForMap(old, new, AnnotationImageRepo, DeprecatedAnnotationImageRepo) &&
+		getAnnotationOrDefaultForMap(old, new, AnnotationImageOverridesCM, DeprecatedAnnotationImageOverridesCM) &&
+		getAnnotationOrDefaultForMap(old, new, AnnotationKubeconfig, DeprecatedAnnotationKubeconfig) &&
+		getAnnotationOrDefaultForMap(old, new, AnnotationTemplateOverridesCM, "")
 }
 
 // AnnotationPresent returns true if annotation is present on object
@@ -103,7 +107,10 @@ func AnnotationPresent(annotation string, obj client.Object) bool {
 	return exists
 }
 
-// getAnnotation returns the annotation value for a given key, or an empty string if not set
+/*
+GetAnnotation returns the annotation value for a given key from the instance's annotations,
+or an empty string if the annotation is not set.
+*/
 func getAnnotation(instance *backplanev1.MultiClusterEngine, key string) string {
 	a := instance.GetAnnotations()
 	if a == nil {
@@ -112,24 +119,97 @@ func getAnnotation(instance *backplanev1.MultiClusterEngine, key string) string 
 	return a[key]
 }
 
-// GetImageRepository returns the image repo annotation, or an empty string if not set
-func GetImageRepository(instance *backplanev1.MultiClusterEngine) string {
-	return getAnnotation(instance, AnnotationImageRepo)
-}
+/*
+getAnnotationOrDefault retrieves the value of the primary annotation key,
+falling back to the deprecated key if the primary key is not set.
+*/
+func getAnnotationOrDefault(instance *backplanev1.MultiClusterEngine, primaryKey, deprecatedKey string) string {
+	primaryValue := getAnnotation(instance, primaryKey)
+	if primaryValue != "" {
+		return primaryValue
+	}
 
-// GetImageOverridesConfigmapName returns the images override configmap annotation value, or an empty string if not set.
-func GetImageOverridesConfigmapName(instance *backplanev1.MultiClusterEngine) string {
-	return getAnnotation(instance, AnnotationImageOverridesCM)
+	return getAnnotation(instance, deprecatedKey)
 }
 
 /*
-GetTemplateOverridesConfigmapName returns the templates override configmap annotation value, or an empty string
-if not set.
+getAnnotationOrDefaultForMap checks if the annotation value from the 'old' map matches the one from the 'new' map,
+including deprecated annotations.
+*/
+func getAnnotationOrDefaultForMap(old, new map[string]string, primaryKey, deprecatedKey string) bool {
+	oldValue := old[primaryKey]
+
+	if oldValue == "" {
+		oldValue = old[deprecatedKey]
+	}
+
+	newValue := new[primaryKey]
+	if newValue == "" {
+		newValue = new[deprecatedKey]
+	}
+
+	return oldValue == newValue
+}
+
+/*
+GetHostedCredentialsSecret returns the NamespacedName of the secret containing the kubeconfig
+to access the hosted cluster, using the primary annotation key and falling back to the deprecated key if not set.
+*/
+func GetHostedCredentialsSecret(mce *backplanev1.MultiClusterEngine) (types.NamespacedName, error) {
+	nn := types.NamespacedName{}
+	nn.Name = getAnnotationOrDefault(mce, AnnotationKubeconfig, DeprecatedAnnotationKubeconfig)
+
+	if nn.Name == "" {
+		return nn, fmt.Errorf("no kubeconfig secret annotation defined in %s", mce.Name)
+	}
+
+	nn.Namespace = mce.Spec.TargetNamespace
+	if mce.Spec.TargetNamespace == "" {
+		nn.Namespace = backplanev1.DefaultTargetNamespace
+	}
+	return nn, nil
+}
+
+/*
+GetImageRepository returns the image repository annotation value,
+using the primary annotation key and falling back to the deprecated key if not set.
+*/
+func GetImageRepository(instance *backplanev1.MultiClusterEngine) string {
+	return getAnnotationOrDefault(instance, AnnotationImageRepo, DeprecatedAnnotationImageRepo)
+}
+
+/*
+GetImageOverridesConfigmapName returns the image overrides ConfigMap annotation value,
+using the primary annotation key and falling back to the deprecated key if not set.
+*/
+func GetImageOverridesConfigmapName(instance *backplanev1.MultiClusterEngine) string {
+	return getAnnotationOrDefault(instance, AnnotationImageOverridesCM, DeprecatedAnnotationImageOverridesCM)
+}
+
+/*
+GetTemplateOverridesConfigmapName returns the template overrides ConfigMap annotation value,
+or an empty string if not set.
 */
 func GetTemplateOverridesConfigmapName(instance *backplanev1.MultiClusterEngine) string {
 	return getAnnotation(instance, AnnotationTemplateOverridesCM)
 }
 
+/*
+HasAnnotation checks if a specific annotation key exists in the instance's annotations.
+*/
+func HasAnnotation(instance *backplanev1.MultiClusterEngine, annotationKey string) bool {
+	a := instance.GetAnnotations()
+	if a == nil {
+		return false
+	}
+
+	_, exists := a[annotationKey]
+	return exists
+}
+
+/*
+OverrideImageRepository modifies image references in a map to use a specified image repository.
+*/
 func OverrideImageRepository(imageOverrides map[string]string, imageRepo string) map[string]string {
 	for imageKey, imageRef := range imageOverrides {
 		image := strings.LastIndex(imageRef, "/")
@@ -138,21 +218,10 @@ func OverrideImageRepository(imageOverrides map[string]string, imageRepo string)
 	return imageOverrides
 }
 
-// GetImageOverridesConfigmap returns the images override configmap annotation, or an empty string if not set
-func GetImageOverridesConfigmap(instance *backplanev1.MultiClusterEngine) string {
-	return getAnnotation(instance, AnnotationImageOverridesCM)
-}
-
-func GetHostedCredentialsSecret(mce *backplanev1.MultiClusterEngine) (types.NamespacedName, error) {
-	nn := types.NamespacedName{}
-	if mce.Annotations == nil || mce.Annotations[AnnotationKubeconfig] == "" {
-		return nn, fmt.Errorf("no kubeconfig secret annotation defined in %s", mce.Name)
-	}
-	nn.Name = mce.Annotations[AnnotationKubeconfig]
-
-	nn.Namespace = mce.Spec.TargetNamespace
-	if mce.Spec.TargetNamespace == "" {
-		nn.Namespace = backplanev1.DefaultTargetNamespace
-	}
-	return nn, nil
+/*
+ShouldIgnoreOCPVersion checks if the instance is annotated to skip the minimum OCP version requirement.
+*/
+func ShouldIgnoreOCPVersion(instance *backplanev1.MultiClusterEngine) bool {
+	return HasAnnotation(instance, AnnotationIgnoreOCPVersion) ||
+		HasAnnotation(instance, DeprecatedAnnotationIgnoreOCPVersion)
 }


### PR DESCRIPTION
# Description

Added new annotation version and deprecating others.

| Deprecated                    | New                                            | Description                                                                                                     |
|-------------------------------|------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ignoreOCPVersion              | multicluster.openshift.io/ignore-ocp-version | Annotation used to indicate the operator should not check the OpenShift Container Platform (OCP) version before proceeding when set. |
| imageOverridesCM              | multicluster.openshift.io/image-overrides-configmap | Annotation used in multiclusterengine to specify a custom ConfigMap containing image overrides.                 |
| imageRepository               | multicluster.openshift.io/image-repository   | Annotation used in multiclusterengine to specify a custom image repository to use.                              |
| mce-kubeconfig                | multicluster.openshift.io/kubeconfig         | Annotation used to specify the secret name residing in the target containing the kubeconfig to access the remote cluster. |
| pause                         | multicluster.openshift.io/pause              | Annotation used in multiclusterengine to identify if the multiclusterengine is paused or not.                   |


## Related Issue

https://issues.redhat.com/browse/ACM-10803

## Changes Made

Enhanced annotation version and deprecated previous.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
