### PR TITLE
Revert "Using recreate strategy in cluster-proxy-addon-manager."

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     component: cluster-proxy-addon-manager
 spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       chart: cluster-proxy-addon-2.1.0


### PR DESCRIPTION
Reverts stolostron/backplane-operator#731

OCP doesn't allowed deployment to set rollingUpdate strategy to Recreate, revert the PR: https://issues.redhat.com/browse/ACM-11989