### PR TITLE
[ACM-20980] Removed unneeded image references for hypershift

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-configmap.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-configmap.yaml
@@ -13,25 +13,6 @@ data:
       lookupPolicy:
         local: false
       tags:
-      - name: apiserver-network-proxy
-        annotations:
-          io.openshift.build.source-location: https://github.com/openshift/apiserver-network-proxy
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.apiserver_network_proxy }}
-      - name: aws-encryption-provider
-        annotations:
-          io.openshift.build.source-location: https://github.com/openshift/aws-encryption-provider
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.aws_encryption_provider }}
-      - name: cluster-api
-        annotations:
-          io.openshift.build.commit.id: e09ed61cc9ba8bd37b0760291c833b4da744a985
-          io.openshift.build.source-location: https://github.com/openshift/cluster-api
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.cluster_api }}
       - name: cluster-api-provider-agent
         annotations:
           io.openshift.build.commit.id: dd6353f609dc9e7bfd0312ce4b2c8d3dac5d749e
@@ -39,13 +20,6 @@ data:
         from:
           kind: DockerImage
           name: {{ .Values.global.imageOverrides.cluster_api_provider_agent }}
-      - name: cluster-api-provider-aws
-        annotations:
-          io.openshift.build.commit.id: 0b2e34680d117b1d8146965f3123c04709d37951
-          io.openshift.build.source-location: https://github.com/openshift/cluster-api-provider-aws
-        from:
-          kind: DockerImage
-          name: {{ .Values.global.imageOverrides.cluster_api_provider_aws }}
       - name: cluster-api-provider-kubevirt
         annotations:
           io.openshift.build.commit.id: 'dbdc825088513dc962ba2103efe2c1a4eb3cf524'

--- a/pkg/templates/charts/toggle/hypershift/values.yaml
+++ b/pkg/templates/charts/toggle/hypershift/values.yaml
@@ -1,11 +1,7 @@
 global:
   imageOverrides:
     hypershift_addon_operator: ""
-    apiserver_network_proxy: ""
-    aws_encryption_provider: ""
-    cluster_api: ""
     cluster_api_provider_agent: ""
-    cluster_api_provider_aws: ""
     hypershift_operator: ""
     cluster_api_provider_kubevirt: ""
     kube_rbac_proxy_mce: "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -187,10 +187,9 @@ func GetTestImages() []string {
 		"clusterlifecycle_state_metrics", "clusterclaims_controller", "provider_credential_controller",
 		"managed_serviceaccount", "assisted_service", "assisted_image_service", "postgresql_12",
 		"assisted_installer_agent", "assisted_installer_controller", "assisted_installer", "console_mce",
-		"hypershift_addon_operator", "hypershift_operator", "apiserver_network_proxy", "aws_encryption_provider",
-		"cluster_api", "cluster_api_provider_agent", "cluster_api_provider_aws", "cluster_api_provider_kubevirt",
-		"kube_rbac_proxy_mce", "cluster_proxy_addon", "cluster_proxy", "cluster_image_set_controller",
-		"image_based_install_operator"}
+		"hypershift_addon_operator", "hypershift_operator", "cluster_api_provider_agent",
+		"cluster_api_provider_kubevirt", "kube_rbac_proxy_mce", "cluster_proxy_addon", "cluster_proxy",
+		"cluster_image_set_controller", "image_based_install_operator"}
 }
 
 func IsUnitTest() bool {


### PR DESCRIPTION
# Description

Removed the following off-boarded images from `hypershift-preview` chart for MCE 2.5.z:
- apiserver-network-proxy
- aws-encryption-provider
- cluster-api
- cluster-api-provider-aws
- cluster-api-provider-azure

## Related Issue

https://issues.redhat.com/browse/ACM-20980

## Changes Made

Updated `hypershift-preview` chart to remove recent  off-boarded images.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
