### PR TITLE
add deployOnOCP field to the charts to support deploy on aks

### DIFF
--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -41,6 +41,7 @@ type Global struct {
 	Namespace         string            `json:"namespace" structs:"namespace"`
 	ConfigSecret      string            `json:"configSecret" structs:"configSecret"`
 	HubSize           v1.HubSize        `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
+	DeployOnOCP       bool            `json:"deployOnOCP" structs:"deployOnOCP"`
 }
 
 type HubConfig struct {
@@ -81,7 +82,7 @@ func (u *Toleration) MarshalJSON() ([]byte, error) {
 	var operator corev1.TolerationOperator = u.Operator
 	var effect corev1.TaintEffect = u.Effect
 
-	//Marshal all Toleration fields that are a number or true/false into a string
+	// Marshal all Toleration fields that are a number or true/false into a string
 	for i := 0; i < reflect.Indirect(v).NumField(); i++ {
 		switch reflect.Indirect(v).Field(i).Kind() {
 		case reflect.String:
@@ -285,18 +286,28 @@ func renderTemplates(chartPath string, backplaneConfig *v1.MultiClusterEngine, i
 	}
 
 	for fileName, templateFile := range rawTemplates {
+		if len(templateFile) == 0 {
+			continue
+		}
+
 		unstructured := &unstructured.Unstructured{}
 		if err = yaml.Unmarshal([]byte(templateFile), unstructured); err != nil {
 			return nil, append(errs, fmt.Errorf("error converting file %s to unstructured", fileName))
 		}
 
+		kind := unstructured.GetKind()
+		if kind == "" {
+			continue
+
+		}
 		utils.AddBackplaneConfigLabels(unstructured, backplaneConfig.Name)
 
 		// Add namespace to namespaced resources
-		switch unstructured.GetKind() {
+		switch kind {
 		case "Deployment", "ServiceAccount", "Role", "RoleBinding", "Service", "ConfigMap", "Route":
 			unstructured.SetNamespace(backplaneConfig.Spec.TargetNamespace)
 		}
+
 		templates = append(templates, unstructured)
 	}
 
@@ -317,6 +328,9 @@ func injectValuesOverrides(values *Values, backplaneConfig *v1.MultiClusterEngin
 	values.Global.HubSize = backplaneConfig.Spec.HubSize
 
 	values.Global.PullSecret = backplaneConfig.Spec.ImagePullSecret
+
+	// TODO: check if operator is working on OCP cluster
+	values.Global.DeployOnOCP = true
 
 	if v1.IsInHostedMode(backplaneConfig) {
 		secretNN, err := utils.GetHostedCredentialsSecret(backplaneConfig)

--- a/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager.yaml
@@ -96,9 +96,11 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if .Values.global.deployOnOCP }}
 {{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+{{- end }}
 {{- end }}
       serviceAccountName: cluster-manager
 {{- with .Values.hubconfig.tolerations }}

--- a/pkg/templates/charts/toggle/cluster-manager/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/values.yaml
@@ -5,6 +5,7 @@ global:
   namespace: default
   pullSecret: null
   templateOverrides: {}
+  deployOnOCP: ""
 hubconfig:
   nodeSelector: null
   ocpVersion: 4.12.0

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-deployment.yaml
@@ -63,9 +63,11 @@ spec:
       hostIPC: false
       securityContext:
         runAsNonRoot: true
+        {{- if .Values.global.deployOnOCP }}
         {{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+        {{- end }}
         {{- end }}
         # runAsUser: 1001
       terminationGracePeriodSeconds: 30

--- a/pkg/templates/charts/toggle/hypershift/values.yaml
+++ b/pkg/templates/charts/toggle/hypershift/values.yaml
@@ -10,6 +10,7 @@ global:
   namespace: default
   pullSecret: null
   hubSize: Small
+  deployOnOCP: ""
 hubconfig:
   nodeSelector: null
   proxyConfigs: {}

--- a/pkg/templates/charts/toggle/server-foundation/templates/managedcluster-import-agent-registration-route.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/managedcluster-import-agent-registration-route.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deployOnOCP }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -13,3 +14,4 @@ spec:
   to:
     kind: Service
     name: agent-registration
+  {{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/managedcluster-import-agent-registration-service.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/managedcluster-import-agent-registration-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deployOnOCP }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -13,3 +14,4 @@ spec:
   type: ClusterIP
   selector:
     app: managedcluster-import-controller-v2
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/managedcluster-import-deployment.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/managedcluster-import-deployment.yaml
@@ -36,9 +36,11 @@ spec:
       terminationGracePeriodSeconds: 60
       securityContext:
         runAsNonRoot: true
+        {{- if .Values.global.deployOnOCP }}
         {{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+        {{- end }}
         {{- end }}
       affinity:
         nodeAffinity:
@@ -72,18 +74,27 @@ spec:
                   operator: In
                   values:
                   - managedclusterimport
+      {{- if .Values.global.deployOnOCP }}
       volumes:
         - name: agent-registration-server-tls
           secret:
             secretName: managedcluster-import-agent-registration-serving-cert
+      {{- end }}
       containers:
       - name: managedcluster-import-controller
         image: "{{ .Values.global.imageOverrides.managedcluster_import_controller }}"
         imagePullPolicy: {{ .Values.global.pullPolicy }}
+        {{- if .Values.global.deployOnOCP }}
         volumeMounts:
           - name: agent-registration-server-tls
             mountPath: /server
             readOnly: true
+        {{- else }}
+        args:
+          - "managedcluster-import-controller"
+          - "--feature-gates=AgentRegistration=false"
+          - "--deploy-on-ocp=false"
+        {{- end }}
         ports:
           - containerPort: 9091
         securityContext:

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-clusterview-api-svc-v1alpha1.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-clusterview-api-svc-v1alpha1.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deployOnOCP }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
@@ -12,4 +13,4 @@ spec:
   version: v1alpha1
   groupPriorityMinimum: 10
   versionPriority: 20
-    
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-clusterview-api-svc.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-clusterview-api-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deployOnOCP }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
@@ -12,4 +13,4 @@ spec:
   version: v1
   groupPriorityMinimum: 10
   versionPriority: 20
-    
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-controller.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-controller.yaml
@@ -104,9 +104,11 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+        {{- if .Values.global.deployOnOCP }}
         {{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+        {{- end }}
         {{- end }}
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver-api-svc.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver-api-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deployOnOCP }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
@@ -12,4 +13,4 @@ spec:
   version: v1beta1
   groupPriorityMinimum: 10000
   versionPriority: 20
-    
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver-svc.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver-svc.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
-
+{{- if .Values.global.deployOnOCP }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +18,4 @@ spec:
       protocol: TCP
   selector:
     control-plane: ocm-proxyserver
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deployOnOCP }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -131,3 +132,4 @@ spec:
         configMap:
           defaultMode: 420
           name: openshift-service-ca.crt
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-webhook.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-webhook.yaml
@@ -96,9 +96,11 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+        {{- if .Values.global.deployOnOCP }}
         {{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+        {{- end }}
         {{- end }}
       serviceAccountName: ocm-foundation-sa
       terminationGracePeriodSeconds: 10

--- a/pkg/templates/charts/toggle/server-foundation/values.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/values.yaml
@@ -5,6 +5,7 @@ global:
   pullSecret: ""
   namespace: default
   hubSize: Small
+  deployOnOCP: ""
 hubconfig:
   nodeSelector: {}
   proxyConfigs: {}


### PR DESCRIPTION
# Description

add deployOnOCP field to the charts to support deploy on aks.
on aks case only need cluster-manager, foundation, hypershift components.

## Related Issue

https://issues.redhat.com/browse/ACM-11040

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
