### PR TITLE
Remove the default addondeploymentconfig for the managedserviceaccount addon

### DIFF
--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -320,14 +320,6 @@ var _ = Describe("BackplaneConfig controller", func() {
 
 		msaTests = testList{
 			{
-				Name: "Managed-ServiceAccount Addon Deployment Config",
-				NamespacedName: types.NamespacedName{
-					Name:      "managed-serviceaccount-addon-deploy-config",
-					Namespace: DestinationNamespace},
-				ResourceType: addonDeploymentConfig,
-				Expected:     nil,
-			},
-			{
 				Name:           "Managed-ServiceAccount Addon Template",
 				NamespacedName: types.NamespacedName{Name: "managed-serviceaccount"},
 				ResourceType:   addonTemplate,

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -207,9 +207,6 @@ func (r *MultiClusterEngineReconciler) ensureNoManagedServiceAccount(ctx context
 	}
 
 	r.StatusManager.AddComponent(toggle.DisabledStatus(types.NamespacedName{Name: "managedservice", Namespace: backplaneConfig.Spec.TargetNamespace}, []*unstructured.Unstructured{}))
-	// TODO: remove this in a future release, since from 2.9, we change the managed-serviceaccount to a template type
-	// addon, so there is no managed-serviceaccount-addon-manager deployment on the hub cluster
-	r.StatusManager.RemoveComponent(toggle.EnabledStatus(types.NamespacedName{Name: "managed-serviceaccount-addon-manager", Namespace: backplaneConfig.Spec.TargetNamespace}))
 
 	// Deletes all templates
 	for _, template := range templates {

--- a/controllers/uninstall.go
+++ b/controllers/uninstall.go
@@ -49,21 +49,10 @@ var (
 				schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Kind: "ClusterRoleBinding", Version: "v1"},
 			),
 			// managed-serviceaccount
+			// TODO: Remove this in the next release
 			newUnstructured(
-				types.NamespacedName{Name: "managed-serviceaccount", Namespace: backplaneConfig.Spec.TargetNamespace},
-				schema.GroupVersionKind{Group: "", Kind: "ServiceAccount", Version: "v1"},
-			),
-			newUnstructured(
-				types.NamespacedName{Name: "managed-serviceaccount-addon-manager", Namespace: backplaneConfig.Spec.TargetNamespace},
-				schema.GroupVersionKind{Group: "apps", Kind: "Deployment", Version: "v1"},
-			),
-			newUnstructured(
-				types.NamespacedName{Name: "open-cluster-management:managed-serviceaccount:managed-serviceaccount"},
-				schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole", Version: "v1"},
-			),
-			newUnstructured(
-				types.NamespacedName{Name: "open-cluster-management:managed-serviceaccount:managed-serviceaccount"},
-				schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Kind: "ClusterRoleBinding", Version: "v1"},
+				types.NamespacedName{Name: "managed-serviceaccount-addon-deploy-config", Namespace: backplaneConfig.Spec.TargetNamespace},
+				schema.GroupVersionKind{Group: "addon.open-cluster-management.io", Kind: "AddOnDeploymentConfig", Version: "v1alpha1"},
 			),
 		}
 

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -174,9 +174,7 @@ func TestRender(t *testing.T) {
 			containsHTTPS = false
 			containsNO = false
 		}
-		if template.GetKind() == "AddOnDeploymentConfig" &&
-			// managed service account addon deployment config does not need a node placement config
-			template.GetName() != "managed-serviceaccount-addon-deploy-config" {
+		if template.GetKind() == "AddOnDeploymentConfig" {
 			addonDep := &addonv1alpha1.AddOnDeploymentConfig{}
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(template.Object, addonDep)
 			if err != nil {

--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/addondeploymentconfig.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/addondeploymentconfig.yaml
@@ -1,6 +1,0 @@
-apiVersion: addon.open-cluster-management.io/v1alpha1
-kind: AddOnDeploymentConfig
-metadata:
-  name: managed-serviceaccount-addon-deploy-config
-  namespace: '{{ .Values.global.namespace }}'
-spec: {}

--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/addontemplate.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/addontemplate.yaml
@@ -12,7 +12,7 @@ spec:
         metadata:
           annotations:
             addon.open-cluster-management.io/deletion-orphan: ''
-          name: '{{ `{{INSTALL_NAMESPACE}}` }}'
+          name: open-cluster-management-agent-addon
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRole
         metadata:

--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/clustermanagementaddon.yaml
@@ -16,10 +16,7 @@ spec:
         type: All
     type: Placements
   supportedConfigs:
-  - defaultConfig:
-      name: managed-serviceaccount-addon-deploy-config
-      namespace: '{{ .Values.global.namespace }}'
-    group: addon.open-cluster-management.io
+  - group: addon.open-cluster-management.io
     resource: addondeploymentconfigs
   - defaultConfig:
       name: managed-serviceaccount-2.6


### PR DESCRIPTION
# Description

Remove the default addondeploymentconfig for the managedserviceaccount addon to fix the upgrade issue introduced by the PR https://github.com/stolostron/backplane-operator/pull/705

## Related Issue

https://issues.redhat.com/browse/ACM-11655

## Changes Made

- address TODOs for the managed service account addon
- remove the default  addondeploymentcondig for the msa addon
- regerate charts for the msa

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

/cc @dislbenn @qiujian16 

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [x] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
