### PR TITLE
ACM-10683 Add XValidation to ClusterCurator CRD

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-engine
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -14,8 +14,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-25T18:14:26Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.34.1
+    createdAt: "2024-05-29T13:26:27Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-engine.v0.0.1
   namespace: placeholder
@@ -567,6 +567,17 @@ spec:
         - apiGroups:
           - addon.open-cluster-management.io
           resources:
+          - addondeploymentconfigs
+          - clustermanagementaddons
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - addon.open-cluster-management.io
+          resources:
           - addontemplates
           verbs:
           - create
@@ -658,6 +669,12 @@ spec:
           - managedclusteraddons/finalizers
           verbs:
           - update
+        - apiGroups:
+          - addon.open-cluster-management.io
+          resources:
+          - clustermanagementaddons/status
+          verbs:
+          - patch
         - apiGroups:
           - addon.open-cluster-management.io
           resources:
@@ -1729,6 +1746,12 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - create
         - apiGroups:
           - extensions.hive.openshift.io
           resources:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: multicluster-engine
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
+++ b/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
@@ -53,16 +53,6 @@ spec:
                 description: 'Specifies deployment replication for improved availability.
                   Options are: Basic and High (default)'
                 type: string
-              hubSize:
-                default: Small
-                description: The resource allocation bucket for this hub to use. Small,
-                  Medium, Large, XLarge]. Defaults to Small if not specified.
-                enum:
-                - Small
-                - Medium
-                - Large
-                - XLarge
-                type: string
               imagePullSecret:
                 description: Override pull secret for accessing MultiClusterEngine
                   operand and endpoint images

--- a/config/manifests/bases/multicluster-engine.clusterserviceversion.yaml
+++ b/config/manifests/bases/multicluster-engine.clusterserviceversion.yaml
@@ -27,12 +27,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:select:High
         - urn:alm:descriptor:com.tectonic.ui:select:Basic
-      - description: The resource allocation bucket for this hub to use. Small, Medium,
-          Large, XLarge]. Defaults to Small if not specified.
-        displayName: Hub Size
-        path: hubSize
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Override pull secret for accessing MultiClusterEngine operand
           and endpoint images
         displayName: Image Pull Secret

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -493,6 +493,17 @@ rules:
 - apiGroups:
   - addon.open-cluster-management.io
   resources:
+  - addondeploymentconfigs
+  - clustermanagementaddons
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
   - addontemplates
   verbs:
   - create

--- a/pkg/templates/crds/cluster-lifecycle/cluster.open-cluster-management.io_clustercurators.yaml
+++ b/pkg/templates/crds/cluster-lifecycle/cluster.open-cluster-management.io_clustercurators.yaml
@@ -358,11 +358,7 @@ spec:
                       the intermediate cluster version when performing EUS to EUS
                       upgrades. Setting both this value and DesiredUpdate will trigger
                       an EUS to EUS upgrade.
-                    maxLength: 512
                     type: string
-                    x-kubernetes-validations:
-                    - message: Value is immutable
-                      rule: self == oldSelf
                   monitorTimeout:
                     default: 120
                     description: MonitorTimeout defines the monitor process timeout,
@@ -453,6 +449,23 @@ spec:
                       for the cluster and region.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: The intermediateUpdate cannot be modified
+                  rule: '!(has(oldSelf.intermediateUpdate) && self.intermediateUpdate
+                    != oldSelf.intermediateUpdate)'
+                - message: The desiredUpdate cannot be modified when intermediateUpdate
+                    exists
+                  rule: '!(has(oldSelf.intermediateUpdate) && oldSelf.intermediateUpdate
+                    != '''' && has(oldSelf.desiredUpdate) && self.desiredUpdate !=
+                    oldSelf.desiredUpdate)'
+                - message: The intermediateUpdate cannot be created if desiredUpdate
+                    is missing or empty
+                  rule: '!has(self.intermediateUpdate) || (has(self.desiredUpdate)
+                    && self.desiredUpdate != '''')'
+                - message: The intermediateUpdate cannot be added via update if desiredUpdate
+                    already exists
+                  rule: '!(has(self.intermediateUpdate) && !has(oldSelf.intermediateUpdate)
+                    && has(oldSelf.desiredUpdate) && oldSelf.desiredUpdate != '''')'
             type: object
           status:
             description: ClusterCuratorStatus defines the observed state of ClusterCurator

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -81,6 +81,7 @@ package main
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs;addontemplates,verbs=get;list;watch
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs;clustermanagementaddons,verbs=create;get;list;update;watch
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons,verbs=get;list;watch
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/finalizers,verbs=update
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/status,verbs=patch
@@ -210,6 +211,7 @@ package main
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements/finalizers,verbs=update
 //+kubebuilder:rbac:groups=clusterview.open-cluster-management.io,resources=managedclusters;managedclustersets,verbs=list;get;watch
+//+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;get;list;patch;update
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch


### PR DESCRIPTION
# Description

Add XValidation to the upgrade option in the ClusterCurator CRD. This performs various validations against the `intermediateUpdate` and `desiredUpdate` fields.

I only changed the ClusterCurator CRD, but looks like previous commits to the repo didn't run `go generate` and `make bundle` so that's why there are many other files changed.

## Related Issue

https://issues.redhat.com/browse/ACM-10683 - ClusterCurator EUS to EUS upgrade

## Changes Made

- Make sure intermediateUpdate is immutable but if it was not present then it shouldn't be allowed to be added afterwards
- Make sure desiredUpdate is only immutable when intermediateVersion is present because we don't want to change the current behaviour which allows users change desiredUpdate after creating the CR
- Make sure intermediateUpdate cannot be by itself when desiredUpdate is missing

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

N/A

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [x] Documentation is updated.
- [x] All checks and tests pass.
- [x] Approved by at least one reviewer.
- [x] Merged into the main/master branch.
