### PR TITLE
Remove lingering hypershift-preview resources on upgrade

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1769,7 +1769,10 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 			}
 		} else {
 			if !apierrors.IsNotFound(err) {
+				log.Error(err, "trouble getting the resource")
 				return ctrl.Result{}, err
+			} else {
+				log.Info("couldn't find the resource")
 			}
 		}
 		hyperShiftPreviewClusterRole := &rbacv1.ClusterRole{}

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1758,7 +1758,7 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 	// hypershift preview component upgraded in ACM 2.8.0
 	if m.Prune(backplanev1.HyperShiftPreview) {
 		hyperShiftPreviewClusterRoleBinding := &unstructured.Unstructured{}
-		err := r.Client.Get(ctx, types.NamespacedName{Name: "", Namespace: m.Namespace}, hyperShiftPreviewClusterRoleBinding)
+		err := r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
 		if err == nil {
 			err = r.Client.Delete(ctx, hyperShiftPreviewClusterRoleBinding)
 			if err != nil {
@@ -1769,6 +1769,19 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 				return ctrl.Result{}, err
 			}
 		}
+		hyperShiftPreviewClusterRole := &unstructured.Unstructured{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
+		if err == nil {
+			err = r.Client.Delete(ctx, hyperShiftPreviewClusterRole)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		} else {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+		}
+
 		updateNecessary = true
 	}
 

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1749,50 +1749,41 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		updateNecessary = true
 	}
 
-	if m.Enabled(backplanev1.HyperShiftPreview) {
-		// if the preview was pruned, enable the non-preview version instea
-		m.Enable(backplanev1.HyperShift)
-		// no need to disable -preview version, as it will get pruned below
-		updateNecessary = true
-	}
-	log.Info("entering the check")
 	// hypershift preview component upgraded in ACM 2.8.0
 	if m.Prune(backplanev1.HyperShiftPreview) {
-		log.Info("we pruning")
-		hyperShiftPreviewClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-		err := r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
-		if err == nil {
-			log.Info("got the resource")
-			err = r.Client.Delete(ctx, hyperShiftPreviewClusterRoleBinding)
-			if err != nil {
-				log.Error(err, "failed to delete the resource")
-				return ctrl.Result{}, err
-			}
-		} else {
-			if !apierrors.IsNotFound(err) {
-				log.Error(err, "trouble getting the resource")
-				return ctrl.Result{}, err
-			} else {
-				log.Info("couldn't find the resource")
-			}
-		}
-		hyperShiftPreviewClusterRole := &rbacv1.ClusterRole{}
-		err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRole)
-		if err == nil {
-			err = r.Client.Delete(ctx, hyperShiftPreviewClusterRole)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-		} else {
-			if !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, err
-			}
-		}
 
 		updateNecessary = true
 	}
-	log.Info("exiting the check")
-
+	log.Info("we pruning")
+	hyperShiftPreviewClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
+	if err == nil {
+		log.Info("got the resource")
+		err = r.Client.Delete(ctx, hyperShiftPreviewClusterRoleBinding)
+		if err != nil {
+			log.Error(err, "failed to delete the resource")
+			return ctrl.Result{}, err
+		}
+	} else {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "trouble getting the resource")
+			return ctrl.Result{}, err
+		} else {
+			log.Info("couldn't find the resource")
+		}
+	}
+	hyperShiftPreviewClusterRole := &rbacv1.ClusterRole{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRole)
+	if err == nil {
+		err = r.Client.Delete(ctx, hyperShiftPreviewClusterRole)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+	}
 	if m.Enabled(backplanev1.ManagedServiceAccountPreview) {
 		// if the preview was pruned, enable the non-preview version instead
 		m.Enable(backplanev1.ManagedServiceAccount)

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1750,7 +1750,7 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 	}
 
 	if m.Enabled(backplanev1.HyperShiftPreview) {
-		// if the preview was pruned, enable the non-preview version instead
+		// if the preview was pruned, enable the non-preview version instea
 		m.Enable(backplanev1.HyperShift)
 		// no need to disable -preview version, as it will get pruned below
 		updateNecessary = true
@@ -1761,8 +1761,10 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		hyperShiftPreviewClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 		err := r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
 		if err == nil {
+			log.Info("got the resource")
 			err = r.Client.Delete(ctx, hyperShiftPreviewClusterRoleBinding)
 			if err != nil {
+				log.Error(err, "failed to delete the resource")
 				return ctrl.Result{}, err
 			}
 		} else {

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1777,7 +1777,7 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 			}
 		}
 		hyperShiftPreviewClusterRole := &rbacv1.ClusterRole{}
-		err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
+		err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRole)
 		if err == nil {
 			err = r.Client.Delete(ctx, hyperShiftPreviewClusterRole)
 			if err != nil {

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1755,9 +1755,10 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		// no need to disable -preview version, as it will get pruned below
 		updateNecessary = true
 	}
-
+	log.Info("entering the check")
 	// hypershift preview component upgraded in ACM 2.8.0
 	if m.Prune(backplanev1.HyperShiftPreview) {
+		log.Info("we pruning")
 		hyperShiftPreviewClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 		err := r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
 		if err == nil {
@@ -1790,6 +1791,7 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 
 		updateNecessary = true
 	}
+	log.Info("exiting the check")
 
 	if m.Enabled(backplanev1.ManagedServiceAccountPreview) {
 		// if the preview was pruned, enable the non-preview version instead

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -2006,12 +2006,10 @@ func (r *MultiClusterEngineReconciler) removeDeprecatedRBAC(ctx context.Context)
 	if err == nil {
 		err = r.Client.Delete(ctx, hyperShiftPreviewClusterRoleBinding)
 		if err != nil {
-			log.Error(err, "failed to delete the resource")
 			return ctrl.Result{}, err
 		}
 	} else {
 		if !apierrors.IsNotFound(err) {
-			log.Error(err, "trouble getting the resource")
 			return ctrl.Result{}, err
 		}
 	}
@@ -2020,12 +2018,10 @@ func (r *MultiClusterEngineReconciler) removeDeprecatedRBAC(ctx context.Context)
 	if err == nil {
 		err = r.Client.Delete(ctx, hyperShiftPreviewClusterRole)
 		if err != nil {
-			log.Error(err, "failed to delete the resource")
 			return ctrl.Result{}, err
 		}
 	} else {
 		if !apierrors.IsNotFound(err) {
-			log.Error(err, "trouble getting the resource")
 			return ctrl.Result{}, err
 		}
 	}

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -43,6 +43,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1748,16 +1749,16 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		updateNecessary = true
 	}
 
-	if m.Enabled(backplanev1.HyperShift) {
+	if m.Enabled(backplanev1.HyperShiftPreview) {
 		// if the preview was pruned, enable the non-preview version instead
-		m.Enable(backplanev1.HyperShiftPreview)
+		m.Enable(backplanev1.HyperShift)
 		// no need to disable -preview version, as it will get pruned below
 		updateNecessary = true
 	}
 
 	// hypershift preview component upgraded in ACM 2.8.0
 	if m.Prune(backplanev1.HyperShiftPreview) {
-		hyperShiftPreviewClusterRoleBinding := &unstructured.Unstructured{}
+		hyperShiftPreviewClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 		err := r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
 		if err == nil {
 			err = r.Client.Delete(ctx, hyperShiftPreviewClusterRoleBinding)
@@ -1769,7 +1770,7 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 				return ctrl.Result{}, err
 			}
 		}
-		hyperShiftPreviewClusterRole := &unstructured.Unstructured{}
+		hyperShiftPreviewClusterRole := &rbacv1.ClusterRole{}
 		err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
 		if err == nil {
 			err = r.Client.Delete(ctx, hyperShiftPreviewClusterRole)


### PR DESCRIPTION
# Description

on upgrading MCE from 2.6 to 2.7 the chart name changes for the hyper shift component by removing the preview flag. Several rbac resources use the chart name in their resource name and so are duplicated or left lingering when disabling the component

## Related Issue

https://issues.redhat.com/browse/ACM-15425

## Changes Made

When pruning the hyper-shift-preview component the controller now explicitly looks for the lingering resources and deletes them if they exist

