### PR TITLE
[ACM-11155] Added finalizer condition to check if local-cluster namespace was deleted

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -435,7 +435,7 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	result, err = r.ensureToggleableComponents(ctx, backplaneConfig)
-	if (result != ctrl.Result{}) || err != nil {
+	if err != nil {
 		return result, err
 	}
 
@@ -994,6 +994,7 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 	if err != nil {
 		errs[backplanev1.HypershiftLocalHosting] = err
 	}
+
 	if utils.DeployOnOCP() {
 		ocpConsole, err := r.CheckConsole(ctx)
 		if err != nil {

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1644,7 +1644,7 @@ func (r *MultiClusterEngineReconciler) finalizeBackplaneConfig(ctx context.Conte
 	}
 
 	localClusterNS := &corev1.Namespace{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: "local-cluster"}, localClusterNS); err != nil {
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: "local-cluster"}, localClusterNS); err == nil {
 		// If wait time exceeds expected then uninstall may not be able to progress
 		if time.Since(backplaneConfig.DeletionTimestamp.Time) < 10*time.Minute {
 			terminatingCondition := status.NewCondition(

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -2024,9 +2024,9 @@ func Test_ensureNoInternalEngineComponent(t *testing.T) {
 
 func Test_ensureNoAllInternalEngineComponents(t *testing.T) {
 	tests := []struct {
-		name        string
-		mce         *backplanev1.MultiClusterEngine
-		errorNotNil bool
+		name string
+		mce  *backplanev1.MultiClusterEngine
+		want bool
 	}{
 		{
 			name: "should ensure no InternalEngineComponent",
@@ -2038,14 +2038,14 @@ func Test_ensureNoAllInternalEngineComponents(t *testing.T) {
 					TargetNamespace: "test-ns",
 				},
 			},
-			errorNotNil: true,
+			want: false,
 		},
 	}
 
+	registerScheme()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			if _, err := recon.ensureNoAllInternalEngineComponents(context.Background(), tt.mce); (err != nil && !errors.IsNotFound(err)) != tt.errorNotNil {
+			if _, err := recon.ensureNoAllInternalEngineComponents(context.Background(), tt.mce); err != nil {
 				t.Errorf("failed to ensure no InternalEngineComponents: %v", err)
 			}
 		})

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -102,7 +102,8 @@ func (r *MultiClusterEngineReconciler) ensureNoConsoleMCE(ctx context.Context, m
 	r.StatusManager.RemoveComponent(toggle.EnabledStatus(namespacedName))
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.ConsoleMCE); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.ConsoleMCE); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -223,7 +224,8 @@ func (r *MultiClusterEngineReconciler) ensureNoManagedServiceAccount(ctx context
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.ManagedServiceAccount); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.ManagedServiceAccount); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -387,7 +389,8 @@ func (r *MultiClusterEngineReconciler) ensureNoDiscovery(ctx context.Context,
 	namespacedName := types.NamespacedName{Name: "discovery-operator", Namespace: mce.Spec.TargetNamespace}
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.Discovery); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.Discovery); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -472,7 +475,8 @@ func (r *MultiClusterEngineReconciler) ensureNoHive(ctx context.Context, mce *ba
 	namespacedName := types.NamespacedName{Name: "hive-operator", Namespace: mce.Spec.TargetNamespace}
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.Hive); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.Hive); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -569,7 +573,8 @@ func (r *MultiClusterEngineReconciler) ensureNoAssistedService(ctx context.Conte
 	namespacedName := types.NamespacedName{Name: "infrastructure-operator", Namespace: targetNamespace}
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.AssistedService); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.AssistedService); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -652,7 +657,8 @@ func (r *MultiClusterEngineReconciler) ensureNoServerFoundation(ctx context.Cont
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 
 	// Ensure that the InternalHubComponent CR instance is created for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.ServerFoundation); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.ServerFoundation); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -740,7 +746,8 @@ func (r *MultiClusterEngineReconciler) ensureNoImageBasedInstallOperator(ctx con
 	namespacedName := types.NamespacedName{Name: "image-based-install-operator", Namespace: targetNamespace}
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.ImageBasedInstallOperator); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.ImageBasedInstallOperator); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -826,7 +833,8 @@ func (r *MultiClusterEngineReconciler) ensureNoClusterLifecycle(ctx context.Cont
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.ClusterLifecycle); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.ClusterLifecycle); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -924,7 +932,8 @@ func (r *MultiClusterEngineReconciler) ensureNoClusterManager(ctx context.Contex
 	namespacedName := types.NamespacedName{Name: "cluster-manager", Namespace: mce.Spec.TargetNamespace}
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.ClusterManager); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.ClusterManager); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -1042,7 +1051,8 @@ func (r *MultiClusterEngineReconciler) ensureNoHyperShift(ctx context.Context,
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.HyperShift); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.HyperShift); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
@@ -1301,7 +1311,8 @@ func (r *MultiClusterEngineReconciler) ensureNoClusterProxyAddon(ctx context.Con
 	r.StatusManager.AddComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
-	if result, err := r.ensureNoInternalEngineComponent(ctx, mce, backplanev1.ClusterProxyAddon); err != nil {
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.ClusterProxyAddon); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 


### PR DESCRIPTION
# Description

Updated the `backplane-operator` finalization to include checking for the `local-cluster` namespace. If the `local-cluster` namespace is not deleted, then MCE will stall when it comes to uninstalling the operator and operands.

## Related Issue

https://issues.redhat.com/browse/ACM-11155

## Changes Made

Updated operator to check for `local-cluster` namespace during uninstall.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
