### PR TITLE
ACM-14534: remove -preview from the hypershift chart name

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/Chart.yaml
+++ b/pkg/templates/charts/toggle/hypershift/Chart.yaml
@@ -4,6 +4,6 @@
 apiVersion: v2
 appVersion: 2.7.0
 description: HyperShift is a middleware for hosting OpenShift control planes at scale that solves for cost and time to provision, as well as portability cross cloud with strong separation of concerns between management and workloads. Clusters are fully compliant OpenShift Container Platform (OCP) clusters and are compatible with standard OCP and Kubernetes toolchains.
-name: hypershift-preview
+name: hypershift
 type: application
 version: 2.7.0


### PR DESCRIPTION
# Description

Since the hypershift feature is not preview, I am removing -preview from the chart name.

## Related Issue

https://issues.redhat.com/browse/ACM-14534

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
