### PR TITLE
Fixed ClusterManager bug

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1096,7 +1096,7 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 		}
 	}
 
-	if backplaneConfig.Enabled(backplanev1.ClusterManager) && foundation.CanInstallAddons(ctx, r.Client) {
+	if backplaneConfig.Enabled(backplanev1.ClusterManager) {
 		result, err = r.ensureClusterManager(ctx, backplaneConfig)
 		if result != (ctrl.Result{}) {
 			requeue = true


### PR DESCRIPTION
ClusterManager brings the addons up, and the `CanInstallAddons` actually checks ClusterManager itself. This removed a feedback loop that prevented all addons from deploying