### PR TITLE
ACM-10683 Update ClusterCurator CRD to support EUS upgrades

### DIFF
--- a/pkg/templates/crds/cluster-lifecycle/cluster.open-cluster-management.io_clustercurators.yaml
+++ b/pkg/templates/crds/cluster-lifecycle/cluster.open-cluster-management.io_clustercurators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: clustercurators.cluster.open-cluster-management.io
 spec:
@@ -18,9 +18,10 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ClusterCurator is the Schema for the clustercurators API This
-          kind allows for prehook and posthook jobs to be executed prior to Hive provisioning
-          and import of a cluster.
+        description: ClusterCurator is the custom resource for the clustercurators
+          API. This kind allows you to run Ansible prehook and posthook jobs before
+          provisioning Hive or HyperShift and importing a cluster. Additionally, cluster
+          upgrade and destroy operations are supported as well.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -348,7 +349,20 @@ spec:
                     description: DesiredUpdate indicates the desired value of the
                       cluster version. Setting this value will trigger an upgrade
                       (if the current version does not match the desired version).
+                      During an EUS to EUS upgrade, this value becomes the final cluster
+                      version (the target version that ClusterCurator will upgrade
+                      the cluster to).
                     type: string
+                  intermediateUpdate:
+                    description: IntermediateUpdate indicates the desired value of
+                      the intermediate cluster version when performing EUS to EUS
+                      upgrades. Setting both this value and DesiredUpdate will trigger
+                      an EUS to EUS upgrade.
+                    maxLength: 512
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
                   monitorTimeout:
                     default: 120
                     description: MonitorTimeout defines the monitor process timeout,
@@ -451,14 +465,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -520,9 +532,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
# Description

Updated the ClusterCurator CRD to support the EUS to EUS upgrade feature for managed clusters.

## Related Issue

https://issues.redhat.com/browse/ACM-10683

## Changes Made

Updated the ClusterCurator CRD, added a `spec.upgrade.intermediateUpdate` field for users to specify the intermediate upgrade version.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [X] I have tested the changes locally and they are functioning as expected.
- [X] I have updated the documentation (if necessary) to reflect the changes.
- [X] I have added/updated relevant unit tests (if applicable).
- [X] I have ensured that my code follows the project's coding standards.
- [X] I have checked for any potential security issues and addressed them.
- [X] I have added necessary comments to the code, especially in complex or unclear sections.
- [X] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

N/A

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
