### PR TITLE
[ACM-15089] Removed cluster-api-provider-azure image key ref

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-configmap.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-configmap.yaml
@@ -46,13 +46,6 @@ data:
         from:
           kind: DockerImage
           name: {{ .Values.global.imageOverrides.cluster_api_provider_aws }}
-      - name: cluster-api-provider-azure
-        annotations:
-          io.openshift.build.commit.id: e17ba23dd8ff1b2698d80499a416917c2084a0c1
-          io.openshift.build.source-location: https://github.com/openshift/cluster-api-provider-azure
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.cluster_api_provider_azure }}
       - name: cluster-api-provider-kubevirt
         annotations:
           io.openshift.build.commit.id: 'dbdc825088513dc962ba2103efe2c1a4eb3cf524'

--- a/pkg/templates/charts/toggle/hypershift/values.yaml
+++ b/pkg/templates/charts/toggle/hypershift/values.yaml
@@ -6,7 +6,6 @@ global:
     cluster_api: ""
     cluster_api_provider_agent: ""
     cluster_api_provider_aws: ""
-    cluster_api_provider_azure: ""
     hypershift_operator: ""
     cluster_api_provider_kubevirt: ""
     kube_rbac_proxy_mce: "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -173,7 +173,7 @@ func GetTestImages() []string {
 		"assisted_service", "assisted_image_service", "postgresql_12", "assisted_installer_agent", "assisted_installer_controller",
 		"assisted_installer", "console_mce", "hypershift_addon_operator", "hypershift_operator",
 		"apiserver_network_proxy", "aws_encryption_provider", "cluster_api", "cluster_api_provider_agent", "cluster_api_provider_aws",
-		"cluster_api_provider_azure", "cluster_api_provider_kubevirt", "kube_rbac_proxy_mce", "cluster_proxy_addon", "cluster_proxy", "cluster_image_set_controller"}
+		"cluster_api_provider_kubevirt", "kube_rbac_proxy_mce", "cluster_proxy_addon", "cluster_proxy", "cluster_image_set_controller"}
 }
 
 func IsUnitTest() bool {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -156,3 +156,24 @@ func TestGetHubType(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetTestImages(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "should get test images",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := GetTestImages()
+
+			// Check that the returned slice is not empty
+			if got := len(i); got <= 0 {
+				t.Errorf("GetTestImages() returned an empty slice; got %d, want > 0", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

In MCE 2.4, the `cluster_api_provider_azure` key was unused and removed; therefore, this PR will remove the remaining image key references for the `hypershift-addon` component.

## Related Issue

https://issues.redhat.com/browse/ACM-15089

## Changes Made

Removed `cluster_api_provider_azure` image ref key.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
