### PR TITLE
[ACM-19424] Updated logic to support generic preview component pruning

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -71,8 +71,8 @@ var allComponents = []string{
 // MCEComponents is a slice containing component names specific to the "MCE" category.
 var MCEComponents = []string{
 	AssistedService,
-	ClusterAPIPreview,
-	ClusterAPIProviderAWSPreview,
+	ClusterAPI,
+	ClusterAPIProviderAWS,
 	ClusterLifecycle,
 	ClusterManager,
 	ClusterProxyAddon,

--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -87,6 +87,30 @@ var MCEComponents = []string{
 }
 
 /*
+PreviewComponents is a list of all MCE component names that represent preview (tech preview) features.
+These components are candidates for pruning when the stable version replaces them.
+*/
+var PreviewComponents = []string{
+	ClusterAPIPreview,
+	ClusterAPIProviderAWSPreview,
+	HyperShiftPreview,
+	ImageBasedInstallOperatorPreview,
+	ManagedServiceAccountPreview,
+}
+
+/*
+PreviewToStable maps each preview component to its corresponding stable replacement.
+This mapping is used to enable the stable component when the preview version is pruned.
+*/
+var PreviewToStable = map[string]string{
+	ClusterAPIPreview:                ClusterAPI,                // Upgraded in ACM 2.14 / MCE 2.9
+	ClusterAPIProviderAWSPreview:     ClusterAPIProviderAWS,     // Upgraded in ACM 2.14 / MCE 2.9
+	HyperShiftPreview:                HyperShift,                // Upgraded in ACM 2.8 / MCE 2.3
+	ImageBasedInstallOperatorPreview: ImageBasedInstallOperator, // Upgraded in ACM 2.12 / MCE 2.7
+	ManagedServiceAccountPreview:     ManagedServiceAccount,     // Upgraded in ACM 2.9 / MCE 2.4
+}
+
+/*
 LegacyConfigKind is a slice of strings that represents the legacy resource kinds
 supported by the Operator SDK and Prometheus. These kinds include "PrometheusRule", "Service",
 and "ServiceMonitor".

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -918,19 +918,19 @@ func (r *MultiClusterEngineReconciler) ensureNoInternalEngineComponent(ctx conte
 
 func (r *MultiClusterEngineReconciler) fetchChartOrCRDPath(component string) string {
 	chartDirs := map[string]string{
-		backplanev1.AssistedService:              toggle.AssistedServiceChartDir,
-		backplanev1.ClusterAPIPreview:            toggle.ClusterAPIChartDir,
-		backplanev1.ClusterAPIProviderAWSPreview: toggle.ClusterAPIProviderAWSChartDir,
-		backplanev1.ClusterLifecycle:             toggle.ClusterLifecycleChartDir,
-		backplanev1.ClusterManager:               toggle.ClusterManagerChartDir,
-		backplanev1.ClusterProxyAddon:            toggle.ClusterProxyAddonDir,
-		backplanev1.ConsoleMCE:                   toggle.ConsoleMCEChartsDir,
-		backplanev1.Discovery:                    toggle.DiscoveryChartDir,
-		backplanev1.Hive:                         toggle.HiveChartDir,
-		backplanev1.HyperShift:                   toggle.HyperShiftChartDir,
-		backplanev1.ImageBasedInstallOperator:    toggle.ImageBasedInstallOperatorChartDir,
-		backplanev1.ManagedServiceAccount:        toggle.ManagedServiceAccountChartDir,
-		backplanev1.ServerFoundation:             toggle.ServerFoundationChartDir,
+		backplanev1.AssistedService:           toggle.AssistedServiceChartDir,
+		backplanev1.ClusterAPI:                toggle.ClusterAPIChartDir,
+		backplanev1.ClusterAPIProviderAWS:     toggle.ClusterAPIProviderAWSChartDir,
+		backplanev1.ClusterLifecycle:          toggle.ClusterLifecycleChartDir,
+		backplanev1.ClusterManager:            toggle.ClusterManagerChartDir,
+		backplanev1.ClusterProxyAddon:         toggle.ClusterProxyAddonDir,
+		backplanev1.ConsoleMCE:                toggle.ConsoleMCEChartsDir,
+		backplanev1.Discovery:                 toggle.DiscoveryChartDir,
+		backplanev1.Hive:                      toggle.HiveChartDir,
+		backplanev1.HyperShift:                toggle.HyperShiftChartDir,
+		backplanev1.ImageBasedInstallOperator: toggle.ImageBasedInstallOperatorChartDir,
+		backplanev1.ManagedServiceAccount:     toggle.ManagedServiceAccountChartDir,
+		backplanev1.ServerFoundation:          toggle.ServerFoundationChartDir,
 	}
 
 	if dir, exists := chartDirs[component]; exists {
@@ -1160,13 +1160,13 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 		}
 	}
 
-	if backplaneConfig.Enabled(backplanev1.ClusterAPIPreview) {
+	if backplaneConfig.Enabled(backplanev1.ClusterAPI) {
 		result, err = r.ensureClusterAPI(ctx, backplaneConfig)
 		if result != (ctrl.Result{}) {
 			requeue = true
 		}
 		if err != nil {
-			errs[backplanev1.ClusterAPIPreview] = err
+			errs[backplanev1.ClusterAPI] = err
 		}
 	} else {
 		result, err = r.ensureNoClusterAPI(ctx, backplaneConfig)
@@ -1174,17 +1174,17 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 			requeue = true
 		}
 		if err != nil {
-			errs[backplanev1.ClusterAPIPreview] = err
+			errs[backplanev1.ClusterAPI] = err
 		}
 	}
 
-	if backplaneConfig.Enabled(backplanev1.ClusterAPIProviderAWSPreview) {
+	if backplaneConfig.Enabled(backplanev1.ClusterAPIProviderAWS) {
 		result, err = r.ensureClusterAPIProviderAWS(ctx, backplaneConfig)
 		if result != (ctrl.Result{}) {
 			requeue = true
 		}
 		if err != nil {
-			errs[backplanev1.ClusterAPIProviderAWSPreview] = err
+			errs[backplanev1.ClusterAPIProviderAWS] = err
 		}
 	} else {
 		result, err = r.ensureNoClusterAPIProviderAWS(ctx, backplaneConfig)
@@ -1192,7 +1192,7 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 			requeue = true
 		}
 		if err != nil {
-			errs[backplanev1.ClusterAPIProviderAWSPreview] = err
+			errs[backplanev1.ClusterAPIProviderAWS] = err
 		}
 	}
 
@@ -1563,8 +1563,8 @@ func (r *MultiClusterEngineReconciler) ensureNoAllInternalEngineComponents(ctx c
 
 	components := []string{
 		backplanev1.AssistedService,
-		backplanev1.ClusterAPIPreview,
-		backplanev1.ClusterAPIProviderAWSPreview,
+		backplanev1.ClusterAPI,
+		backplanev1.ClusterAPIProviderAWS,
 		backplanev1.ClusterLifecycle,
 		backplanev1.ClusterManager,
 		backplanev1.ClusterProxyAddon,
@@ -1891,11 +1891,16 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 	for _, preview := range backplanev1.PreviewComponents {
 		if m.Enabled(preview) {
 			if stable, exists := backplanev1.PreviewToStable[preview]; exists {
+				log.Info("Stable component version enabled due to preview being enabled",
+					"preview", preview,
+					"stable", stable,
+				)
 				m.Enable(stable)
 			}
 		}
 
 		if m.Prune(preview) {
+			log.Info("Pruning preview component", "preview", preview)
 			updateNecessary = true
 		}
 	}

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -401,11 +401,11 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: true,
 								},
 								{
-									Name:    backplanev1.ClusterAPIPreview,
+									Name:    backplanev1.ClusterAPI,
 									Enabled: true,
 								},
 								{
-									Name:    backplanev1.ClusterAPIProviderAWSPreview,
+									Name:    backplanev1.ClusterAPIProviderAWS,
 									Enabled: true,
 								},
 								{
@@ -580,11 +580,11 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: false,
 								},
 								{
-									Name:    backplanev1.ClusterAPIProviderAWSPreview,
+									Name:    backplanev1.ClusterAPIProviderAWS,
 									Enabled: false,
 								},
 								{
-									Name:    backplanev1.ClusterAPIPreview,
+									Name:    backplanev1.ClusterAPI,
 									Enabled: false,
 								},
 								{
@@ -861,13 +861,13 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: true,
 								},
 								{
-									Name:    backplanev1.ClusterAPIPreview,
+									Name:    backplanev1.ClusterAPI,
 									Enabled: true,
 								},
 								// EnvTest does not support namespace deletion; therefore, if we try to re-enable this component, the test will fail.
 								// https: //book.kubebuilder.io/reference/envtest
 								// {
-								// 	Name:    backplanev1.ClusterAPIProviderAWSPreview,
+								// 	Name:    backplanev1.ClusterAPIProviderAWS,
 								// 	Enabled: false,
 								// },
 								{
@@ -975,11 +975,11 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: false,
 								},
 								{
-									Name:    backplanev1.ClusterAPIPreview,
+									Name:    backplanev1.ClusterAPI,
 									Enabled: false,
 								},
 								{
-									Name:    backplanev1.ClusterAPIProviderAWSPreview,
+									Name:    backplanev1.ClusterAPIProviderAWS,
 									Enabled: false,
 								},
 								{

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -390,12 +390,12 @@ func (r *MultiClusterEngineReconciler) ensureClusterAPI(ctx context.Context, mce
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
 	// Ensure that the InternalHubComponent CR instance is created for component in MCE.
-	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.ClusterAPIPreview); err != nil {
+	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.ClusterAPI); err != nil {
 		return result, err
 	}
 
 	// Renders all templates from charts
-	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPIPreview)
+	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPI)
 	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
 
 	if len(errs) > 0 {
@@ -406,7 +406,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterAPI(ctx context.Context, mce
 	}
 
 	// Apply deployment config overrides
-	if result, err := r.applyComponentDeploymentOverrides(mce, templates, backplanev1.ClusterAPIPreview); err != nil {
+	if result, err := r.applyComponentDeploymentOverrides(mce, templates, backplanev1.ClusterAPI); err != nil {
 		return result, err
 	}
 
@@ -428,12 +428,12 @@ func (r *MultiClusterEngineReconciler) ensureNoClusterAPI(ctx context.Context,
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
 	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
-		backplanev1.ClusterAPIPreview); (result != ctrl.Result{}) || err != nil {
+		backplanev1.ClusterAPI); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
 	// Renders all templates from charts
-	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPIPreview)
+	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPI)
 	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
 
 	if len(errs) > 0 {
@@ -465,12 +465,12 @@ func (r *MultiClusterEngineReconciler) ensureClusterAPIProviderAWS(ctx context.C
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
 	// Ensure that the InternalHubComponent CR instance is created for component in MCE.
-	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.ClusterAPIProviderAWSPreview); err != nil {
+	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.ClusterAPIProviderAWS); err != nil {
 		return result, err
 	}
 
 	// Renders all templates from charts
-	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPIProviderAWSPreview)
+	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPIProviderAWS)
 	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
 
 	if len(errs) > 0 {
@@ -481,7 +481,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterAPIProviderAWS(ctx context.C
 	}
 
 	// Apply deployment config overrides
-	if result, err := r.applyComponentDeploymentOverrides(mce, templates, backplanev1.ClusterAPIProviderAWSPreview); err != nil {
+	if result, err := r.applyComponentDeploymentOverrides(mce, templates, backplanev1.ClusterAPIProviderAWS); err != nil {
 		return result, err
 	}
 
@@ -503,12 +503,12 @@ func (r *MultiClusterEngineReconciler) ensureNoClusterAPIProviderAWS(ctx context
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
 	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
-		backplanev1.ClusterAPIProviderAWSPreview); (result != ctrl.Result{}) || err != nil {
+		backplanev1.ClusterAPIProviderAWS); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
 	// Renders all templates from charts
-	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPIProviderAWSPreview)
+	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterAPIProviderAWS)
 	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
 
 	if len(errs) > 0 {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -61,8 +61,8 @@ var onComponents = []string{
 }
 
 var offComponents = []string{
-	backplanev1.ClusterAPIPreview,
-	backplanev1.ClusterAPIProviderAWSPreview,
+	backplanev1.ClusterAPI,
+	backplanev1.ClusterAPIProviderAWS,
 	backplanev1.ImageBasedInstallOperator,
 }
 


### PR DESCRIPTION
# Description

As we onboard `tech-preview` components into ACM/MCE, it's important to ensure a smooth transition to `stable` and GA status. Specifically, we need to safely remove the `-preview` version while maintaining the necessary configuration for the new stable component required by our CR. This PR introduces a generic solution to handle the duplication involved in pruning and enabling individual components within our operator.

## Related Issue

https://issues.redhat.com/browse/ACM-19424
https://issues.redhat.com/browse/ACM-19598
https://issues.redhat.com/browse/ACM-19601

## Changes Made

Improved controller logic to more effectively manage the transition from `preview` to `stable` components.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Related logs
```bash
2025-05-08T15:01:28.408Z INFO reconcile Stable component version enabled due to preview being enabled {"preview": "cluster-api-preview", "stable": "cluster-api"}
2025-05-08T15:01:28.408Z INFO reconcile Pruning preview component {"preview": "cluster-api-preview"}
2025-05-08T15:01:28.408Z INFO reconcile Pruning preview component {"preview": "cluster-api-provider-aws-preview"}
2025-05-08T15:01:28.408Z INFO reconcile Stable component version enabled due to preview being enabled {"preview": "hypershift-preview", "stable": "hypershift"}
2025-05-08T15:01:28.408Z INFO reconcile Pruning preview component {"preview": "hypershift-preview"}
2025-05-08T15:01:28.408Z INFO reconcile Stable component version enabled due to preview being enabled {"preview": "image-based-install-operator-preview", "stable": "image-based-install-operator"}
2025-05-08T15:01:28.408Z INFO reconcile Pruning preview component {"preview": "image-based-install-operator-preview"}
```

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [x] Approved by at least one reviewer.
- [x] Merged into the main/master branch.
