### PR TITLE
[ACM-18235] Enable IBIO before prune IBIO-preview

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1902,6 +1902,13 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		updateNecessary = true
 	}
 
+	if m.Enabled(backplanev1.ImageBasedInstallOperatorPreview) {
+		// if the preview was pruned, enable the non-preview version instead
+		m.Enable(backplanev1.ImageBasedInstallOperator)
+
+		// no need to disable -preview version, as it will get pruned below
+		updateNecessary = true
+	}
 	// image based install operator preview component upgraded in ACM 2.12.0
 	if m.Prune(backplanev1.ImageBasedInstallOperatorPreview) {
 		updateNecessary = true


### PR DESCRIPTION
When upgrading from 2.6 to 2.8, it was discovered that IBIO would be disabled, even if IBIO-preview had been enabled by the customer in 2.6, this PR will resolve that issue by ensuring that the GA version will inherit the preview version enabled status.

Related issue: https://issues.redhat.com/browse/ACM-18235