### PR TITLE
[2.7][ACM-18091] Updated deprecated resources cleanup to include IBIO webhook

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -261,9 +261,34 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}
-	result, err = r.removeDeprecatedRBAC(ctx)
-	if err != nil {
-		return result, err
+
+	/*----------------------------------------------------------------
+	// Deprecated Resource Cleanup
+	//
+	// This section handles the cleanup of deprecated or legacy resources
+	// that were created in previous versions of ACM, ensuring they are removed
+	// during an upgrade to prevent conflicts or redundancy.
+	//
+	// Version History:
+	// - ACM 2.12: Hypershift changed the chart name from "hypershift-preview" to "hypershift",
+	//   which impacted the removal of associated resources like ClusterRole and
+	//   ClusterRoleBinding. Therefore, we need to explicitly clean up the resources
+	//   associated with the "hypershift-preview" chart.
+	//
+	// - >= ACM 2.12.3, IBIO introduced a new service and validating webhook configuration
+	//   for their component. Therefore, we need to clean up resources associated with their older Service.
+	//
+	// Future Versions:
+	// - In future versions, ensure that each component has a unique service and webhook name to
+	//   avoid similar issues with overlapping resources.
+	//
+	// - Any additional deprecated resources or changes in the future should also be
+	//   addressed in this section to ensure a smooth upgrade process.
+	//----------------------------------------------------------------*/
+	for _, obj := range r.GetDeprecatedResources(backplaneConfig) {
+		if result, err := r.EnsureDeprecatedResourceCleanup(ctx, obj); (result != ctrl.Result{}) || err != nil {
+			return result, err
+		}
 	}
 
 	if !utils.ShouldIgnoreOCPVersion(backplaneConfig) && utils.DeployOnOCP() {
@@ -2000,30 +2025,90 @@ func ensureCRD(ctx context.Context, c client.Client, crd *unstructured.Unstructu
 	return nil
 }
 
-func (r *MultiClusterEngineReconciler) removeDeprecatedRBAC(ctx context.Context) (ctrl.Result, error) {
-	hyperShiftPreviewClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRoleBinding)
-	if err == nil {
-		err = r.Client.Delete(ctx, hyperShiftPreviewClusterRoleBinding)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
-		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, err
-		}
+/*
+EnsureDeprecatedResourceCleanup ensures that a given Kubernetes resource is deleted if it exists.
+It first attempts to fetch the resource, logs if it is already being deleted, and then proceeds
+with deletion if necessary.
+Parameters:
+  - ctx: The context for managing request deadlines and cancellations.
+  - obj: The Kubernetes resource (client.Object) to check and delete.
+
+Returns:
+  - ctrl.Result: An empty result indicating no requeue is needed.
+  - error: Any error encountered while fetching or deleting the resource.
+*/
+func (r *MultiClusterEngineReconciler) EnsureDeprecatedResourceCleanup(ctx context.Context, obj client.Object) (
+	ctrl.Result, error) {
+	/*
+	   Resources can be either namespace-scoped or cluster-scoped.
+	   To accommodate both cases, we first initialize `key` with only the resource name.
+	   If the resource is namespace-scoped, we then set the namespace accordingly.
+	*/
+	key := types.NamespacedName{Name: obj.GetName()}
+
+	// Only set the namespace if the resource is namespace-scoped
+	if obj.GetNamespace() != "" {
+		key.Namespace = obj.GetNamespace()
 	}
-	hyperShiftPreviewClusterRole := &rbacv1.ClusterRole{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, hyperShiftPreviewClusterRole)
-	if err == nil {
-		err = r.Client.Delete(ctx, hyperShiftPreviewClusterRole)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
-		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, err
-		}
+
+	/*
+		Since we are disabling the cache for specific resources, some of the data in the object structure is dropped.
+		By converting the resource, we can get those fields back without needing to cache the resource kinds.
+	*/
+	resource := &unstructured.Unstructured{}
+	if err := r.Scheme.Convert(obj, resource, nil); err != nil {
+		log.Error(err, "failed to convert unstructured object")
 	}
+
+	// Fetch the deprecated resource
+	if err := r.Client.Get(ctx, key, resource); err != nil {
+		// Resource not found, no cleanup needed
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		log.Error(err, "Failed to get resource", "Kind", resource.GetKind(),
+			"Name", resource.GetName(), "Namespace", resource.GetNamespace())
+		return ctrl.Result{}, err
+	}
+
+	// Check if resource is already marked for deletion
+	if obj.GetDeletionTimestamp() != nil {
+		log.Info("Waiting for resource to be terminated", "Kind", resource.GetKind(),
+			"Name", resource.GetName(), "Namespace", resource.GetNamespace(),
+			"DeletionTimestamp", resource.GetDeletionTimestamp())
+
+		return ctrl.Result{RequeueAfter: utils.FastRefreshInterval}, nil
+	}
+
+	// Delete the resource
+	log.Info("Deleting deprecated resource", "Kind", resource.GetKind(), "Name", resource.GetName(),
+		"Namespace", resource.GetNamespace())
+
+	if err := r.Client.Delete(ctx, resource); err != nil {
+		log.Error(err, "Failed to delete resource", "Kind", resource.GetKind(),
+			"Name", resource.GetName(), "Namespace", resource.GetNamespace())
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterEngineReconciler) GetDeprecatedResources(m *backplanev1.MultiClusterEngine) []client.Object {
+	return []client.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "webhook-service",
+				Namespace: m.Spec.TargetNamespace,
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding"},
+			ObjectMeta: metav1.ObjectMeta{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"},
+		},
+		&rbacv1.ClusterRole{
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole"},
+			ObjectMeta: metav1.ObjectMeta{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"},
+		},
+	}
 }

--- a/controllers/toggle_components_test.go
+++ b/controllers/toggle_components_test.go
@@ -5,12 +5,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	"github.com/stolostron/backplane-operator/pkg/status"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -128,64 +126,6 @@ func Test_reconcileLocalHosting(t *testing.T) {
 		t.Errorf("Got status %s, expected %s", component.Type, "Available")
 	}
 	r.StatusManager.Reset("")
-}
-
-func Test_HypershiftPreview(t *testing.T) {
-	scheme := runtime.NewScheme()
-	corev1.AddToScheme(scheme)
-	appsv1.AddToScheme(scheme)
-	backplanev1.AddToScheme(scheme)
-	addonv1alpha1.AddToScheme(scheme)
-	rbacv1.AddToScheme(scheme)
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	images := map[string]string{}
-	// ctx := context.TODO()
-	statusManager := &status.StatusTracker{Client: cl}
-	r := &MultiClusterEngineReconciler{
-		Client:        cl,
-		Scheme:        cl.Scheme(),
-		Images:        images,
-		StatusManager: statusManager,
-	}
-
-	clusterRole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager", // Name of the cluster role
-		},
-		Rules: []rbacv1.PolicyRule{}, // No rules, so it's empty
-	}
-
-	err := cl.Create(context.Background(), clusterRole)
-	if err != nil {
-		wrappedErr := errors.Wrap(err, "failed to create ClusterRole")
-
-		t.Errorf(wrappedErr.Error())
-	}
-
-	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager", // Name of the ClusterRoleBinding
-		},
-		// No subjects and no roleRef, meaning it doesn't bind any ClusterRole
-		Subjects: []rbacv1.Subject{},
-		RoleRef:  rbacv1.RoleRef{},
-	}
-
-	// Create the ClusterRoleBinding in the fake client
-	err = cl.Create(context.Background(), clusterRoleBinding)
-	if err != nil {
-		wrappedErr := errors.Wrap(err, "failed to create ClusterRoleBinding")
-
-		t.Errorf(wrappedErr.Error())
-	}
-	_, err = r.removeDeprecatedRBAC(context.Background())
-	if err != nil {
-		wrappedErr := errors.Wrap(err, "failed to delete")
-
-		t.Errorf(wrappedErr.Error())
-	}
-
 }
 
 func Test_clusterManagementAddOnNotFoundStatus(t *testing.T) {

--- a/pkg/utils/defaults.go
+++ b/pkg/utils/defaults.go
@@ -7,11 +7,20 @@ import (
 )
 
 const (
-	// ShortRefreshInterval is ideal for frequently changing or moderately critical state requiring timely updates.
-	ShortRefreshInterval = 5 * time.Minute
-
-	// ErrorRefreshInterval is used for handling critical errors that require immediate attention.
+	/*
+		ErrorRefreshInterval is used for handling critical errors that require immediate attention.
+	*/
 	ErrorRefreshInterval = 30 * time.Second
+
+	/*
+		FastRefreshInterval is useful for rapidly changing environments where frequent updates are needed.
+	*/
+	FastRefreshInterval = 1 * time.Minute
+
+	/*
+		ShortRefreshInterval is ideal for frequently changing or moderately critical state requiring timely updates.
+	*/
+	ShortRefreshInterval = 5 * time.Minute
 
 	/*
 		WarningRefreshInterval is suitable for addressing warnings or non-critical issues that should still be addressed


### PR DESCRIPTION
# Description

Updated the MCE operator to remove old references to the `webhook-service` Service resource.
Note: Moving forward, squads should not use the default name from `operator-sdk` for `webhook` or `service` resources, the name should be unique to their component.
 
## Related Issue

https://issues.redhat.com/browse/ACM-18091

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
