### PR TITLE
Added prow/konflux Dockerfiles to ./build dir

### DIFF
--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,0 +1,30 @@
+# Build the backplane-operator binary
+FROM registry.ci.openshift.org/stolostron/builder:go1.22-linux AS builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o backplane-operator main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+WORKDIR /app
+COPY --from=builder /workspace/backplane-operator .
+COPY --from=builder /workspace/pkg/templates pkg/templates
+
+USER 65532:65532
+
+ENTRYPOINT ["/app/backplane-operator"]

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,0 +1,37 @@
+# Copyright Contributors to the Open Cluster Management project
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as cloner
+
+RUN microdnf install -y git findutils
+COPY hack/scripts hack/scripts
+
+# Build the backplane-operator binary
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -mod=readonly -o backplane-operator main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+LABEL org.label-schema.vendor="Red Hat" \
+      org.label-schema.name="backplane-operator" \
+      org.label-schema.description="Installer operator for Red Hat multicluster engine for Kubernetes"
+
+WORKDIR /app
+COPY --from=builder /workspace/backplane-operator .
+COPY --from=builder /workspace/pkg/templates pkg/templates
+
+USER 65532:65532
+
+ENTRYPOINT ["/app/backplane-operator"]

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -1,0 +1,25 @@
+# Build the backplane-operator binary
+FROM registry.ci.openshift.org/stolostron/builder:go1.22-linux AS builder
+
+WORKDIR /workspace
+
+COPY api/ api/
+COPY test/function_tests/ test/function_tests/
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
+RUN ginkgo build test/function_tests/backplane_operator_install_test
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ENV KUBECONFIG "/opt/.kube/config"
+ENV RESOURCE_DIR "resources"
+
+USER root
+WORKDIR /test
+
+COPY --from=builder /workspace/test/function_tests/backplane_operator_install_test/backplane_operator_install_test.test backplane_operator_install_test/backplane_operator_install_test.test
+COPY --from=builder /workspace/test/function_tests/resources/ resources/
+
+CMD ["/test/backplane_operator_install_test/backplane_operator_install_test.test" , "-ginkgo.v"]


### PR DESCRIPTION
# Description

Moving the `prow` and `rhtap` Dockerfiles to the `build` directory. This change is just to remain consistent across our repositories.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
