### PR TITLE
[ACM-18096] Readded setting the controller reference to APIService resources

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1343,14 +1343,29 @@ func (r *MultiClusterEngineReconciler) applyComponentDeploymentOverrides(mce *ba
 	return ctrl.Result{}, nil
 }
 
+func (r *MultiClusterEngineReconciler) ApplyControllerReference(backplaneConfig *backplanev1.MultiClusterEngine,
+	template *unstructured.Unstructured) error {
+	if err := ctrl.SetControllerReference(backplaneConfig, template, r.Scheme); err != nil {
+		log.Error(err, "error setting controller reference on resource", "Kind", template.GetKind(),
+			"Name", template.GetName())
+		return err
+	}
+
+	log.Info("Setting controller reference on resource", "Kind", template.GetKind(), "Name", template.GetName(),
+		"Owner", backplaneConfig.GetName())
+	return nil
+}
+
 func (r *MultiClusterEngineReconciler) applyTemplate(ctx context.Context,
 	backplaneConfig *backplanev1.MultiClusterEngine, template *unstructured.Unstructured) (ctrl.Result, error) {
 
 	if template.GetKind() == "APIService" {
-		result, err := r.ensureUnstructuredResource(ctx, backplaneConfig, template)
-		if err != nil {
-			return result, err
+		// Ensure the controller reference is applied to the resource before proceeding.
+		if err := r.ApplyControllerReference(backplaneConfig, template); err != nil {
+			return ctrl.Result{}, err
 		}
+		return r.ensureUnstructuredResource(ctx, backplaneConfig, template)
+
 	} else {
 		// Check if the namespace exists if the template specifies a namespace.
 		if template.GetNamespace() != backplaneConfig.Spec.TargetNamespace && template.GetNamespace() != "" {
@@ -1376,11 +1391,9 @@ func (r *MultiClusterEngineReconciler) applyTemplate(ctx context.Context,
 				// Set owner reference.
 				// Don't set owner reference on hypershift-addon ManagedClusterAddOn. See ACM-2289
 				if !(template.GetName() == "hypershift-addon" && template.GetKind() == "ManagedClusterAddOn") {
-					err := ctrl.SetControllerReference(backplaneConfig, template, r.Scheme)
-					if err != nil {
-						return ctrl.Result{},
-							fmt.Errorf("error setting controller reference on resource Name: %s Kind: %s Error: %w",
-								template.GetName(), template.GetKind(), err)
+					// Ensure the controller reference is applied to the resource before proceeding.
+					if err := r.ApplyControllerReference(backplaneConfig, template); err != nil {
+						return ctrl.Result{}, err
 					}
 				}
 

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -570,16 +570,7 @@ func (r *MultiClusterEngineReconciler) ensureHive(ctx context.Context, mce *back
 	}
 
 	hiveTemplate := hive.HiveConfig(mce)
-	if err := ctrl.SetControllerReference(mce, hiveTemplate, r.Scheme); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "Error setting controller reference on resource %s", hiveTemplate.GetName())
-	}
-
-	result, err := r.ensureUnstructuredResource(ctx, mce, hiveTemplate)
-	if err != nil {
-		return result, err
-	}
-
-	return ctrl.Result{}, nil
+	return r.ensureUnstructuredResource(ctx, mce, hiveTemplate)
 }
 
 func (r *MultiClusterEngineReconciler) ensureNoHive(ctx context.Context, mce *backplanev1.MultiClusterEngine) (


### PR DESCRIPTION
# Description

In [PR #1244](https://github.com/stolostron/backplane-operator/pull/1244), we updated the logging in our operator to indicate when a resource is created for the first time. However, during the process of reorganizing some logic, we inadvertently moved the SetControllerReference call to a later part of the function. As a result, the APIService resources were unable to have a controller reference set. Since MCE relies on garbage collection to clean up resources, these resources were not being removed from the cluster, causing the uninstall process to hang when initiated.

## Related Issue

https://issues.redhat.com/browse/ACM-18096

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
