### PR TITLE
[ACM-20312] Webhook should block updating local-cluster name if managed by ACM

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -258,3 +258,14 @@ func GetLegacyServiceMonitorName(component string) (string, error) {
 		return val, nil
 	}
 }
+
+// IsACMManaged returns true if operator is managed by ACM
+func IsACMManaged(mce *MultiClusterEngine) bool {
+	managedByACMLabel := "multiclusterhubs.operator.open-cluster-management.io/managed-by"
+	if labels := mce.GetLabels(); labels != nil {
+		if labels[managedByACMLabel] == "true" {
+			return true
+		}
+	}
+	return false
+}

--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -259,9 +259,14 @@ func (r *MultiClusterEngine) ValidateUpdate(old runtime.Object) (admission.Warni
 		}
 	}
 
-	// Block changing localClusterName if ManagedCluster with label `local-cluster = true` exists
 	// if the Spec.LocalClusterName field has changed
 	if oldMCE.Spec.LocalClusterName != r.Spec.LocalClusterName {
+		// block changing localClusterName if the label `managedBy` is set to `true`
+		if IsACMManaged(r) {
+			return nil, fmt.Errorf("cannot update Spec.LocalClusterName from MCE CR when managed by ACM")
+		}
+
+		// Block changing localClusterName if ManagedCluster with label `local-cluster = true` exists
 		ctx := context.Background()
 		managedClusterGVK := schema.GroupVersionKind{
 			Group:   "cluster.open-cluster-management.io",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -275,17 +275,6 @@ func isCommunityMode() bool {
 	}
 }
 
-// isACMManaged returns true if operator is managed by ACM
-func isACMManaged(mce *backplanev1.MultiClusterEngine) bool {
-	managedByACMLabel := "multiclusterhubs.operator.open-cluster-management.io/managed-by"
-	if labels := mce.GetLabels(); labels != nil {
-		if labels[managedByACMLabel] == "true" {
-			return true
-		}
-	}
-	return false
-}
-
 // HubType defines the circumstances of how MCE is being run
 type HubType string
 
@@ -303,7 +292,7 @@ const (
 // GetHubType returns the HubType which defines the circumstances of how MCE is being run
 func GetHubType(mce *backplanev1.MultiClusterEngine) string {
 	isCommunity := isCommunityMode()
-	isManaged := isACMManaged(mce)
+	isManaged := backplanev1.IsACMManaged(mce)
 	if isCommunity {
 		if isManaged {
 			return string(HubTypeStolostron)


### PR DESCRIPTION
# Description

Webhook should block updating local-cluster name if managed by ACM

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
