### PR TITLE
rename edge management

### DIFF
--- a/config/crd/bases/authentication.open-cluster-management.io_managedserviceaccounts.yaml
+++ b/config/crd/bases/authentication.open-cluster-management.io_managedserviceaccounts.yaml
@@ -1,0 +1,340 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: managedserviceaccounts.authentication.open-cluster-management.io
+spec:
+  group: authentication.open-cluster-management.io
+  names:
+    kind: ManagedServiceAccount
+    listKind: ManagedServiceAccountList
+    plural: managedserviceaccounts
+    singular: managedserviceaccount
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    deprecationWarning: authentication.open-cluster-management.io/v1alpha1 ManagedServiceAccount
+      is deprecated; use authentication.open-cluster-management.io/v1beta1 ManagedServiceAccount;
+      version v1alpha1 will be removed in the next release
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedServiceAccount is the Schema for the managedserviceaccounts
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedServiceAccountSpec defines the desired state of ManagedServiceAccount
+            properties:
+              rotation:
+                description: Rotation is the policy for rotation the credentials.
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled prescribes whether the ServiceAccount token will
+                      be rotated from the upstream
+                    type: boolean
+                  validity:
+                    default: 8640h0m0s
+                    description: Validity is the duration for which the signed ServiceAccount
+                      token is valid.
+                    type: string
+                type: object
+              ttlSecondsAfterCreation:
+                description: |-
+                  ttlSecondsAfterCreation limits the lifetime of a ManagedServiceAccount.
+                  If the ttlSecondsAfterCreation field is set, the ManagedServiceAccount will be
+                  automatically deleted regardless of the ManagedServiceAccount's status.
+                  When the ManagedServiceAccount is deleted, its lifecycle guarantees
+                  (e.g. finalizers) will be honored. If this field is unset, the ManagedServiceAccount
+                  won't be automatically deleted. If this field is set to zero, the
+                  ManagedServiceAccount becomes eligible for deletion immediately after its creation.
+                  In order to use ttlSecondsAfterCreation, the EphemeralIdentity feature gate must be enabled.
+                exclusiveMinimum: true
+                format: int32
+                minimum: 0
+                type: integer
+            required:
+            - rotation
+            type: object
+          status:
+            description: ManagedServiceAccountStatus defines the observed state of
+              ManagedServiceAccount
+            properties:
+              conditions:
+                description: Conditions is the condition list.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              expirationTimestamp:
+                description: ExpirationTimestamp is the time when the token will expire.
+                format: date-time
+                type: string
+              tokenSecretRef:
+                description: |-
+                  TokenSecretRef is a reference to the corresponding ServiceAccount's Secret, which stores
+                  the CA certficate and token from the managed cluster.
+                properties:
+                  lastRefreshTimestamp:
+                    description: |-
+                      LastRefreshTimestamp is the timestamp indicating when the token in the Secret
+                      is refreshed.
+                    format: date-time
+                    type: string
+                  name:
+                    description: Name is the name of the referenced secret.
+                    type: string
+                required:
+                - lastRefreshTimestamp
+                - name
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ManagedServiceAccount is the Schema for the managedserviceaccounts
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedServiceAccountSpec defines the desired state of ManagedServiceAccount
+            properties:
+              rotation:
+                description: Rotation is the policy for rotation the credentials.
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled prescribes whether the ServiceAccount token will be rotated before it expires.
+                      Deprecated: All ServiceAccount tokens will be rotated before they expire regardless of this field.
+                    type: boolean
+                  validity:
+                    default: 8640h0m0s
+                    description: Validity is the duration of validity for requesting
+                      the signed ServiceAccount token.
+                    type: string
+                type: object
+              ttlSecondsAfterCreation:
+                description: |-
+                  ttlSecondsAfterCreation limits the lifetime of a ManagedServiceAccount.
+                  If the ttlSecondsAfterCreation field is set, the ManagedServiceAccount will be
+                  automatically deleted regardless of the ManagedServiceAccount's status.
+                  When the ManagedServiceAccount is deleted, its lifecycle guarantees
+                  (e.g. finalizers) will be honored. If this field is unset, the ManagedServiceAccount
+                  won't be automatically deleted. If this field is set to zero, the
+                  ManagedServiceAccount becomes eligible for deletion immediately after its creation.
+                  In order to use ttlSecondsAfterCreation, the EphemeralIdentity feature gate must be enabled.
+                exclusiveMinimum: true
+                format: int32
+                minimum: 0
+                type: integer
+            required:
+            - rotation
+            type: object
+          status:
+            description: ManagedServiceAccountStatus defines the observed state of
+              ManagedServiceAccount
+            properties:
+              conditions:
+                description: Conditions is the condition list.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              expirationTimestamp:
+                description: ExpirationTimestamp is the time when the token will expire.
+                format: date-time
+                type: string
+              tokenSecretRef:
+                description: |-
+                  TokenSecretRef is a reference to the corresponding ServiceAccount's Secret, which stores
+                  the CA certficate and token from the managed cluster.
+                properties:
+                  lastRefreshTimestamp:
+                    description: |-
+                      LastRefreshTimestamp is the timestamp indicating when the token in the Secret
+                      is refreshed.
+                    format: date-time
+                    type: string
+                  name:
+                    description: Name is the name of the referenced secret.
+                    type: string
+                required:
+                - lastRefreshTimestamp
+                - name
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -370,9 +370,9 @@ func injectValuesOverrides(values *Values, backplaneConfig *v1.MultiClusterEngin
 
 	values.HubConfig.HubType = utils.GetHubType(backplaneConfig)
 
-	enableFlightctl := utils.GetFightEnabled(backplaneConfig)
+	enableEdgeManagement := utils.GetEdgeManagementEnabled(backplaneConfig)
 
-	if enableFlightctl == "true" {
+	if enableEdgeManagement == "true" {
 		values.HubConfig.EnableFlightCtl = true
 	} else {
 		values.HubConfig.EnableFlightCtl = false

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -26,9 +26,9 @@ var (
 	DeprecatedAnnotationIgnoreOCPVersion = "ignoreOCPVersion"
 
 	/*
-		AnnotationFlightEnabled is an annotation used in multiclusterhub to whether the component flight control is enabled or not
+		AnnotationEdgeManagementEnabled is an annotation used in multiclusterhub to whether the component edge management  is enabled or not
 	*/
-	AnnotationFlightEnabled = "installer.open-cluster-management.io/flight-control-enabled"
+	AnnotationEdgeManagementEnabled = "installer.open-cluster-management.io/edge-management-enabled"
 
 	/*
 		AnnotationImageOverridesCM is an annotation used in multiclusterengine to specify a custom ConfigMap containing
@@ -229,9 +229,9 @@ func HasAnnotation(instance *backplanev1.MultiClusterEngine, annotationKey strin
 	return exists
 }
 
-func GetFightEnabled(instance *backplanev1.MultiClusterEngine) string {
-	if HasAnnotation(instance, AnnotationFlightEnabled) {
-		return instance.GetAnnotations()[AnnotationFlightEnabled]
+func GetEdgeManagementEnabled(instance *backplanev1.MultiClusterEngine) string {
+	if HasAnnotation(instance, AnnotationEdgeManagementEnabled) {
+		return instance.GetAnnotations()[AnnotationEdgeManagementEnabled]
 	} else {
 		return "false"
 	}

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -87,20 +87,20 @@ func Test_AnnotationMatch(t *testing.T) {
 	}
 }
 
-func Test_getAnnotationFlightControl(t *testing.T) {
+func Test_getAnnotationEdgeManagement(t *testing.T) {
 	instance := &backplanev1.MultiClusterEngine{
-		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationFlightEnabled: "true"}},
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationEdgeManagementEnabled: "true"}},
 	}
-	result := GetFightEnabled(instance)
+	result := GetEdgeManagementEnabled(instance)
 	if result != "true" {
-		t.Errorf("Was expecting true for the flight control annotation. Did not receive")
+		t.Errorf("Was expecting true for the edge management annotation. Did not receive")
 	}
 	instance = &backplanev1.MultiClusterEngine{
 		ObjectMeta: metav1.ObjectMeta{},
 	}
-	result = GetFightEnabled(instance)
+	result = GetEdgeManagementEnabled(instance)
 	if result != "false" {
-		t.Errorf("Was expecting false for the flight control annotation. Did not receive")
+		t.Errorf("Was expecting false for the edge management annotation. Did not receive")
 	}
 }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ACM-17576

Renaming all references to flight control to edge management per marketing decision. One reference remains in our rendering global struct. Will need to coordinate with server foundation to see when they arechanging their code