### PR TITLE
ValidateUpdate now blocks renaming local-cluster

### DIFF
--- a/api/v1/multiclusterengine_webhook_test.go
+++ b/api/v1/multiclusterengine_webhook_test.go
@@ -130,16 +130,20 @@ var _ = Describe("Multiclusterengine webhook", func() {
 				}
 				Expect(k8sClient.Update(ctx, mce)).NotTo(BeNil(), "invalid components should not be permitted")
 			})
+
+			By("because of existing local-cluster resource", func() {
+				managedCluster := NewManagedCluster(mce.Spec.LocalClusterName)
+				Expect(k8sClient.Create(ctx, managedCluster)).To(Succeed())
+
+				mce.Spec.LocalClusterName = "updated-local-cluster"
+				Expect(k8sClient.Update(ctx, mce)).NotTo(BeNil(), "updating local-Cluster name while one exists should not be permitted")
+			})
 		})
 
 		It("Should succeed in deleting multiclusterengine", func() {
 			mce := &MultiClusterEngine{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())
 
-			By("Creating the managedCluster", func() {
-				managedCluster := NewManagedCluster(mce.Spec.LocalClusterName)
-				Expect(k8sClient.Create(ctx, managedCluster)).To(Succeed())
-			})
 			By("Deleting the multiclusterengine", func() {
 				Expect(k8sClient.Delete(ctx, mce)).To(Succeed())
 			})


### PR DESCRIPTION
# Description

Setting Spec.LocalClusterName should be blocked if local-cluster resource exists (is enabled)

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
