### PR TITLE
[ACM-13577] Onboarded cluster-api (CAPI) component to MCE 2.8

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -24,6 +24,8 @@ import (
 
 const (
 	AssistedService                  = "assisted-service"
+	ClusterAPI                       = "cluster-api"
+	ClusterAPIPreview                = "cluster-api-preview"
 	ClusterLifecycle                 = "cluster-lifecycle"
 	ClusterManager                   = "cluster-manager"
 	ClusterProxyAddon                = "cluster-proxy-addon"
@@ -43,6 +45,8 @@ const (
 
 var allComponents = []string{
 	AssistedService,
+	ClusterAPI,
+	ClusterAPIPreview,
 	ClusterLifecycle,
 	ClusterManager,
 	ClusterProxyAddon,
@@ -63,6 +67,7 @@ var allComponents = []string{
 // MCEComponents is a slice containing component names specific to the "MCE" category.
 var MCEComponents = []string{
 	AssistedService,
+	ClusterAPIPreview,
 	ClusterLifecycle,
 	ClusterManager,
 	ClusterProxyAddon,

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1743,7 +1743,7 @@ func (r *MultiClusterEngineReconciler) ensureUnstructuredResource(ctx context.Co
 			return ctrl.Result{}, err
 		}
 		// Creation was successful
-		r.Log.Info("Creating resource", "Name", "Kind", u.GetName(), u.GetKind())
+		r.Log.Info("Creating resource", "Name", u.GetName(), "Kind", u.GetKind())
 		return ctrl.Result{}, nil
 
 	} else if err != nil {

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -779,6 +779,7 @@ func (r *MultiClusterEngineReconciler) createMetricsServiceMonitor(ctx context.C
 func (r *MultiClusterEngineReconciler) DeployAlwaysSubcomponents(ctx context.Context,
 	backplaneConfig *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 	chartsDir := renderer.AlwaysChartsDir
+
 	// Renders all templates from charts
 	templates, errs := renderer.RenderCharts(chartsDir, backplaneConfig, r.CacheSpec.ImageOverrides,
 		r.CacheSpec.TemplateOverrides)
@@ -896,6 +897,7 @@ func (r *MultiClusterEngineReconciler) fetchChartOrCRDPath(component string, use
 
 	chartDirs := map[string]string{
 		backplanev1.AssistedService:           toggle.AssistedServiceChartDir,
+		backplanev1.ClusterAPIPreview:         toggle.ClusterAPIChartDir,
 		backplanev1.ClusterLifecycle:          toggle.ClusterLifecycleChartDir,
 		backplanev1.ClusterManager:            toggle.ClusterManagerChartDir,
 		backplanev1.ClusterProxyAddon:         toggle.ClusterProxyAddonDir,
@@ -1149,6 +1151,25 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 			errs[backplanev1.ClusterProxyAddon] = err
 		}
 	}
+
+	if backplaneConfig.Enabled(backplanev1.ClusterAPIPreview) {
+		result, err = r.ensureClusterAPI(ctx, backplaneConfig)
+		if result != (ctrl.Result{}) {
+			requeue = true
+		}
+		if err != nil {
+			errs[backplanev1.ClusterAPIPreview] = err
+		}
+	} else {
+		result, err = r.ensureNoClusterAPI(ctx, backplaneConfig)
+		if result != (ctrl.Result{}) {
+			requeue = true
+		}
+		if err != nil {
+			errs[backplanev1.ClusterAPIPreview] = err
+		}
+	}
+
 	if backplaneConfig.Enabled(backplanev1.LocalCluster) {
 		result, err := r.ensureLocalCluster(ctx, backplaneConfig)
 		if result != (ctrl.Result{}) {
@@ -1434,18 +1455,19 @@ func (r *MultiClusterEngineReconciler) ensureNoAllInternalEngineComponents(ctx c
 	requeue := false
 
 	components := []string{
+		backplanev1.AssistedService,
+		backplanev1.ClusterAPIPreview,
+		backplanev1.ClusterLifecycle,
+		backplanev1.ClusterManager,
+		backplanev1.ClusterProxyAddon,
 		backplanev1.ConsoleMCE,
-		backplanev1.ManagedServiceAccount,
 		backplanev1.Discovery,
 		backplanev1.Hive,
-		backplanev1.AssistedService,
-		backplanev1.ServerFoundation,
-		backplanev1.ImageBasedInstallOperator,
-		backplanev1.ClusterLifecycle,
 		backplanev1.HyperShift,
-		backplanev1.ClusterProxyAddon,
+		backplanev1.ImageBasedInstallOperator,
 		backplanev1.LocalCluster,
-		backplanev1.ClusterManager,
+		backplanev1.ManagedServiceAccount,
+		backplanev1.ServerFoundation,
 	}
 
 	for _, v := range components {
@@ -1721,9 +1743,7 @@ func (r *MultiClusterEngineReconciler) ensureUnstructuredResource(ctx context.Co
 			return ctrl.Result{}, err
 		}
 		// Creation was successful
-		r.Log.Info(fmt.Sprintf("Created new resource - kind: %s name: %s", u.GetKind(), u.GetName()))
-		// condition := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, NewComponentReason, "Created new resource")
-		// SetHubCondition(&m.Status, *condition)
+		r.Log.Info("Creating resource", "Name", "Kind", u.GetName(), u.GetKind())
 		return ctrl.Result{}, nil
 
 	} else if err != nil {

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -406,6 +406,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: true,
 								},
 								{
+									Name:    backplanev1.ClusterAPIPreview,
+									Enabled: true,
+								},
+								{
 									Name:    backplanev1.ClusterLifecycle,
 									Enabled: true,
 								},
@@ -518,7 +522,7 @@ var _ = Describe("BackplaneConfig controller", func() {
 						Eventually(func() bool {
 							foundCR := &backplanev1.InternalEngineComponent{}
 							err := k8sClient.Get(context.Background(), types.NamespacedName{Name: mcecomponent, Namespace: backplaneConfig.Spec.DeepCopy().TargetNamespace}, foundCR)
-							log.Info(fmt.Sprintf("component retrieved: %v", componentCR))
+							log.Info(fmt.Sprintf("component retrieved: %v", foundCR))
 							return errors.IsNotFound(err)
 						}, timeout, interval).Should(BeTrue())
 
@@ -574,6 +578,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 							Components: []backplanev1.ComponentConfig{
 								{
 									Name:    backplanev1.AssistedService,
+									Enabled: false,
+								},
+								{
+									Name:    backplanev1.ClusterAPIPreview,
 									Enabled: false,
 								},
 								{
@@ -850,6 +858,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: true,
 								},
 								{
+									Name:    backplanev1.ClusterAPIPreview,
+									Enabled: true,
+								},
+								{
 									Name:    backplanev1.ClusterLifecycle,
 									Enabled: true,
 								},
@@ -951,6 +963,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 							Components: []backplanev1.ComponentConfig{
 								{
 									Name:    backplanev1.AssistedService,
+									Enabled: false,
+								},
+								{
+									Name:    backplanev1.ClusterAPIPreview,
 									Enabled: false,
 								},
 								{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -80,12 +80,13 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),
-			filepath.Join("..", "pkg", "templates", "crds", "cluster-manager"),
-			filepath.Join("..", "pkg", "templates", "crds", "hive-operator"),
-			filepath.Join("..", "pkg", "templates", "crds", "foundation"),
+			filepath.Join("..", "pkg", "templates", "crds", "cluster-api"),
 			filepath.Join("..", "pkg", "templates", "crds", "cluster-lifecycle"),
-			filepath.Join("..", "pkg", "templates", "crds", "discovery-operator"),
+			filepath.Join("..", "pkg", "templates", "crds", "cluster-manager"),
 			filepath.Join("..", "pkg", "templates", "crds", "cluster-proxy-addon"),
+			filepath.Join("..", "pkg", "templates", "crds", "discovery-operator"),
+			filepath.Join("..", "pkg", "templates", "crds", "foundation"),
+			filepath.Join("..", "pkg", "templates", "crds", "hive-operator"),
 			filepath.Join("..", "pkg", "templates", "crds", "internal"),
 			filepath.Join("..", "hack", "unit-test-crds"),
 		},

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -385,7 +385,6 @@ func (r *MultiClusterEngineReconciler) ensureDiscovery(ctx context.Context, mce 
 
 func (r *MultiClusterEngineReconciler) ensureNoDiscovery(ctx context.Context,
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
-
 	namespacedName := types.NamespacedName{Name: "discovery-operator", Namespace: mce.Spec.TargetNamespace}
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
@@ -396,6 +395,81 @@ func (r *MultiClusterEngineReconciler) ensureNoDiscovery(ctx context.Context,
 
 	// Renders all templates from charts
 	chartPath := r.fetchChartOrCRDPath(backplanev1.Discovery, false)
+	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
+
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Info(err.Error())
+		}
+		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
+	}
+
+	r.StatusManager.RemoveComponent(toggle.EnabledStatus(namespacedName))
+	r.StatusManager.AddComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
+
+	// Deletes all templates
+	for _, template := range templates {
+		result, err := r.deleteTemplate(ctx, mce, template)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Failed to delete template: %s", template.GetName()))
+			return result, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterEngineReconciler) ensureClusterAPI(ctx context.Context, mce *backplanev1.MultiClusterEngine) (
+	ctrl.Result, error) {
+
+	namespacedName := types.NamespacedName{Name: "capi-controller-manager", Namespace: mce.Spec.TargetNamespace}
+	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
+	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
+
+	// Ensure that the InternalHubComponent CR instance is created for component in MCE.
+	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.ClusterAPIPreview); err != nil {
+		return result, err
+	}
+
+	// Renders all templates from charts
+	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPIPreview, false)
+	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
+
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Info(err.Error())
+		}
+		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
+	}
+
+	// Apply deployment config overrides
+	if result, err := r.applyComponentDeploymentOverrides(mce, templates, backplanev1.ClusterAPIPreview); err != nil {
+		return result, err
+	}
+
+	// Applies all templates
+	for _, template := range templates {
+		applyReleaseVersionAnnotation(template)
+		result, err := r.applyTemplate(ctx, mce, template)
+		if err != nil {
+			return result, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterEngineReconciler) ensureNoClusterAPI(ctx context.Context,
+	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
+	namespacedName := types.NamespacedName{Name: "capi-controller-manager", Namespace: mce.Spec.TargetNamespace}
+
+	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.ClusterAPIPreview); (result != ctrl.Result{}) || err != nil {
+		return result, err
+	}
+
+	// Renders all templates from charts
+	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPIPreview, false)
 	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
 
 	if len(errs) > 0 {

--- a/docs/available-components.md
+++ b/docs/available-components.md
@@ -1,17 +1,19 @@
 
 # Table list of the deployed components
 
-| Name                      | Description                                                                                                          | Enabled |
-|---------------------------|----------------------------------------------------------------------------------------------------------------------|---------|
-| assisted-service          | Installs OpenShift with minimal infrastructure prerequisites and comprehensive pre-flight validations.               | True    |
-| cluster-lifecycle         | Provides cluster management capabilities for {ocp-short} and {product-title-short} hub clusters.                     | True    |
-| cluster-manager           | Manages various cluster-related operations within the cluster environment.                                           | True    |
-| cluster-proxy-addon       | Automates the installation of apiserver-network-proxy on both hub and managed clusters using a reverse proxy server. | True    |
-| console-mce               | Enables the {mce-short} console plug-in.                                                                             | True    |
-| discovery                 | Discovers and identifies new clusters within the {ocm}.                                                              | True    |
-| hive                      | Provisions and performs initial configuration of {ocp-short} clusters.                                               | True    |
-| hypershift                | Hosts OpenShift control planes at scale with cost and time efficiency, and cross-cloud portability.                  | True    |
-| hypershift-local-hosting  | Enables local hosting capabilities for within the local cluster environment.                                         | True    |
-| local-cluster             | Enables the import and self-management of the local hub cluster where the {mce-short} is deployed.                   | True    |
-| managedserviceaccount     | Syncronizes service accounts to the managed clusters and collects tokens as secret resources back to the hub cluster.| True    |
-| server-foundation         | Provides foundational services for server-side operations within the cluster environment.                            | True    |
+| Name                         | Description                                                                                                          | Enabled |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------|---------|
+| assisted-service             | Installs OpenShift with minimal infrastructure prerequisites and comprehensive pre-flight validations.               | True    |
+| cluster-api-preview          | Provides capabilities for declaratively handling the Cluster API lifecycle from within a managment cluster           | False   |
+| cluster-lifecycle            | Provides cluster management capabilities for {ocp-short} and {product-title-short} hub clusters.                     | True    |
+| cluster-manager              | Manages various cluster-related operations within the cluster environment.                                           | True    |
+| cluster-proxy-addon          | Automates the installation of apiserver-network-proxy on both hub and managed clusters using a reverse proxy server. | True    |
+| console-mce                  | Enables the {mce-short} console plug-in.                                                                             | True    |
+| discovery                    | Discovers and identifies new clusters within the {ocm}.                                                              | True    |
+| hive                         | Provisions and performs initial configuration of {ocp-short} clusters.                                               | True    |
+| hypershift                   | Hosts OpenShift control planes at scale with cost and time efficiency, and cross-cloud portability.                  | True    |
+| hypershift-local-hosting     | Enables local hosting capabilities for within the local cluster environment.                                         | True    |
+| image-based-install-operator | Provide site configuration to Single Node OpenShift clusters to complete installation.                               | False   |
+| local-cluster                | Enables the import and self-management of the local hub cluster where the {mce-short} is deployed.                   | True    |
+| managedserviceaccount        | Syncronizes service accounts to the managed clusters and collects tokens as secret resources back to the hub cluster.| True    |
+| server-foundation            | Provides foundational services for server-side operations within the cluster environment.                            | True    |

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-controller-manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-controller-manager-deployment.yaml
@@ -101,9 +101,7 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: true
-          runAsGroup: 65532
           runAsNonRoot: true
-          runAsUser: 65532
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs

--- a/pkg/templates/rbac.go
+++ b/pkg/templates/rbac.go
@@ -44,10 +44,12 @@ const (
 //+kubebuilder:rbac:groups=proxy.open-cluster-management.io,resources=managedproxyconfigurations;managedproxyserviceresolvers,verbs=get;create;update;list;watch;delete;patch
 
 var resources = []string{
+	"AddOnDeploymentConfig",
+	"AddOnTemplate",
 	"APIService",
 	"ClusterManagementAddOn",
-	"ClusterRoleBinding",
 	"ClusterRole",
+	"ClusterRoleBinding",
 	"ConfigMap",
 	"ConsolePlugin",
 	"ConsoleQuickStart",
@@ -66,8 +68,6 @@ var resources = []string{
 	"ServiceAccount",
 	"ServiceMonitor",
 	"ValidatingWebhookConfiguration",
-	"AddOnDeploymentConfig",
-	"AddOnTemplate",
 }
 
 func main() {

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -18,20 +18,21 @@ import (
 )
 
 const (
-	ManagedServiceAccountChartDir     = "pkg/templates/charts/toggle/managed-serviceaccount"
-	ConsoleMCEChartsDir               = "pkg/templates/charts/toggle/console-mce"
-	ManagedServiceAccountCRDPath      = "pkg/templates/managed-serviceaccount/crds"
-	ImageBasedInstallOperatorChartDir = "pkg/templates/charts/toggle/image-based-install-operator"
-	DiscoveryChartDir                 = "pkg/templates/charts/toggle/discovery-operator"
-	HostedImportChartDir              = "pkg/templates/charts/hosted/server-foundation"
-	HostingImportChartDir             = "pkg/templates/charts/hosting/server-foundation"
-	HiveChartDir                      = "pkg/templates/charts/toggle/hive-operator"
 	AssistedServiceChartDir           = "pkg/templates/charts/toggle/assisted-service"
+	ClusterAPIChartDir                = "pkg/templates/charts/toggle/cluster-api"
 	ClusterLifecycleChartDir          = "pkg/templates/charts/toggle/cluster-lifecycle"
 	ClusterManagerChartDir            = "pkg/templates/charts/toggle/cluster-manager"
-	ServerFoundationChartDir          = "pkg/templates/charts/toggle/server-foundation"
-	HyperShiftChartDir                = "pkg/templates/charts/toggle/hypershift"
 	ClusterProxyAddonDir              = "pkg/templates/charts/toggle/cluster-proxy-addon"
+	ConsoleMCEChartsDir               = "pkg/templates/charts/toggle/console-mce"
+	DiscoveryChartDir                 = "pkg/templates/charts/toggle/discovery-operator"
+	HiveChartDir                      = "pkg/templates/charts/toggle/hive-operator"
+	HostedImportChartDir              = "pkg/templates/charts/hosted/server-foundation"
+	HostingImportChartDir             = "pkg/templates/charts/hosting/server-foundation"
+	HyperShiftChartDir                = "pkg/templates/charts/toggle/hypershift"
+	ImageBasedInstallOperatorChartDir = "pkg/templates/charts/toggle/image-based-install-operator"
+	ManagedServiceAccountChartDir     = "pkg/templates/charts/toggle/managed-serviceaccount"
+	ManagedServiceAccountCRDPath      = "pkg/templates/managed-serviceaccount/crds"
+	ServerFoundationChartDir          = "pkg/templates/charts/toggle/server-foundation"
 )
 
 func EnabledStatus(namespacedName types.NamespacedName) status.StatusReporter {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -61,16 +61,17 @@ var onComponents = []string{
 }
 
 var offComponents = []string{
+	backplanev1.ClusterAPIPreview,
 	backplanev1.ImageBasedInstallOperator,
 }
 
 var nonOCPComponents = []string{
+	backplanev1.ClusterLifecycle,
 	backplanev1.ClusterManager,
-	backplanev1.ServerFoundation,
 	backplanev1.HyperShift,
 	backplanev1.HypershiftLocalHosting,
 	backplanev1.LocalCluster,
-	backplanev1.ClusterLifecycle,
+	backplanev1.ServerFoundation,
 }
 
 var GlobalDeployOnOCP = true


### PR DESCRIPTION
# Description

Updated MCE operator to support new `cluster-api` (CAPI) component.
Follow up to #1127 PR.

## Related Issue

https://issues.redhat.com/browse/ACM-13577

## Changes Made

Added new toggle for enable/disabling `cluster-api` component within MCE.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [x] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
