### PR TITLE
Adjust assisted service image mappings [ACM-11781]

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -25,7 +25,8 @@
     - name: assisted-service
       bundlePath: "deploy/olm-catalog/manifests/"
       imageMappings:
-        assisted-service: assisted_service
+        assisted-service: assisted_service_9
+        assisted-service-el8: assisted_service_8
         postgresql-12-c8s: postgresql_12
         assisted-installer-agent: assisted_installer_agent
         assisted-installer-controller: assisted_installer_controller


### PR DESCRIPTION
# Description

In order to address some FIPS-related issue, the assisted service image is being built both on a RHEL8 and RHEL9 base in MCE 2.6.  These two images will be represented by new image keys `assisted_service_8` and `assisted_service_9` (and the previous unsuffixed key `assisted_service` will no longer be used).  


## Related Issue
- Our Jira ticket for the change: [ACM-11781](https://issues.redhat.com/browse/ACM-11781)
- Change to assisted service CSV to add a new env var:  [asisted-service PR 6349](https://github.com/openshift/assisted-service/pull/6349) (merged into their release-ocm-2.11 branch)

## Changes Made

This PR updates the image mappings in the bundle-to-chart transform config.