### PR TITLE
[ACM-18091] Updated deprecated resources cleanup to include IBIO webhook

### DIFF
--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -157,7 +157,7 @@ var _ webhook.Validator = &MultiClusterEngine{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *MultiClusterEngine) ValidateCreate() (admission.Warnings, error) {
 	ctx := context.Background()
-	backplaneconfiglog.Info("validate create", "name", r.Name)
+	backplaneconfiglog.Info("validate create", "Kind", r.Kind, "Name", r.GetName())
 
 	if (r.Spec.AvailabilityConfig != HABasic) && (r.Spec.AvailabilityConfig != HAHigh) && (r.Spec.AvailabilityConfig != "") {
 		return nil, ErrInvalidAvailability
@@ -198,7 +198,7 @@ func (r *MultiClusterEngine) ValidateCreate() (admission.Warnings, error) {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *MultiClusterEngine) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
-	backplaneconfiglog.Info("validate update", "name", r.Name)
+	backplaneconfiglog.Info("validate update", "Kind", r.Kind, "Name", r.GetName())
 
 	oldMCE := old.(*MultiClusterEngine)
 	backplaneconfiglog.Info(oldMCE.Spec.TargetNamespace)
@@ -269,7 +269,7 @@ func (r *MultiClusterEngine) ValidateUpdate(old runtime.Object) (admission.Warni
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *MultiClusterEngine) ValidateDelete() (admission.Warnings, error) {
 	// TODO(user): fill in your validation logic upon object deletion.
-	backplaneconfiglog.Info("validate delete", "name", r.Name)
+	backplaneconfiglog.Info("validate delete", "Kind", r.Kind, "Name", r.GetName())
 	ctx := context.Background()
 
 	cfg, err := config.GetConfig()

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -2190,34 +2190,6 @@ func ensureCRD(ctx context.Context, c client.Client, crd *unstructured.Unstructu
 	return nil
 }
 
-func (r *MultiClusterEngineReconciler) removeDeprecatedRBAC(ctx context.Context) (ctrl.Result, error) {
-	hyperShiftPreviewClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
-	if err == nil {
-		err = r.Client.Delete(ctx, hyperShiftPreviewClusterRoleBinding)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
-		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, err
-		}
-	}
-	hyperShiftPreviewClusterRole := &rbacv1.ClusterRole{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRole)
-	if err == nil {
-		err = r.Client.Delete(ctx, hyperShiftPreviewClusterRole)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
-		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, err
-		}
-	}
-	return ctrl.Result{}, nil
-}
-
 func (r *MultiClusterEngineReconciler) GetDeprecatedResources(m *backplanev1.MultiClusterEngine) []client.Object {
 	return []client.Object{
 		&corev1.Service{

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -262,9 +262,34 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	result, err = r.removeDeprecatedRBAC(ctx)
-	if err != nil {
-		return result, err
+	/*----------------------------------------------------------------
+	// Deprecated Resource Cleanup
+	//
+	// This section handles the cleanup of deprecated or legacy resources
+	// that were created in previous versions of ACM, ensuring they are removed
+	// during an upgrade to prevent conflicts or redundancy.
+	//
+	// Version History:
+	// - ACM 2.12: Hypershift changed the chart name from "hypershift-preview" to "hypershift",
+	//   which impacted the removal of associated resources like ClusterRole and
+	//   ClusterRoleBinding. Therefore, we need to explicitly clean up the resources
+	//   associated with the "hypershift-preview" chart.
+	//
+	// - >= ACM 2.12.3, IBIO introduced a new service and validating webhook configuration
+	//   for their component. Therefore, we need to clean up resources associated with their older Service.
+	//
+	// Future Versions:
+	// - In future versions, ensure that each component has a unique service and webhook name to
+	//   avoid similar issues with overlapping resources.
+	//
+	// - Any additional deprecated resources or changes in the future should also be
+	//   addressed in this section to ensure a smooth upgrade process.
+	//----------------------------------------------------------------*/
+
+	for _, obj := range r.GetDeprecatedResources(backplaneConfig) {
+		if result, err := r.EnsureResourceCleanup(ctx, obj); (result != ctrl.Result{}) || err != nil {
+			return result, err
+		}
 	}
 
 	if !utils.ShouldIgnoreOCPVersion(backplaneConfig) && utils.DeployOnOCP() {
@@ -1872,10 +1897,6 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		updateNecessary = true
 	}
 
-	if utils.DeduplicateComponents(m) {
-		updateNecessary = true
-	}
-
 	if utils.DeployOnOCP() {
 		// Set and store cluster Ingress domain for use later
 		clusterIngressDomain, err := r.getClusterIngressDomain(ctx, m)
@@ -1937,6 +1958,66 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 	} else {
 		return ctrl.Result{}, nil
 	}
+}
+
+/*
+EnsureResourceCleanup ensures that a given Kubernetes resource is deleted if it exists.
+It first attempts to fetch the resource, logs if it is already being deleted, and then proceeds
+with deletion if necessary.
+
+Parameters:
+  - ctx: The context for managing request deadlines and cancellations.
+  - obj: The Kubernetes resource (client.Object) to check and delete.
+
+Returns:
+  - ctrl.Result: An empty result indicating no requeue is needed.
+  - error: Any error encountered while fetching or deleting the resource.
+*/
+func (r *MultiClusterEngineReconciler) EnsureResourceCleanup(ctx context.Context, obj client.Object) (
+	ctrl.Result, error) {
+
+	/*
+	   Resources can be either namespace-scoped or cluster-scoped.
+	   To accommodate both cases, we first initialize `key` with only the resource name.
+	   If the resource is namespace-scoped, we then set the namespace accordingly.
+	*/
+	key := types.NamespacedName{Name: obj.GetName()}
+
+	// Only set the namespace if the resource is namespace-scoped
+	if obj.GetNamespace() != "" {
+		key.Namespace = obj.GetNamespace()
+	}
+
+	if err := r.Client.Get(ctx, key, obj); err != nil {
+		// Resource not found, no cleanup needed
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		log.Error(err, "Failed to get resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			"Name", obj.GetName(), "Namespace", obj.GetNamespace())
+		return ctrl.Result{}, err
+	}
+
+	// Check if resource is already marked for deletion
+	if obj.GetDeletionTimestamp() != nil {
+		log.Info("Waiting for resource to be terminated", "Kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			"Name", obj.GetName(), "Namespace", obj.GetNamespace(), "DeletionTimestamp", obj.GetDeletionTimestamp())
+
+		return ctrl.Result{RequeueAfter: utils.FastRefreshInterval}, nil
+	}
+
+	// Delete the resource
+	log.Info("Deleting resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind, "Name",
+		obj.GetName(), "Namespace", obj.GetNamespace())
+
+	if err := r.Client.Delete(ctx, obj); err != nil {
+		log.Error(err, "Failed to delete resource", "Kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			"Name", obj.GetName(), "Namespace", obj.GetNamespace())
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *MultiClusterEngineReconciler) validateNamespace(ctx context.Context, m *backplanev1.MultiClusterEngine) (
@@ -2122,4 +2203,25 @@ func (r *MultiClusterEngineReconciler) removeDeprecatedRBAC(ctx context.Context)
 		}
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterEngineReconciler) GetDeprecatedResources(m *backplanev1.MultiClusterEngine) []client.Object {
+	return []client.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "webhook-service",
+				Namespace: m.Spec.TargetNamespace,
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager",
+			},
+		},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager",
+			},
+		},
+	}
 }

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -285,9 +285,8 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// - Any additional deprecated resources or changes in the future should also be
 	//   addressed in this section to ensure a smooth upgrade process.
 	//----------------------------------------------------------------*/
-
 	for _, obj := range r.GetDeprecatedResources(backplaneConfig) {
-		if result, err := r.EnsureResourceCleanup(ctx, obj); (result != ctrl.Result{}) || err != nil {
+		if result, err := r.EnsureDeprecatedResourceCleanup(ctx, obj); (result != ctrl.Result{}) || err != nil {
 			return result, err
 		}
 	}
@@ -1965,7 +1964,7 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 }
 
 /*
-EnsureResourceCleanup ensures that a given Kubernetes resource is deleted if it exists.
+EnsureDeprecatedResourceCleanup ensures that a given Kubernetes resource is deleted if it exists.
 It first attempts to fetch the resource, logs if it is already being deleted, and then proceeds
 with deletion if necessary.
 
@@ -1977,7 +1976,7 @@ Returns:
   - ctrl.Result: An empty result indicating no requeue is needed.
   - error: Any error encountered while fetching or deleting the resource.
 */
-func (r *MultiClusterEngineReconciler) EnsureResourceCleanup(ctx context.Context, obj client.Object) (
+func (r *MultiClusterEngineReconciler) EnsureDeprecatedResourceCleanup(ctx context.Context, obj client.Object) (
 	ctrl.Result, error) {
 
 	/*
@@ -2218,14 +2217,12 @@ func (r *MultiClusterEngineReconciler) GetDeprecatedResources(m *backplanev1.Mul
 			},
 		},
 		&rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager",
-			},
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding"},
+			ObjectMeta: metav1.ObjectMeta{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"},
 		},
 		&rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager",
-			},
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole"},
+			ObjectMeta: metav1.ObjectMeta{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"},
 		},
 	}
 }

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1897,6 +1897,10 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		updateNecessary = true
 	}
 
+	if utils.DeduplicateComponents(m) {
+		updateNecessary = true
+	}
+
 	if utils.DeployOnOCP() {
 		// Set and store cluster Ingress domain for use later
 		clusterIngressDomain, err := r.getClusterIngressDomain(ctx, m)

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -73,6 +73,7 @@ var (
 	mockClient = fake.NewClientBuilder().Build()
 	recon      = MultiClusterEngineReconciler{
 		Client:        mockClient,
+		Scheme:        scheme.Scheme,
 		StatusManager: &status.StatusTracker{Client: mockClient},
 	}
 )
@@ -2291,6 +2292,42 @@ func Test_ensureResourceVersionAlignment(t *testing.T) {
 			got := recon.ensureResourceVersionAlignment(tt.template, os.Getenv("OPERATOR_VERSION"))
 			if got != tt.want {
 				t.Errorf("ensureResourceVersionAlignment() = %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_EnsureDeprecatedResourceCleanup(t *testing.T) {
+	tests := []struct {
+		name string
+		mce  *backplanev1.MultiClusterEngine
+		want error
+	}{
+		{
+			mce: &backplanev1.MultiClusterEngine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "multiclusterengine",
+				},
+				Spec: backplanev1.MultiClusterEngineSpec{
+					TargetNamespace: "test-ns",
+				},
+			},
+			name: "should ensure deprecated resources are cleaned up",
+			want: nil,
+		},
+	}
+
+	registerScheme()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, obj := range recon.GetDeprecatedResources(tt.mce) {
+				if err := recon.Client.Create(context.TODO(), obj); err != nil {
+					t.Errorf("Failed to create %v: %v", obj, err)
+				}
+
+				if _, err := recon.EnsureDeprecatedResourceCleanup(context.TODO(), obj); err != nil {
+					t.Errorf("EnsureDeprecatedResourceCleanup() = %v, want: %v", err, tt.want)
+				}
 			}
 		})
 	}

--- a/controllers/toggle_components_test.go
+++ b/controllers/toggle_components_test.go
@@ -5,12 +5,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	"github.com/stolostron/backplane-operator/pkg/status"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -133,64 +131,6 @@ func Test_reconcileLocalHosting(t *testing.T) {
 	// 	t.Errorf("Got status %s, expected %s", component.Type, "Available")
 	// }
 	r.StatusManager.Reset("")
-}
-
-func Test_HypershiftPreview(t *testing.T) {
-	scheme := runtime.NewScheme()
-	corev1.AddToScheme(scheme)
-	appsv1.AddToScheme(scheme)
-	backplanev1.AddToScheme(scheme)
-	addonv1alpha1.AddToScheme(scheme)
-	rbacv1.AddToScheme(scheme)
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	images := map[string]string{}
-	// ctx := context.TODO()
-	statusManager := &status.StatusTracker{Client: cl}
-	r := &MultiClusterEngineReconciler{
-		Client:        cl,
-		Scheme:        cl.Scheme(),
-		Images:        images,
-		StatusManager: statusManager,
-	}
-
-	clusterRole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager", // Name of the cluster role
-		},
-		Rules: []rbacv1.PolicyRule{}, // No rules, so it's empty
-	}
-
-	err := cl.Create(context.Background(), clusterRole)
-	if err != nil {
-		wrappedErr := errors.Wrap(err, "failed to create ClusterRole")
-
-		t.Errorf(wrappedErr.Error())
-	}
-
-	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager", // Name of the ClusterRoleBinding
-		},
-		// No subjects and no roleRef, meaning it doesn't bind any ClusterRole
-		Subjects: []rbacv1.Subject{},
-		RoleRef:  rbacv1.RoleRef{},
-	}
-
-	// Create the ClusterRoleBinding in the fake client
-	err = cl.Create(context.Background(), clusterRoleBinding)
-	if err != nil {
-		wrappedErr := errors.Wrap(err, "failed to create ClusterRoleBinding")
-
-		t.Errorf(wrappedErr.Error())
-	}
-	_, err = r.removeDeprecatedRBAC(context.Background())
-	if err != nil {
-		wrappedErr := errors.Wrap(err, "failed to delete")
-
-		t.Errorf(wrappedErr.Error())
-	}
-
 }
 
 func Test_clusterManagementAddOnNotFoundStatus(t *testing.T) {

--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -19,7 +19,7 @@
 
 - repo_name: "cluster-api-installer"
   github_ref: "https://github.com/stolostron/cluster-api-installer.git"
-  branch: "main"
+  branch: "backplane-2.8"
   charts:
     - name: "cluster-api"
       chart-path: "charts/cluster-api"
@@ -37,7 +37,7 @@
 
 - repo_name: "cluster-api-installer"
   github_ref: "https://github.com/stolostron/cluster-api-installer.git"
-  branch: "main"
+  branch: "backplane-2.8"
   charts:
     - name: "cluster-api-provider-aws"
       chart-path: "charts/cluster-api-provider-aws"

--- a/main.go
+++ b/main.go
@@ -362,9 +362,8 @@ func ensureCRD(ctx context.Context, c client.Client, crd *unstructured.Unstructu
 	err := c.Get(ctx, types.NamespacedName{Name: crd.GetName()}, existingCRD)
 	if err != nil && errors.IsNotFound(err) {
 		// CRD not found. Create and return
-		setupLog.Info(fmt.Sprintf("creating CRD '%s'", crd.GetName()))
-		err = c.Create(ctx, crd)
-		if err != nil {
+		setupLog.Info("Creating CRD", "Name", crd.GetName())
+		if err = c.Create(ctx, crd); err != nil {
 			return fmt.Errorf("error creating CRD '%s': %w", crd.GetName(), err)
 		}
 
@@ -374,13 +373,13 @@ func ensureCRD(ctx context.Context, c client.Client, crd *unstructured.Unstructu
 	} else {
 		// CRD already exists. Update and return
 		if utils.AnnotationPresent(utils.AnnotationMCEIgnore, existingCRD) {
-			setupLog.Info(fmt.Sprintf("CRD '%s' has ignore label. Skipping update.", crd.GetName()))
+			setupLog.Info("CRD has ignore label. Skipping update.", "Name", crd.GetName())
 			return nil
 		}
+
 		crd.SetResourceVersion(existingCRD.GetResourceVersion())
-		setupLog.Info(fmt.Sprintf("updating CRD '%s'", crd.GetName()))
-		err = c.Update(ctx, crd)
-		if err != nil {
+		setupLog.Info("Updating CRD", "Name", crd.GetName())
+		if err = c.Update(ctx, crd); err != nil {
 			return fmt.Errorf("error updating CRD '%s': %w", crd.GetName(), err)
 		}
 	}

--- a/pkg/utils/defaults.go
+++ b/pkg/utils/defaults.go
@@ -7,11 +7,20 @@ import (
 )
 
 const (
-	// ShortRefreshInterval is ideal for frequently changing or moderately critical state requiring timely updates.
-	ShortRefreshInterval = 5 * time.Minute
-
-	// ErrorRefreshInterval is used for handling critical errors that require immediate attention.
+	/*
+		ErrorRefreshInterval is used for handling critical errors that require immediate attention.
+	*/
 	ErrorRefreshInterval = 30 * time.Second
+
+	/*
+		FastRefreshInterval is useful for rapidly changing environments where frequent updates are needed.
+	*/
+	FastRefreshInterval = 1 * time.Minute
+
+	/*
+		ShortRefreshInterval is ideal for frequently changing or moderately critical state requiring timely updates.
+	*/
+	ShortRefreshInterval = 5 * time.Minute
 
 	/*
 		WarningRefreshInterval is suitable for addressing warnings or non-critical issues that should still be addressed


### PR DESCRIPTION
# Description

Updated the MCE operator to remove old references to the `webhook-service` Service resource.
Note: Moving forward, squads should not use the default name from `operator-sdk` for `webhook` or `service` resources, the name should be unique to their component.
 
## Related Issue

https://issues.redhat.com/browse/ACM-18091

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
