### PR TITLE
Cap local-cluster name to 34 chars

### DIFF
--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -178,6 +178,10 @@ func (r *MultiClusterEngine) ValidateCreate() (admission.Warnings, error) {
 		targetNS = DefaultTargetNamespace
 	}
 
+	if err := validateLocalClusterNameLength(r.Spec.LocalClusterName); err != nil {
+		return nil, err
+	}
+
 	for _, mce := range mceList.Items {
 		mce := mce
 		if mce.Spec.TargetNamespace == targetNS || (targetNS == DefaultTargetNamespace && mce.Spec.TargetNamespace == "") {
@@ -190,6 +194,13 @@ func (r *MultiClusterEngine) ValidateCreate() (admission.Warnings, error) {
 		}
 	}
 	return nil, nil
+}
+
+func validateLocalClusterNameLength(name string) (err error) {
+	if len(name) >= 64 {
+		return fmt.Errorf("local-cluster name must be shorter than 64 characters")
+	}
+	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -261,6 +272,9 @@ func (r *MultiClusterEngine) ValidateUpdate(old runtime.Object) (admission.Warni
 
 	// if the Spec.LocalClusterName field has changed
 	if oldMCE.Spec.LocalClusterName != r.Spec.LocalClusterName {
+		if err := validateLocalClusterNameLength(r.Spec.LocalClusterName); err != nil {
+			return nil, err
+		}
 		// block changing localClusterName if the label `managedBy` is set to `true`
 		if IsACMManaged(r) {
 			logf.Log.Info("MCE is managed by ACM, local-cluster name will be set through MultiClusterHub CR")

--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -197,8 +197,8 @@ func (r *MultiClusterEngine) ValidateCreate() (admission.Warnings, error) {
 }
 
 func validateLocalClusterNameLength(name string) (err error) {
-	if len(name) >= 64 {
-		return fmt.Errorf("local-cluster name must be shorter than 64 characters")
+	if len(name) >= 35 {
+		return fmt.Errorf("local-cluster name must be shorter than 35 characters")
 	}
 	return nil
 }

--- a/api/v1/multiclusterengine_webhook_test.go
+++ b/api/v1/multiclusterengine_webhook_test.go
@@ -4,6 +4,7 @@ package v1
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -145,6 +146,11 @@ var _ = Describe("Multiclusterengine webhook", func() {
 
 				mce.Spec.LocalClusterName = "updated-local-cluster"
 				Expect(k8sClient.Update(ctx, mce)).NotTo(BeNil(), "updating local-Cluster name while one exists should not be permitted")
+			})
+
+			By("because the local-cluster name must be less than 35 characters long", func() {
+				mce.Spec.LocalClusterName = strings.Repeat("t", 35)
+				Expect(k8sClient.Update(ctx, mce)).NotTo(BeNil(), "local-cluster name must be less than 35 characters long")
 			})
 		})
 


### PR DESCRIPTION
# Description

Through speaking with other teams and QE, it seems that exceeding 39 characters in length (yes 39, not 34) will cause MCE installed components to fail due to how components tack on information to existing resource names, causing them to exceed the Kubernetes allowed 63 character limit. The 34 character limit is to make sure that we don't get close to that number.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
