### PR TITLE
Revert cluster-proxy rollout strategy change.

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     component: cluster-proxy-addon-manager
 spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       chart: cluster-proxy-addon-2.1.0


### PR DESCRIPTION
# Description

"Recreate" is forbidden on OCP platform.
```
      message: 'error applying object Name: cluster-proxy-addon-manager Kind: Deployment
        Error: Deployment.apps "cluster-proxy-addon-manager" is invalid: spec.strategy.rollingUpdate:
        Forbidden: may not be specified when strategy `type` is ''Recreate'''
```

## Related Issue

https://issues.redhat.com/browse/ACM-11989

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
