### PR TITLE
Inject annotations for deployments in addonTemplates

### DIFF
--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/addontemplate.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/addontemplate.yaml
@@ -50,6 +50,8 @@ spec:
               addon-agent: managed-serviceaccount
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 addon-agent: managed-serviceaccount
             spec:


### PR DESCRIPTION
# Description

Add the annotation `target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'` to deployments in the managedserviceaccount addonTemplates. 

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

https://issues.redhat.com/browse/ACM-11315

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
