### PR TITLE
Using recreate strategy in cluster-proxy-addon-manager.

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     component: cluster-proxy-addon-manager
 spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       chart: cluster-proxy-addon-2.1.0


### PR DESCRIPTION
# Description

This PR change rollout strategy of cluster-proxy-addon-manager to be "Recreate".

## Related Issue

https://issues.redhat.com/browse/ACM-11947

## Changes Made

cluster-proxy-addon-manager doesn't using leader election to start controller, so in upgrade case from 2.10 to 2.11, the old pod and new pod will override the managedclusteraddon with different value. Which will create many CSRs and cause cluster-proxy-addon pending.

In 2.11, we have to turn the rollout strategy to "Recreate" to avoid new pods and old pods run together, we also working on adding leaderelection on cluster-proxy-addon-manager.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
