### PR TITLE
Remove cluster-api image reference from hypershift addon chart

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-configmap.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-configmap.yaml
@@ -13,13 +13,6 @@ data:
       lookupPolicy:
         local: false
       tags:
-      - name: cluster-api
-        annotations:
-          io.openshift.build.commit.id: e09ed61cc9ba8bd37b0760291c833b4da744a985
-          io.openshift.build.source-location: https://github.com/openshift/cluster-api
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.cluster_api }}
       - name: cluster-api-provider-agent
         annotations:
           io.openshift.build.commit.id: dd6353f609dc9e7bfd0312ce4b2c8d3dac5d749e


### PR DESCRIPTION
# Description

The hypershift operator uses `cluster-api` container image from the hosted cluster's OCP payload instead of using the one that is packaged as part of MCE. Before removing the image from MCE, the image reference should be removed from the chart first.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
