### PR TITLE
pass MCH namespace to MCE rendering

### DIFF
--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -52,6 +52,7 @@ type HubConfig struct {
 	ReplicaCount         int               `json:"replicaCount" structs:"replicaCount"`
 	Tolerations          []Toleration      `json:"tolerations" structs:"tolerations"`
 	OCPVersion           string            `json:"ocpVersion" structs:"ocpVersion"`
+	MCHNamespace         string            `json:"mCHNamespace" structs:"mCHNamespace"`
 	ClusterIngressDomain string            `json:"clusterIngressDomain" structs:"clusterIngressDomain"`
 	HubType              string            `json:"hubType" structs:"hubType"`
 	EnableFlightCtl      bool              `json:"enableFlightCtl" structs:"enableFlightCtl"`
@@ -353,6 +354,8 @@ func injectValuesOverrides(values *Values, backplaneConfig *v1.MultiClusterEngin
 		}
 	}
 	values.HubConfig.ReplicaCount = utils.DefaultReplicaCount(backplaneConfig)
+
+	values.HubConfig.MCHNamespace = utils.GetMCHNamespace(backplaneConfig)
 
 	values.HubConfig.NodeSelector = backplaneConfig.Spec.NodeSelector
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -225,6 +225,14 @@ func IsUnitTest() bool {
 	return false
 }
 
+func GetMCHNamespace(m *backplanev1.MultiClusterEngine) string {
+	val, ok := m.Labels["installer.namespace"]
+	if ok {
+		return val
+	}
+	return ""
+}
+
 func DefaultTolerations() []corev1.Toleration {
 	return []corev1.Toleration{
 		{


### PR DESCRIPTION
# Description

Server foundation has requested a flag in MCE which reports the MCH namespace so that they are able to accurately depict the flight control server name. I have taken it from the installer labels which are generated when MCH creates or adopts MCE

## Related Issue

https://issues.redhat.com/browse/ACM-17903

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
