### PR TITLE
[ACM-13578] Onboarded cluster-api-provider-aws (CAPA) component to MCE 2.8

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -24,6 +24,8 @@ import (
 
 const (
 	AssistedService                  = "assisted-service"
+	ClusterAPIProviderAWS            = "cluster-api-provider-aws"
+	ClusterAPIProviderAWSPreview     = "cluster-api-provider-aws-preview"
 	ClusterLifecycle                 = "cluster-lifecycle"
 	ClusterManager                   = "cluster-manager"
 	ClusterProxyAddon                = "cluster-proxy-addon"
@@ -43,6 +45,8 @@ const (
 
 var allComponents = []string{
 	AssistedService,
+	ClusterAPIProviderAWS,
+	ClusterAPIProviderAWSPreview,
 	ClusterLifecycle,
 	ClusterManager,
 	ClusterProxyAddon,
@@ -63,6 +67,7 @@ var allComponents = []string{
 // MCEComponents is a slice containing component names specific to the "MCE" category.
 var MCEComponents = []string{
 	AssistedService,
+	ClusterAPIProviderAWSPreview,
 	ClusterLifecycle,
 	ClusterManager,
 	ClusterProxyAddon,

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -898,7 +898,7 @@ func (r *MultiClusterEngineReconciler) fetchChartOrCRDPath(component string, use
 	chartDirs := map[string]string{
 		backplanev1.AssistedService:              toggle.AssistedServiceChartDir,
 		backplanev1.ClusterAPIPreview:            toggle.ClusterAPIChartDir,
-		backplanev1.ClusterAPIProviderAWSPreview: toggle.ClusterAPIProviderAWSDir,
+		backplanev1.ClusterAPIProviderAWSPreview: toggle.ClusterAPIProviderAWSChartDir,
 		backplanev1.ClusterLifecycle:             toggle.ClusterLifecycleChartDir,
 		backplanev1.ClusterManager:               toggle.ClusterManagerChartDir,
 		backplanev1.ClusterProxyAddon:            toggle.ClusterProxyAddonDir,

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -895,17 +895,18 @@ func (r *MultiClusterEngineReconciler) ensureNoInternalEngineComponent(ctx conte
 func (r *MultiClusterEngineReconciler) fetchChartOrCRDPath(component string, useCRDPath bool) string {
 
 	chartDirs := map[string]string{
-		backplanev1.AssistedService:           toggle.AssistedServiceChartDir,
-		backplanev1.ClusterLifecycle:          toggle.ClusterLifecycleChartDir,
-		backplanev1.ClusterManager:            toggle.ClusterManagerChartDir,
-		backplanev1.ClusterProxyAddon:         toggle.ClusterProxyAddonDir,
-		backplanev1.ConsoleMCE:                toggle.ConsoleMCEChartsDir,
-		backplanev1.Discovery:                 toggle.DiscoveryChartDir,
-		backplanev1.Hive:                      toggle.HiveChartDir,
-		backplanev1.HyperShift:                toggle.HyperShiftChartDir,
-		backplanev1.ImageBasedInstallOperator: toggle.ImageBasedInstallOperatorChartDir,
-		backplanev1.ManagedServiceAccount:     toggle.ManagedServiceAccountChartDir,
-		backplanev1.ServerFoundation:          toggle.ServerFoundationChartDir,
+		backplanev1.AssistedService:              toggle.AssistedServiceChartDir,
+		backplanev1.ClusterAPIProviderAWSPreview: toggle.ClusterAPIProviderAWSDir,
+		backplanev1.ClusterLifecycle:             toggle.ClusterLifecycleChartDir,
+		backplanev1.ClusterManager:               toggle.ClusterManagerChartDir,
+		backplanev1.ClusterProxyAddon:            toggle.ClusterProxyAddonDir,
+		backplanev1.ConsoleMCE:                   toggle.ConsoleMCEChartsDir,
+		backplanev1.Discovery:                    toggle.DiscoveryChartDir,
+		backplanev1.Hive:                         toggle.HiveChartDir,
+		backplanev1.HyperShift:                   toggle.HyperShiftChartDir,
+		backplanev1.ImageBasedInstallOperator:    toggle.ImageBasedInstallOperatorChartDir,
+		backplanev1.ManagedServiceAccount:        toggle.ManagedServiceAccountChartDir,
+		backplanev1.ServerFoundation:             toggle.ServerFoundationChartDir,
 	}
 
 	crdDirs := map[string]string{
@@ -1149,6 +1150,25 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 			errs[backplanev1.ClusterProxyAddon] = err
 		}
 	}
+
+	if backplaneConfig.Enabled(backplanev1.ClusterAPIProviderAWSPreview) {
+		result, err = r.ensureClusterAPIProviderAWS(ctx, backplaneConfig)
+		if result != (ctrl.Result{}) {
+			requeue = true
+		}
+		if err != nil {
+			errs[backplanev1.ClusterAPIProviderAWSPreview] = err
+		}
+	} else {
+		result, err = r.ensureNoClusterAPIProviderAWS(ctx, backplaneConfig)
+		if result != (ctrl.Result{}) {
+			requeue = true
+		}
+		if err != nil {
+			errs[backplanev1.ClusterAPIProviderAWSPreview] = err
+		}
+	}
+
 	if backplaneConfig.Enabled(backplanev1.LocalCluster) {
 		result, err := r.ensureLocalCluster(ctx, backplaneConfig)
 		if result != (ctrl.Result{}) {
@@ -1446,6 +1466,7 @@ func (r *MultiClusterEngineReconciler) ensureNoAllInternalEngineComponents(ctx c
 		backplanev1.ClusterProxyAddon,
 		backplanev1.LocalCluster,
 		backplanev1.ClusterManager,
+		backplanev1.ClusterAPIProviderAWSPreview,
 	}
 
 	for _, v := range components {

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -983,10 +983,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Name:    backplanev1.ClusterAPIPreview,
 									Enabled: false,
 								},
-								// {
-								// 	Name:    backplanev1.ClusterAPIProviderAWSPreview,
-								// 	Enabled: false,
-								// },
+								{
+									Name:    backplanev1.ClusterAPIProviderAWSPreview,
+									Enabled: false,
+								},
 								{
 									Name:    backplanev1.ClusterLifecycle,
 									Enabled: false,

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -64,7 +64,7 @@ const (
 	DestinationNamespace       = "test"
 	JobName                    = "test-job"
 
-	timeout  = time.Second * 60
+	timeout  = time.Second * 20
 	duration = time.Second * 10
 	interval = time.Millisecond * 250
 )

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -871,10 +871,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 								},
 								// EnvTest does not support namespace deletion; therefore, if we try to re-enable this component, the test will fail.
 								// https: //book.kubebuilder.io/reference/envtest
-								{
-									Name:    backplanev1.ClusterAPIProviderAWSPreview,
-									Enabled: false,
-								},
+								// {
+								// 	Name:    backplanev1.ClusterAPIProviderAWSPreview,
+								// 	Enabled: false,
+								// },
 								{
 									Name:    backplanev1.ClusterLifecycle,
 									Enabled: true,
@@ -983,10 +983,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Name:    backplanev1.ClusterAPIPreview,
 									Enabled: false,
 								},
-								{
-									Name:    backplanev1.ClusterAPIProviderAWSPreview,
-									Enabled: false,
-								},
+								// {
+								// 	Name:    backplanev1.ClusterAPIProviderAWSPreview,
+								// 	Enabled: false,
+								// },
 								{
 									Name:    backplanev1.ClusterLifecycle,
 									Enabled: false,

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -406,6 +406,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: true,
 								},
 								{
+									Name:    backplanev1.ClusterAPIProviderAWSPreview,
+									Enabled: true,
+								},
+								{
 									Name:    backplanev1.ClusterLifecycle,
 									Enabled: true,
 								},
@@ -574,6 +578,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 							Components: []backplanev1.ComponentConfig{
 								{
 									Name:    backplanev1.AssistedService,
+									Enabled: false,
+								},
+								{
+									Name:    backplanev1.ClusterAPIProviderAWSPreview,
 									Enabled: false,
 								},
 								{
@@ -850,6 +858,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: true,
 								},
 								{
+									Name:    backplanev1.ClusterAPIProviderAWSPreview,
+									Enabled: true,
+								},
+								{
 									Name:    backplanev1.ClusterLifecycle,
 									Enabled: true,
 								},
@@ -952,6 +964,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 								{
 									Name:    backplanev1.AssistedService,
 									Enabled: false,
+								},
+								{
+									Name:    backplanev1.ClusterAPIProviderAWSPreview,
+									Enabled: true,
 								},
 								{
 									Name:    backplanev1.ClusterLifecycle,

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -857,10 +857,12 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Name:    backplanev1.AssistedService,
 									Enabled: true,
 								},
-								{
-									Name:    backplanev1.ClusterAPIProviderAWSPreview,
-									Enabled: true,
-								},
+								// EnvTest does not support namespace deletion; therefore, if we try to re-enable this component, the test will fail.
+								// https://book.kubebuilder.io/reference/envtest
+								// {
+								// 	Name:    backplanev1.ClusterAPIProviderAWSPreview,
+								// 	Enabled: true,
+								// },
 								{
 									Name:    backplanev1.ClusterLifecycle,
 									Enabled: true,
@@ -967,7 +969,7 @@ var _ = Describe("BackplaneConfig controller", func() {
 								},
 								{
 									Name:    backplanev1.ClusterAPIProviderAWSPreview,
-									Enabled: true,
+									Enabled: false,
 								},
 								{
 									Name:    backplanev1.ClusterLifecycle,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -87,6 +87,7 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "pkg", "templates", "crds", "discovery-operator"),
 			filepath.Join("..", "pkg", "templates", "crds", "cluster-proxy-addon"),
 			filepath.Join("..", "pkg", "templates", "crds", "internal"),
+			filepath.Join("..", "pkg", "templates", "crds", "cluster-api-provider-aws"),
 			filepath.Join("..", "hack", "unit-test-crds"),
 		},
 		CRDInstallOptions: envtest.CRDInstallOptions{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -81,6 +81,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),
 			filepath.Join("..", "pkg", "templates", "crds", "cluster-api"),
+			filepath.Join("..", "pkg", "templates", "crds", "cluster-api-provider-aws"),
 			filepath.Join("..", "pkg", "templates", "crds", "cluster-lifecycle"),
 			filepath.Join("..", "pkg", "templates", "crds", "cluster-manager"),
 			filepath.Join("..", "pkg", "templates", "crds", "cluster-proxy-addon"),
@@ -88,7 +89,6 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "pkg", "templates", "crds", "foundation"),
 			filepath.Join("..", "pkg", "templates", "crds", "hive-operator"),
 			filepath.Join("..", "pkg", "templates", "crds", "internal"),
-			filepath.Join("..", "pkg", "templates", "crds", "cluster-api-provider-aws"),
 			filepath.Join("..", "hack", "unit-test-crds"),
 		},
 		CRDInstallOptions: envtest.CRDInstallOptions{

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -649,10 +649,11 @@ func (r *MultiClusterEngineReconciler) ensureNoHive(ctx context.Context, mce *ba
 	err := r.Client.Get(ctx, types.NamespacedName{Name: "hive"}, hiveConfig)
 	if err == nil { // If resource exists, delete
 		err := r.Client.Delete(ctx, hiveConfig)
-		if err != nil {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-	} else if err != nil && !apierrors.IsNotFound(err) {
+
+	} else if !apierrors.IsNotFound(err) {
 		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
 	}
 

--- a/docs/available-components.md
+++ b/docs/available-components.md
@@ -1,17 +1,18 @@
 
 # Table list of the deployed components
 
-| Name                      | Description                                                                                                          | Enabled |
-|---------------------------|----------------------------------------------------------------------------------------------------------------------|---------|
-| assisted-service          | Installs OpenShift with minimal infrastructure prerequisites and comprehensive pre-flight validations.               | True    |
-| cluster-lifecycle         | Provides cluster management capabilities for {ocp-short} and {product-title-short} hub clusters.                     | True    |
-| cluster-manager           | Manages various cluster-related operations within the cluster environment.                                           | True    |
-| cluster-proxy-addon       | Automates the installation of apiserver-network-proxy on both hub and managed clusters using a reverse proxy server. | True    |
-| console-mce               | Enables the {mce-short} console plug-in.                                                                             | True    |
-| discovery                 | Discovers and identifies new clusters within the {ocm}.                                                              | True    |
-| hive                      | Provisions and performs initial configuration of {ocp-short} clusters.                                               | True    |
-| hypershift                | Hosts OpenShift control planes at scale with cost and time efficiency, and cross-cloud portability.                  | True    |
-| hypershift-local-hosting  | Enables local hosting capabilities for within the local cluster environment.                                         | True    |
-| local-cluster             | Enables the import and self-management of the local hub cluster where the {mce-short} is deployed.                   | True    |
-| managedserviceaccount     | Syncronizes service accounts to the managed clusters and collects tokens as secret resources back to the hub cluster.| True    |
-| server-foundation         | Provides foundational services for server-side operations within the cluster environment.                            | True    |
+| Name                             | Description                                                                                                          | Enabled |
+|----------------------------------|----------------------------------------------------------------------------------------------------------------------|---------|
+| assisted-service                 | Installs OpenShift with minimal infrastructure prerequisites and comprehensive pre-flight validations.               | True    |
+| cluster-api-provider-aws-preview | Provides declarative, Kubernetes-style APIs to cluster creation, configuration and management.                       | False   |
+| cluster-lifecycle                | Provides cluster management capabilities for {ocp-short} and {product-title-short} hub clusters.                     | True    |
+| cluster-manager                  | Manages various cluster-related operations within the cluster environment.                                           | True    |
+| cluster-proxy-addon              | Automates the installation of apiserver-network-proxy on both hub and managed clusters using a reverse proxy server. | True    |
+| console-mce                      | Enables the {mce-short} console plug-in.                                                                             | True    |
+| discovery                        | Discovers and identifies new clusters within the {ocm}.                                                              | True    |
+| hive                             | Provisions and performs initial configuration of {ocp-short} clusters.                                               | True    |
+| hypershift                       | Hosts OpenShift control planes at scale with cost and time efficiency, and cross-cloud portability.                  | True    |
+| hypershift-local-hosting         | Enables local hosting capabilities for within the local cluster environment.                                         | True    |
+| local-cluster                    | Enables the import and self-management of the local hub cluster where the {mce-short} is deployed.                   | True    |
+| managedserviceaccount            | Syncronizes service accounts to the managed clusters and collects tokens as secret resources back to the hub cluster.| True    |
+| server-foundation                | Provides foundational services for server-side operations within the cluster environment.                            | True    |

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-controller-manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-controller-manager-deployment.yaml
@@ -97,9 +97,7 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: true
-          runAsGroup: 65532
           runAsNonRoot: true
-          runAsUser: 65532
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-controller-manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-controller-manager-deployment.yaml
@@ -117,7 +117,6 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       securityContext:
-        fsGroup: 1000
         runAsNonRoot: true
 {{- if .Values.global.deployOnOCP }}
 {{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-leader-elect-role-role.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-leader-elect-role-role.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-leader-elect-role
-  namespace: capa-system
+  namespace: {{ default "capa-system" .Values.global.namespace }}
 rules:
 - apiGroups:
   - ""

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-leader-elect-rolebinding-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-leader-elect-rolebinding-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-leader-elect-rolebinding
-  namespace: capa-system
+  namespace: {{ default "capa-system" .Values.global.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -14,4 +14,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capa-controller-manager
-  namespace: capa-system
+  namespace: {{ default "capa-system" .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-manager-bootstrap-credentials-secret.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-manager-bootstrap-credentials-secret.yaml
@@ -8,5 +8,5 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-manager-bootstrap-credentials
-  namespace: capa-system
+  namespace: {{ default "capa-system" .Values.global.namespace }}
 type: Opaque

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-manager-rolebinding-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-manager-rolebinding-clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capa-controller-manager
-  namespace: capa-system
+  namespace: {{ default "capa-system" .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-metrics-service-service.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-metrics-service-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-metrics-service
-  namespace: capa-system
+  namespace: {{ default "capa-system" .Values.global.namespace }}
 spec:
   ports:
   - port: 8080

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -15,7 +15,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awscluster
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -37,7 +37,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awsclustercontrolleridentity
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -59,7 +59,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awsclusterroleidentity
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -81,7 +81,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awsclusterstaticidentity
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -103,7 +103,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awsclustertemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -125,7 +125,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachine
   failurePolicy: Fail
   name: mutation.awsmachine.infrastructure.cluster.x-k8s.io
@@ -146,7 +146,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awsfargateprofile
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -168,7 +168,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachinepool
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -190,7 +190,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-awsmanagedmachinepool
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -212,7 +212,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-rosamachinepool
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -234,7 +234,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-bootstrap-cluster-x-k8s-io-v1beta2-eksconfig
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -256,7 +256,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-bootstrap-cluster-x-k8s-io-v1beta2-eksconfigtemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -278,7 +278,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-controlplane-cluster-x-k8s-io-v1beta2-awsmanagedcontrolplane
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -300,7 +300,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /mutate-controlplane-cluster-x-k8s-io-v1beta2-rosacontrolplane
   failurePolicy: Fail
   matchPolicy: Equivalent

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -15,7 +15,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awscluster
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -37,7 +37,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsclustercontrolleridentity
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -59,7 +59,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsclusterroleidentity
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -81,7 +81,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsclusterstaticidentity
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -103,7 +103,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsclustertemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -125,7 +125,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachine
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -147,7 +147,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachinetemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -169,7 +169,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsfargateprofile
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -191,7 +191,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachinepool
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -213,7 +213,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsmanagedmachinepool
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -235,7 +235,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-rosamachinepool
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -257,7 +257,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-bootstrap-cluster-x-k8s-io-v1beta2-eksconfig
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -279,7 +279,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-bootstrap-cluster-x-k8s-io-v1beta2-eksconfigtemplate
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -301,7 +301,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-controlplane-cluster-x-k8s-io-v1beta2-awsmanagedcontrolplane
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -323,7 +323,7 @@ webhooks:
   clientConfig:
     service:
       name: capa-webhook-service
-      namespace: capa-system
+      namespace: {{ default "capa-system" .Values.global.namespace }}
       path: /validate-controlplane-cluster-x-k8s-io-v1beta2-rosacontrolplane
   failurePolicy: Fail
   matchPolicy: Equivalent

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-webhook-service-service.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/templates/capa-webhook-service-service.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-webhook-service
-  namespace: capa-system
+  namespace: {{ default "capa-system" .Values.global.namespace }}
 spec:
   ports:
   - port: 443

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-admin-rolebinding-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-admin-rolebinding-clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capi-manager
-  namespace: capi-system
+  namespace: {{ default "capi-system" .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-leader-election-role-role.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-leader-election-role-role.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: capi-leader-election-role
-  namespace: capi-system
+  namespace: {{ default "capi-system" .Values.global.namespace }}
 rules:
   - apiGroups:
       - ""

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-leader-election-rolebinding-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-leader-election-rolebinding-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: capi-leader-election-rolebinding
-  namespace: capi-system
+  namespace: {{ default "capi-system" .Values.global.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -14,4 +14,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: capi-manager
-    namespace: capi-system
+    namespace: {{ default "capi-system" .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-manager-rolebinding-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-manager-rolebinding-clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: capi-manager
-  namespace: capi-system
+  namespace: {{ default "capi-system" .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -15,7 +15,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /mutate-cluster-x-k8s-io-v1beta1-cluster
     failurePolicy: Fail
     matchPolicy: Equivalent

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -15,7 +15,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-cluster-x-k8s-io-v1beta1-cluster
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -38,7 +38,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-cluster-x-k8s-io-v1beta1-clusterclass
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -61,7 +61,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-cluster-x-k8s-io-v1beta1-machine
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -83,7 +83,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-cluster-x-k8s-io-v1beta1-machinedeployment
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -105,7 +105,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-cluster-x-k8s-io-v1beta1-machinehealthcheck
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -127,7 +127,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-cluster-x-k8s-io-v1beta1-machineset
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -149,7 +149,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-runtime-cluster-x-k8s-io-v1alpha1-extensionconfig
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -171,7 +171,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-cluster-x-k8s-io-v1beta1-machinepool
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -193,7 +193,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -215,7 +215,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourcesetbinding
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -237,7 +237,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-ipam-cluster-x-k8s-io-v1beta1-ipaddress
     failurePolicy: Fail
     matchPolicy: Equivalent
@@ -260,7 +260,7 @@ webhooks:
     clientConfig:
       service:
         name: capi-webhook-service
-        namespace: capi-system
+        namespace: {{ default "capi-system" .Values.global.namespace }}
         path: /validate-ipam-cluster-x-k8s-io-v1beta1-ipaddressclaim
     failurePolicy: Fail
     matchPolicy: Equivalent

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-webhook-service-service.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-webhook-service-service.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: capi-webhook-service
-  namespace: capi-system
+  namespace: {{ default "capi-system" .Values.global.namespace }}
 spec:
   ports:
     - port: 443

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -32,6 +32,7 @@ const (
 	ServerFoundationChartDir          = "pkg/templates/charts/toggle/server-foundation"
 	HyperShiftChartDir                = "pkg/templates/charts/toggle/hypershift"
 	ClusterProxyAddonDir              = "pkg/templates/charts/toggle/cluster-proxy-addon"
+	ClusterAPIProviderAWSDir          = "pkg/templates/charts/toggle/cluster-api-provider-aws"
 )
 
 func EnabledStatus(namespacedName types.NamespacedName) status.StatusReporter {

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -20,7 +20,7 @@ import (
 const (
 	AssistedServiceChartDir           = "pkg/templates/charts/toggle/assisted-service"
 	ClusterAPIChartDir                = "pkg/templates/charts/toggle/cluster-api"
-	ClusterAPIProviderAWSDir          = "pkg/templates/charts/toggle/cluster-api-provider-aws"
+	ClusterAPIProviderAWSChartDir     = "pkg/templates/charts/toggle/cluster-api-provider-aws"
 	ClusterLifecycleChartDir          = "pkg/templates/charts/toggle/cluster-lifecycle"
 	ClusterManagerChartDir            = "pkg/templates/charts/toggle/cluster-manager"
 	ClusterProxyAddonDir              = "pkg/templates/charts/toggle/cluster-proxy-addon"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -61,6 +61,7 @@ var onComponents = []string{
 }
 
 var offComponents = []string{
+	backplanev1.ClusterAPIProviderAWSPreview,
 	backplanev1.ImageBasedInstallOperator,
 }
 


### PR DESCRIPTION
# Description

Updated MCE operator to support new `cluster-api-provider-aws` (CAPA) component.
Follow up to #1128 PR.

## Related Issue

https://issues.redhat.com/browse/ACM-13578

## Changes Made

Added new toggle for enable/disabling `cluster-api-provider-aws` component within MCE.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [x] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
