### PR TITLE
[ACM-12431] Added MultiClusterEngine current and desired version columns to MCE CRD

### DIFF
--- a/api/v1/multiclusterengine_types.go
+++ b/api/v1/multiclusterengine_types.go
@@ -230,6 +230,8 @@ type MultiClusterEngineCondition struct {
 // determined based on the configuration that is defined in this resource.
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="The overall state of the MultiClusterEngine"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="CurrentVersion",type="string",JSONPath=".status.currentVersion",description="The current version of the MultiClusterEngine"
+// +kubebuilder:printcolumn:name="DesiredVersion",type="string",JSONPath=".status.desiredVersion",description="The desired version of the MultiClusterEngine"
 // +operator-sdk:csv:customresourcedefinitions:displayName="MultiCluster Engine"
 type MultiClusterEngine struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/bundle/manifests/multicluster.openshift.io_multiclusterengines.yaml
+++ b/bundle/manifests/multicluster.openshift.io_multiclusterengines.yaml
@@ -24,6 +24,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - description: The current version of the multiclusterhub
+      jsonPath: .status.currentVersion
+      name: CurrentVersion
+      type: string
+    - description: The desired version of the multiclusterhub
+      jsonPath: .status.desiredVersion
+      name: DesiredVersion
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
+++ b/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
@@ -24,6 +24,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - description: The current version of the MultiClusterEngine
+      jsonPath: .status.currentVersion
+      name: CurrentVersion
+      type: string
+    - description: The desired version of the MultiClusterEngine
+      jsonPath: .status.desiredVersion
+      name: DesiredVersion
+      type: string
     name: v1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
# Description

Added `currentVersion` and `desiredVersion` to the `additionalPrinterColumns` in MCE CRD.

## Related Issue

https://issues.redhat.com/browse/ACM-12431

## Changes Made

Added support to print out the `currentVersion` and `desiredVersion` of the MCE operator.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
