### PR TITLE
[ACM-12132] Fixed standalone mce failing to install on custom namespace

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -260,18 +260,6 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	/*
-		In MCE 2.4, we need to ensure that the openshift.io/cluster-monitoring is added to the same namespace as the
-		MultiClusterEngine to avoid conflicts with the openshift-* namespace when deploying PrometheusRules and
-		ServiceMonitors in ACM and MCE.
-	*/
-	_, err = r.ensureOpenShiftNamespaceLabel(ctx, backplaneConfig)
-	if err != nil {
-		r.Log.Error(err, "Failed to add to %s label to namespace: %s", utils.OpenShiftClusterMonitoringLabel,
-			backplaneConfig.Spec.TargetNamespace)
-		return ctrl.Result{}, err
-	}
-
 	if !utils.ShouldIgnoreOCPVersion(backplaneConfig) {
 		currentOCPVersion, err := r.getClusterVersion(ctx)
 		if err != nil {
@@ -291,6 +279,18 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
+	}
+
+	/*
+		In MCE 2.4, we need to ensure that the openshift.io/cluster-monitoring is added to the same namespace as the
+		MultiClusterEngine to avoid conflicts with the openshift-* namespace when deploying PrometheusRules and
+		ServiceMonitors in ACM and MCE.
+	*/
+	_, err = r.ensureOpenShiftNamespaceLabel(ctx, backplaneConfig)
+	if err != nil {
+		r.Log.Error(err, fmt.Sprintf("Failed to add to %s label to namespace: %s", utils.OpenShiftClusterMonitoringLabel,
+			backplaneConfig.Spec.TargetNamespace))
+		return ctrl.Result{}, err
 	}
 
 	result, err = r.validateImagePullSecret(ctx, backplaneConfig)


### PR DESCRIPTION
# Description

In MCE 2.4, a regression introduced into our code: https://github.com/stolostron/backplane-operator/blob/backplane-2.4/controllers/backplaneconfig_controller.go#L232-L242.

We are attempting to apply the `openshift.io/cluster-monitoring` label to the `targetNamespace` before it is created by the MCE operator. Beforehand, if the `targetNamespace` did not exist, MCE would create it; however, since we are trying to apply the label before that validation happens, the regression was introduced. This PR will fix that issue by moving the label apply later on in the reconcile loop.

## Related Issue

https://issues.redhat.com/browse/ACM-12132

## Changes Made

Updated order for applying label for MCE operand's namespace.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
