### PR TITLE
Updated cluster-api-installer branch ref to target backplane-2.9 instead of main

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -955,14 +955,6 @@ rules:
 - apiGroups:
   - apiextensions.k8s.io
   resources:
-  - customresourcedefinitions
-  - customresourcedefinitions/status
-  verbs:
-  - patch
-  - update
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
   - customresourcedefinitions/status
   verbs:
   - patch
@@ -1588,7 +1580,6 @@ rules:
   - clusters
   - clusters/finalizers
   - clusters/status
-  - machinedrainrules
   - machinehealthchecks/finalizers
   - machinehealthchecks/status
   verbs:
@@ -1704,6 +1695,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedrainrules
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - cluster.x-k8s.io
@@ -2442,22 +2441,9 @@ rules:
 - apiGroups:
   - ipam.cluster.x-k8s.io
   resources:
-  - ipaddressclaims
-  - ipaddresses
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ipam.cluster.x-k8s.io
-  resources:
   - ipaddressclaims/status
   verbs:
   - get
-  - patch
-  - update
   - watch
 - apiGroups:
   - ipam.cluster.x-k8s.io

--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -19,7 +19,7 @@
 
 - repo_name: "cluster-api-installer"
   github_ref: "https://github.com/stolostron/cluster-api-installer.git"
-  branch: "main"
+  branch: "backplane-2.9"
   charts:
     - name: "cluster-api"
       chart-path: "charts/cluster-api"

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/Chart.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: cluster-api-provider-aws
+appVersion: '4.19'
 description: Cluster API provider for AWS
+name: cluster-api-provider-aws
 type: application
-version: "4.19"
-appVersion: "4.19"
+version: '2.9'

--- a/pkg/templates/charts/toggle/cluster-api-provider-metal3/Chart.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-metal3/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: cluster-api-provider-metal3
+appVersion: '4.19'
 description: Cluster API provider for Metal3
+name: cluster-api-provider-metal3
 type: application
-version: "4.19"
-appVersion: "4.19"
+version: '2.9'

--- a/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/Chart.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: cluster-api-provider-openshift-assisted
+appVersion: '2.9'
 description: Cluster API Bootstrap and Controlplane providers for OpenShift Assisted Installer
+name: cluster-api-provider-openshift-assisted
 type: application
-version: "0.0.0-dev"
-appVersion: "0.0.0-dev"
+version: '2.9'

--- a/pkg/templates/charts/toggle/cluster-api/Chart.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: cluster-api
+appVersion: '4.19'
 description: Cluster API
+name: cluster-api
 type: application
-version: "4.19"
-appVersion: "4.19"
+version: '2.9'

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-controller-manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-controller-manager-deployment.yaml
@@ -45,7 +45,8 @@ spec:
         - --leader-elect
         - --diagnostics-address=:8443
         - --insecure-diagnostics=false
-        - --feature-gates=MachinePool=true,ClusterResourceSet=true,ClusterTopology=false,RuntimeSDK=false,MachineSetPreflightChecks=true,MachineWaitForVolumeDetachConsiderVolumeAttachments=true,PriorityQueue=false
+        - --use-deprecated-infra-machine-naming=false
+        - --feature-gates=MachinePool=true,ClusterResourceSet=true,ClusterTopology=false,RuntimeSDK=false,MachineSetPreflightChecks=true,MachineWaitForVolumeDetachConsiderVolumeAttachments=true
         command:
         - /bin/cluster-api-controller-manager
         env:

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-manager-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-manager-role-clusterrole.yaml
@@ -9,39 +9,10 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ''
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ''
-  resources:
   - namespaces
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - ''
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - addons.cluster.x-k8s.io
@@ -76,28 +47,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apiextensions.k8s.io
-  resourceNames:
-  - clusterclasses.cluster.x-k8s.io
-  - clusterresourcesetbindings.addons.cluster.x-k8s.io
-  - clusterresourcesets.addons.cluster.x-k8s.io
-  - clusters.cluster.x-k8s.io
-  - extensionconfigs.runtime.cluster.x-k8s.io
-  - ipaddressclaims.ipam.cluster.x-k8s.io
-  - ipaddresses.ipam.cluster.x-k8s.io
-  - machinedeployments.cluster.x-k8s.io
-  - machinedrainrules.cluster.x-k8s.io
-  - machinehealthchecks.cluster.x-k8s.io
-  - machinepools.cluster.x-k8s.io
-  - machines.cluster.x-k8s.io
-  - machinesets.cluster.x-k8s.io
-  resources:
-  - customresourcedefinitions
-  - customresourcedefinitions/status
-  verbs:
-  - patch
-  - update
-- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -117,7 +66,6 @@ rules:
   - clusters
   - clusters/finalizers
   - clusters/status
-  - machinedrainrules
   - machinehealthchecks/finalizers
   - machinehealthchecks/status
   verbs:
@@ -151,11 +99,37 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ipam.cluster.x-k8s.io
+  - cluster.x-k8s.io
   resources:
-  - ipaddressclaims
-  - ipaddresses
+  - machinedrainrules
   verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
   - get
   - list
   - patch
@@ -164,10 +138,11 @@ rules:
 - apiGroups:
   - ipam.cluster.x-k8s.io
   resources:
-  - ipaddressclaims/status
+  - ipaddressclaims
   verbs:
-  - patch
-  - update
+  - get
+  - list
+  - watch
 - apiGroups:
   - runtime.cluster.x-k8s.io
   resources:

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -58,28 +58,6 @@ webhooks:
     service:
       name: capi-webhook-service
       namespace: '{{ default "capi-system" .Values.global.namespace }}'
-      path: /mutate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.clusterresourceset.addons.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - addons.cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusterresourcesets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: capi-webhook-service
-      namespace: '{{ default "capi-system" .Values.global.namespace }}'
       path: /mutate-cluster-x-k8s-io-v1beta1-machine
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -204,4 +182,26 @@ webhooks:
     - UPDATE
     resources:
     - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: '{{ default "capi-system" .Values.global.namespace }}'
+      path: /mutate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
   sideEffects: None

--- a/pkg/templates/charts/toggle/cluster-api/templates/capi-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/capi-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -60,50 +60,6 @@ webhooks:
     service:
       name: capi-webhook-service
       namespace: '{{ default "capi-system" .Values.global.namespace }}'
-      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.clusterresourceset.addons.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - addons.cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusterresourcesets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: capi-webhook-service
-      namespace: '{{ default "capi-system" .Values.global.namespace }}'
-      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourcesetbinding
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.clusterresourcesetbinding.addons.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - addons.cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusterresourcesetbindings
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: capi-webhook-service
-      namespace: '{{ default "capi-system" .Values.global.namespace }}'
       path: /validate-cluster-x-k8s-io-v1beta1-machine
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -250,6 +206,50 @@ webhooks:
     - UPDATE
     resources:
     - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: '{{ default "capi-system" .Values.global.namespace }}'
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: '{{ default "capi-system" .Values.global.namespace }}'
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourcesetbinding
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourcesetbinding.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesetbindings
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_clusterclasses.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_clusterclasses.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -63,7 +63,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of ClusterClass.
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
             properties:
               controlPlane:
                 description: |-
@@ -72,7 +72,7 @@ spec:
                 properties:
                   machineInfrastructure:
                     description: |-
-                      machineInfrastructure defines the metadata and infrastructure information
+                      MachineTemplate defines the metadata and infrastructure information
                       for control plane machines.
 
                       This field is supported if and only if the control plane provider template
@@ -147,7 +147,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -407,7 +407,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
                                     More info: http://kubernetes.io/docs/user-guide/labels
@@ -457,47 +457,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of ClusterClass.
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
             properties:
-              availabilityGates:
-                description: |-
-                  availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
-
-                  NOTE: this field is considered only for computing v1beta2 conditions.
-                  NOTE: If a Cluster is using this ClusterClass, and this Cluster defines a custom list of availabilityGates,
-                  such list overrides availabilityGates defined in this field.
-                items:
-                  description: ClusterAvailabilityGate contains the type of a Cluster
-                    condition to be used as availability gate.
-                  properties:
-                    conditionType:
-                      description: |-
-                        conditionType refers to a condition with matching type in the Cluster's condition list.
-                        If the conditions doesn't exist, it will be treated as unknown.
-                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
-                      maxLength: 316
-                      minLength: 1
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                    polarity:
-                      description: |-
-                        polarity of the conditionType specified in this availabilityGate.
-                        Valid values are Positive, Negative and omitted.
-                        When omitted, the default behaviour will be Positive.
-                        A positive polarity means that the condition should report a true status under normal conditions.
-                        A negative polarity means that the condition should report a false status under normal conditions.
-                      enum:
-                      - Positive
-                      - Negative
-                      type: string
-                  required:
-                  - conditionType
-                  type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - conditionType
-                x-kubernetes-list-type: map
               controlPlane:
                 description: |-
                   controlPlane is a reference to a local struct that holds the details
@@ -514,8 +475,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxUnhealthy specifies the maximum number of unhealthy machines allowed.
-                          Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                          Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
                           "selector" are not healthy.
                         x-kubernetes-int-or-string: true
                       nodeStartupTimeout:
@@ -594,19 +554,11 @@ spec:
                             status for at least the timeout value, a node is considered unhealthy.
                           properties:
                             status:
-                              description: status of the condition, one of True, False,
-                                Unknown.
                               minLength: 1
                               type: string
                             timeout:
-                              description: |-
-                                timeout is the duration that a node must be in a given status for,
-                                after which the node is considered unhealthy.
-                                For example, with a value of "1h", the node must match the status
-                                for at least 1 hour before being considered unhealthy.
                               type: string
                             type:
-                              description: type of Node condition
                               minLength: 1
                               type: string
                           required:
@@ -614,18 +566,14 @@ spec:
                           - timeout
                           - type
                           type: object
-                        maxItems: 100
                         type: array
                       unhealthyRange:
                         description: |-
-                          unhealthyRange specifies the range of unhealthy machines allowed.
                           Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                          is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                          is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
                           Eg. "[3-5]" - This means that remediation will be allowed only when:
                           (a) there are at least 3 unhealthy machines (and)
                           (b) there are at most 5 unhealthy machines
-                        maxLength: 32
-                        minLength: 1
                         pattern: ^\[[0-9]+-[0-9]+\]$
                         type: string
                     type: object
@@ -708,7 +656,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -727,8 +675,6 @@ spec:
                           The templating mechanism provides the following arguments:
                           * `.cluster.name`: The name of the cluster object.
                           * `.random`: A random alphanumeric string, without vowels, of length 5.
-                        maxLength: 1024
-                        minLength: 1
                         type: string
                     type: object
                   nodeDeletionTimeout:
@@ -751,50 +697,6 @@ spec:
                       to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
                       NOTE: This value can be overridden while defining a Cluster.Topology.
                     type: string
-                  readinessGates:
-                    description: |-
-                      readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
-
-                      This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
-                      computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
-
-                      NOTE: This field is considered only for computing v1beta2 conditions.
-                      NOTE: If a Cluster defines a custom list of readinessGates for the control plane,
-                      such list overrides readinessGates defined in this field.
-                      NOTE: Specific control plane provider implementations might automatically extend the list of readinessGates;
-                      e.g. the kubeadm control provider adds ReadinessGates for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
-                    items:
-                      description: MachineReadinessGate contains the type of a Machine
-                        condition to be used as a readiness gate.
-                      properties:
-                        conditionType:
-                          description: |-
-                            conditionType refers to a condition with matching type in the Machine's condition list.
-                            If the conditions doesn't exist, it will be treated as unknown.
-                            Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
-                          maxLength: 316
-                          minLength: 1
-                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                          type: string
-                        polarity:
-                          description: |-
-                            polarity of the conditionType specified in this readinessGate.
-                            Valid values are Positive, Negative and omitted.
-                            When omitted, the default behaviour will be Positive.
-                            A positive polarity means that the condition should report a true status under normal conditions.
-                            A negative polarity means that the condition should report a false status under normal conditions.
-                          enum:
-                          - Positive
-                          - Negative
-                          type: string
-                      required:
-                      - conditionType
-                      type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - conditionType
-                    x-kubernetes-list-type: map
                   ref:
                     description: |-
                       ref is a required reference to a custom resource
@@ -899,23 +801,6 @@ spec:
                 required:
                 - ref
                 type: object
-              infrastructureNamingStrategy:
-                description: infrastructureNamingStrategy allows changing the naming
-                  pattern used when creating the infrastructure object.
-                properties:
-                  template:
-                    description: |-
-                      template defines the template to use for generating the name of the Infrastructure object.
-                      If not defined, it will fallback to `{{ .cluster.name }}-{{ .random }}`.
-                      If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
-                      get concatenated with a random suffix of length 5.
-                      The templating mechanism provides the following arguments:
-                      * `.cluster.name`: The name of the cluster object.
-                      * `.random`: A random alphanumeric string, without vowels, of length 5.
-                    maxLength: 1024
-                    minLength: 1
-                    type: string
-                type: object
               patches:
                 description: |-
                   patches defines the patches which are applied to customize
@@ -946,10 +831,6 @@ spec:
                                   description: |-
                                     op defines the operation of the patch.
                                     Note: Only `add`, `replace` and `remove` are supported.
-                                  enum:
-                                  - add
-                                  - replace
-                                  - remove
                                   type: string
                                 path:
                                   description: |-
@@ -958,8 +839,6 @@ spec:
                                     Note: For now the only allowed array modifications are `append` and `prepend`, i.e.:
                                     * for op: `add`: only index 0 (prepend) and - (append) are allowed
                                     * for op: `replace` or `remove`: no indexes are allowed
-                                  maxLength: 512
-                                  minLength: 1
                                   type: string
                                 value:
                                   description: |-
@@ -982,22 +861,17 @@ spec:
                                         template is the Go template to be used to calculate the value.
                                         A template can reference variables defined in .spec.variables and builtin variables.
                                         Note: The template must evaluate to a valid YAML or JSON value.
-                                      maxLength: 10240
-                                      minLength: 1
                                       type: string
                                     variable:
                                       description: |-
                                         variable is the variable to be used as value.
                                         Variable can be one of the variables defined in .spec.variables or a builtin variable.
-                                      maxLength: 256
-                                      minLength: 1
                                       type: string
                                   type: object
                               required:
                               - op
                               - path
                               type: object
-                            maxItems: 100
                             type: array
                           selector:
                             description: selector defines on which templates the patch
@@ -1005,13 +879,9 @@ spec:
                             properties:
                               apiVersion:
                                 description: apiVersion filters templates by apiVersion.
-                                maxLength: 512
-                                minLength: 1
                                 type: string
                               kind:
                                 description: kind filters templates by kind.
-                                maxLength: 256
-                                minLength: 1
                                 type: string
                               matchResources:
                                 description: matchResources selects templates based
@@ -1036,10 +906,7 @@ spec:
                                         description: names selects templates by class
                                           names.
                                         items:
-                                          maxLength: 256
-                                          minLength: 1
                                           type: string
-                                        maxItems: 100
                                         type: array
                                     type: object
                                   machinePoolClass:
@@ -1051,10 +918,7 @@ spec:
                                         description: names selects templates by class
                                           names.
                                         items:
-                                          maxLength: 256
-                                          minLength: 1
                                           type: string
-                                        maxItems: 100
                                         type: array
                                     type: object
                                 type: object
@@ -1067,13 +931,10 @@ spec:
                         - jsonPatches
                         - selector
                         type: object
-                      maxItems: 100
                       type: array
                     description:
                       description: description is a human-readable description of
                         this patch.
-                      maxLength: 1024
-                      minLength: 1
                       type: string
                     enabledIf:
                       description: |-
@@ -1082,8 +943,6 @@ spec:
                         The patch will be enabled if the template evaluates to `true`, otherwise it will
                         be disabled.
                         If EnabledIf is not set, the patch will be enabled per default.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     external:
                       description: |-
@@ -1093,14 +952,10 @@ spec:
                         discoverVariablesExtension:
                           description: discoverVariablesExtension references an extension
                             which is called to discover variables.
-                          maxLength: 512
-                          minLength: 1
                           type: string
                         generateExtension:
                           description: generateExtension references an extension which
                             is called to generate patches.
-                          maxLength: 512
-                          minLength: 1
                           type: string
                         settings:
                           additionalProperties:
@@ -1113,19 +968,14 @@ spec:
                         validateExtension:
                           description: validateExtension references an extension which
                             is called to validate the topology.
-                          maxLength: 512
-                          minLength: 1
                           type: string
                       type: object
                     name:
                       description: name of the patch.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - name
                   type: object
-                maxItems: 1000
                 type: array
               variables:
                 description: |-
@@ -1156,14 +1006,12 @@ spec:
                           additionalProperties:
                             type: string
                           description: |-
-                            labels is a map of string keys and values that can be used to organize and categorize
+                            Map of string keys and values that can be used to organize and categorize
                             (scope and select) variables.
                           type: object
                       type: object
                     name:
                       description: name of the variable.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     required:
                       description: |-
@@ -1209,8 +1057,6 @@ spec:
                             description:
                               description: description is a human-readable description
                                 of this variable.
-                              maxLength: 4096
-                              minLength: 1
                               type: string
                             enum:
                               description: |-
@@ -1218,7 +1064,6 @@ spec:
                                 NOTE: Can be set for all types.
                               items:
                                 x-kubernetes-preserve-unknown-fields: true
-                              maxItems: 100
                               type: array
                             example:
                               description: example is an example for this variable.
@@ -1239,8 +1084,6 @@ spec:
                                 For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using)
                                 https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
                                 NOTE: Can only be set if type is string.
-                              maxLength: 32
-                              minLength: 1
                               type: string
                             items:
                               description: |-
@@ -1317,8 +1160,6 @@ spec:
                               description: |-
                                 pattern is the regex which a string variable must match.
                                 NOTE: Can only be set if type is string.
-                              maxLength: 512
-                              minLength: 1
                               type: string
                             properties:
                               description: |-
@@ -1333,22 +1174,12 @@ spec:
                                 required specifies which fields of an object are required.
                                 NOTE: Can only be set if type is object.
                               items:
-                                maxLength: 256
-                                minLength: 1
                                 type: string
-                              maxItems: 1000
                               type: array
                             type:
                               description: |-
                                 type is the type of the variable.
                                 Valid values are: object, array, string, integer, number or boolean.
-                              enum:
-                              - object
-                              - array
-                              - string
-                              - integer
-                              - number
-                              - boolean
                               type: string
                             uniqueItems:
                               description: |-
@@ -1396,8 +1227,6 @@ spec:
                                       Numeric index of array is not supported.
                                       For field name which contains special characters, use `['specialName']` to refer the field name.
                                       e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
-                                    maxLength: 512
-                                    minLength: 1
                                     type: string
                                   message:
                                     description: |-
@@ -1405,8 +1234,6 @@ spec:
                                       line breaks. The message must not contain line breaks.
                                       If unset, the message is "failed rule: {Rule}".
                                       e.g. "must be a URL with the host matching spec.host"
-                                    maxLength: 512
-                                    minLength: 1
                                     type: string
                                   messageExpression:
                                     description: |-
@@ -1419,8 +1246,6 @@ spec:
                                       messageExpression has access to all the same variables as the rule; the only difference is the return type.
                                       Example:
                                       "x must be less than max ("+string(self.max)+")"
-                                    maxLength: 1024
-                                    minLength: 1
                                     type: string
                                   reason:
                                     default: FieldValueInvalid
@@ -1496,13 +1321,10 @@ spec:
                                       rules by default are applied only on UPDATE
                                       requests and are\nskipped if an old value could
                                       not be found."
-                                    maxLength: 4096
-                                    minLength: 1
                                     type: string
                                 required:
                                 - rule
                                 type: object
-                              maxItems: 100
                               type: array
                               x-kubernetes-list-map-keys:
                               - rule
@@ -1524,7 +1346,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    Map of string keys and values that can be used to organize and categorize
                                     (scope and select) variables.
                                   type: object
                               type: object
@@ -1537,7 +1359,6 @@ spec:
                   - required
                   - schema
                   type: object
-                maxItems: 1000
                 type: array
               workers:
                 description: |-
@@ -1559,16 +1380,12 @@ spec:
                             class denotes a type of worker node present in the cluster,
                             this name MUST be unique within a ClusterClass and can be referenced
                             in the Cluster to create a managed MachineDeployment.
-                          maxLength: 256
-                          minLength: 1
                           type: string
                         failureDomain:
                           description: |-
                             failureDomain is the failure domain the machines will be created in.
                             Must match a key in the FailureDomains map stored on the cluster object.
                             NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
-                          maxLength: 256
-                          minLength: 1
                           type: string
                         machineHealthCheck:
                           description: machineHealthCheck defines a MachineHealthCheck
@@ -1579,8 +1396,7 @@ spec:
                               - type: integer
                               - type: string
                               description: |-
-                                maxUnhealthy specifies the maximum number of unhealthy machines allowed.
-                                Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                                Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
                                 "selector" are not healthy.
                               x-kubernetes-int-or-string: true
                             nodeStartupTimeout:
@@ -1659,19 +1475,11 @@ spec:
                                   status for at least the timeout value, a node is considered unhealthy.
                                 properties:
                                   status:
-                                    description: status of the condition, one of True,
-                                      False, Unknown.
                                     minLength: 1
                                     type: string
                                   timeout:
-                                    description: |-
-                                      timeout is the duration that a node must be in a given status for,
-                                      after which the node is considered unhealthy.
-                                      For example, with a value of "1h", the node must match the status
-                                      for at least 1 hour before being considered unhealthy.
                                     type: string
                                   type:
-                                    description: type of Node condition
                                     minLength: 1
                                     type: string
                                 required:
@@ -1679,24 +1487,20 @@ spec:
                                 - timeout
                                 - type
                                 type: object
-                              maxItems: 100
                               type: array
                             unhealthyRange:
                               description: |-
-                                unhealthyRange specifies the range of unhealthy machines allowed.
                                 Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                                is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                                is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
                                 Eg. "[3-5]" - This means that remediation will be allowed only when:
                                 (a) there are at least 3 unhealthy machines (and)
                                 (b) there are at most 5 unhealthy machines
-                              maxLength: 32
-                              minLength: 1
                               pattern: ^\[[0-9]+-[0-9]+\]$
                               type: string
                           type: object
                         minReadySeconds:
                           description: |-
-                            minReadySeconds is the minimum number of seconds for which a newly created machine should
+                            Minimum number of seconds for which a newly created machine should
                             be ready.
                             Defaults to 0 (machine will be considered available as soon as it
                             is ready)
@@ -1717,8 +1521,6 @@ spec:
                                 * `.cluster.name`: The name of the cluster object.
                                 * `.random`: A random alphanumeric string, without vowels, of length 5.
                                 * `.machineDeployment.topologyName`: The name of the MachineDeployment topology (Cluster.spec.topology.workers.machineDeployments[].name).
-                              maxLength: 1024
-                              minLength: 1
                               type: string
                           type: object
                         nodeDeletionTimeout:
@@ -1741,51 +1543,9 @@ spec:
                             to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
                             NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
                           type: string
-                        readinessGates:
-                          description: |-
-                            readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
-
-                            This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
-                            computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
-
-                            NOTE: This field is considered only for computing v1beta2 conditions.
-                            NOTE: If a Cluster defines a custom list of readinessGates for a MachineDeployment using this MachineDeploymentClass,
-                            such list overrides readinessGates defined in this field.
-                          items:
-                            description: MachineReadinessGate contains the type of
-                              a Machine condition to be used as a readiness gate.
-                            properties:
-                              conditionType:
-                                description: |-
-                                  conditionType refers to a condition with matching type in the Machine's condition list.
-                                  If the conditions doesn't exist, it will be treated as unknown.
-                                  Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
-                                maxLength: 316
-                                minLength: 1
-                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                type: string
-                              polarity:
-                                description: |-
-                                  polarity of the conditionType specified in this readinessGate.
-                                  Valid values are Positive, Negative and omitted.
-                                  When omitted, the default behaviour will be Positive.
-                                  A positive polarity means that the condition should report a true status under normal conditions.
-                                  A negative polarity means that the condition should report a false status under normal conditions.
-                                enum:
-                                - Positive
-                                - Negative
-                                type: string
-                            required:
-                            - conditionType
-                            type: object
-                          maxItems: 32
-                          type: array
-                          x-kubernetes-list-map-keys:
-                          - conditionType
-                          x-kubernetes-list-type: map
                         strategy:
                           description: |-
-                            strategy is the deployment strategy to use to replace existing machines with
+                            The deployment strategy to use to replace existing machines with
                             new ones.
                             NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
                           properties:
@@ -1817,7 +1577,7 @@ spec:
                               type: object
                             rollingUpdate:
                               description: |-
-                                rollingUpdate is the rolling update config params. Present only if
+                                Rolling update config params. Present only if
                                 MachineDeploymentStrategyType = RollingUpdate.
                               properties:
                                 deletePolicy:
@@ -1835,7 +1595,7 @@ spec:
                                   - type: integer
                                   - type: string
                                   description: |-
-                                    maxSurge is the maximum number of machines that can be scheduled above the
+                                    The maximum number of machines that can be scheduled above the
                                     desired number of machines.
                                     Value can be an absolute number (ex: 5) or a percentage of
                                     desired machines (ex: 10%).
@@ -1854,7 +1614,7 @@ spec:
                                   - type: integer
                                   - type: string
                                   description: |-
-                                    maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                                    The maximum number of machines that can be unavailable during the update.
                                     Value can be an absolute number (ex: 5) or a percentage of desired
                                     machines (ex: 10%).
                                     Absolute number is calculated from percentage by rounding down.
@@ -2006,7 +1766,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
                                     More info: http://kubernetes.io/docs/user-guide/labels
@@ -2020,7 +1780,6 @@ spec:
                       - class
                       - template
                       type: object
-                    maxItems: 100
                     type: array
                     x-kubernetes-list-map-keys:
                     - class
@@ -2039,8 +1798,6 @@ spec:
                             class denotes a type of machine pool present in the cluster,
                             this name MUST be unique within a ClusterClass and can be referenced
                             in the Cluster to create a managed MachinePool.
-                          maxLength: 256
-                          minLength: 1
                           type: string
                         failureDomains:
                           description: |-
@@ -2048,14 +1805,11 @@ spec:
                             Must match a key in the FailureDomains map stored on the cluster object.
                             NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
                           items:
-                            maxLength: 256
-                            minLength: 1
                             type: string
-                          maxItems: 100
                           type: array
                         minReadySeconds:
                           description: |-
-                            minReadySeconds is the minimum number of seconds for which a newly created machine pool should
+                            Minimum number of seconds for which a newly created machine pool should
                             be ready.
                             Defaults to 0 (machine will be considered available as soon as it
                             is ready)
@@ -2076,8 +1830,6 @@ spec:
                                 * `.cluster.name`: The name of the cluster object.
                                 * `.random`: A random alphanumeric string, without vowels, of length 5.
                                 * `.machinePool.topologyName`: The name of the MachinePool topology (Cluster.spec.topology.workers.machinePools[].name).
-                              maxLength: 1024
-                              minLength: 1
                               type: string
                           type: object
                         nodeDeletionTimeout:
@@ -2229,7 +1981,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
                                     More info: http://kubernetes.io/docs/user-guide/labels
@@ -2243,7 +1995,6 @@ spec:
                       - class
                       - template
                       type: object
-                    maxItems: 100
                     type: array
                     x-kubernetes-list-map-keys:
                     - class
@@ -2251,7 +2002,7 @@ spec:
                 type: object
             type: object
           status:
-            description: status is the observed state of ClusterClass.
+            description: ClusterClassStatus defines the observed state of the ClusterClass.
             properties:
               conditions:
                 description: conditions defines current observed state of the ClusterClass.
@@ -2261,32 +2012,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -2296,8 +2042,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -2397,8 +2141,6 @@ spec:
                               from specifies the origin of the variable definition.
                               This will be `inline` for variables defined in the ClusterClass or the name of a patch defined in the ClusterClass
                               for variables discovered from a DiscoverVariables runtime extensions.
-                            maxLength: 256
-                            minLength: 1
                             type: string
                           metadata:
                             description: |-
@@ -2420,7 +2162,7 @@ spec:
                                 additionalProperties:
                                   type: string
                                 description: |-
-                                  labels is a map of string keys and values that can be used to organize and categorize
+                                  Map of string keys and values that can be used to organize and categorize
                                   (scope and select) variables.
                                 type: object
                             type: object
@@ -2468,8 +2210,6 @@ spec:
                                   description:
                                     description: description is a human-readable description
                                       of this variable.
-                                    maxLength: 4096
-                                    minLength: 1
                                     type: string
                                   enum:
                                     description: |-
@@ -2477,7 +2217,6 @@ spec:
                                       NOTE: Can be set for all types.
                                     items:
                                       x-kubernetes-preserve-unknown-fields: true
-                                    maxItems: 100
                                     type: array
                                   example:
                                     description: example is an example for this variable.
@@ -2498,8 +2237,6 @@ spec:
                                       For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using)
                                       https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
                                       NOTE: Can only be set if type is string.
-                                    maxLength: 32
-                                    minLength: 1
                                     type: string
                                   items:
                                     description: |-
@@ -2576,8 +2313,6 @@ spec:
                                     description: |-
                                       pattern is the regex which a string variable must match.
                                       NOTE: Can only be set if type is string.
-                                    maxLength: 512
-                                    minLength: 1
                                     type: string
                                   properties:
                                     description: |-
@@ -2592,22 +2327,12 @@ spec:
                                       required specifies which fields of an object are required.
                                       NOTE: Can only be set if type is object.
                                     items:
-                                      maxLength: 256
-                                      minLength: 1
                                       type: string
-                                    maxItems: 1000
                                     type: array
                                   type:
                                     description: |-
                                       type is the type of the variable.
                                       Valid values are: object, array, string, integer, number or boolean.
-                                    enum:
-                                    - object
-                                    - array
-                                    - string
-                                    - integer
-                                    - number
-                                    - boolean
                                     type: string
                                   uniqueItems:
                                     description: |-
@@ -2655,8 +2380,6 @@ spec:
                                             Numeric index of array is not supported.
                                             For field name which contains special characters, use `['specialName']` to refer the field name.
                                             e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
-                                          maxLength: 512
-                                          minLength: 1
                                           type: string
                                         message:
                                           description: |-
@@ -2664,8 +2387,6 @@ spec:
                                             line breaks. The message must not contain line breaks.
                                             If unset, the message is "failed rule: {Rule}".
                                             e.g. "must be a URL with the host matching spec.host"
-                                          maxLength: 512
-                                          minLength: 1
                                           type: string
                                         messageExpression:
                                           description: |-
@@ -2678,8 +2399,6 @@ spec:
                                             messageExpression has access to all the same variables as the rule; the only difference is the return type.
                                             Example:
                                             "x must be less than max ("+string(self.max)+")"
-                                          maxLength: 1024
-                                          minLength: 1
                                           type: string
                                         reason:
                                           default: FieldValueInvalid
@@ -2764,13 +2483,10 @@ spec:
                                             rules by default are applied only on UPDATE
                                             requests and are\nskipped if an old value
                                             could not be found."
-                                          maxLength: 4096
-                                          minLength: 1
                                           type: string
                                       required:
                                       - rule
                                       type: object
-                                    maxItems: 100
                                     type: array
                                     x-kubernetes-list-map-keys:
                                     - rule
@@ -2792,7 +2508,7 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          labels is a map of string keys and values that can be used to organize and categorize
+                                          Map of string keys and values that can be used to organize and categorize
                                           (scope and select) variables.
                                         type: object
                                     type: object
@@ -2805,7 +2521,6 @@ spec:
                         - required
                         - schema
                         type: object
-                      maxItems: 100
                       type: array
                     definitionsConflict:
                       description: definitionsConflict specifies whether or not there
@@ -2813,14 +2528,11 @@ spec:
                       type: boolean
                     name:
                       description: name is the name of the variable.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - definitions
                   - name
                   type: object
-                maxItems: 1000
                 type: array
             type: object
         type: object

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_clusterresourcesetbindings.addons.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_clusterresourcesetbindings.addons.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -56,7 +56,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of ClusterResourceSetBinding.
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
             properties:
               bindings:
                 description: bindings is a list of ClusterResourceSets and their resources.
@@ -150,7 +151,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of ClusterResourceSetBinding.
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
             properties:
               bindings:
                 description: bindings is a list of ClusterResourceSets and their resources.
@@ -241,7 +243,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of ClusterResourceSetBinding.
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
             properties:
               bindings:
                 description: bindings is a list of ClusterResourceSets and their resources.
@@ -252,8 +255,6 @@ spec:
                     clusterResourceSetName:
                       description: clusterResourceSetName is the name of the ClusterResourceSet
                         that is applied to the owner cluster of the binding.
-                      maxLength: 253
-                      minLength: 1
                       type: string
                     resources:
                       description: resources is a list of resources that the ClusterResourceSet
@@ -271,8 +272,6 @@ spec:
                             description: |-
                               hash is the hash of a resource's data. This can be used to decide if a resource is changed.
                               For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
-                            maxLength: 256
-                            minLength: 1
                             type: string
                           kind:
                             description: 'kind of the resource. Supported kinds are:
@@ -289,7 +288,6 @@ spec:
                           name:
                             description: name of the resource that is in the same
                               namespace with ClusterResourceSet object.
-                            maxLength: 253
                             minLength: 1
                             type: string
                         required:
@@ -297,19 +295,15 @@ spec:
                         - kind
                         - name
                         type: object
-                      maxItems: 100
                       type: array
                   required:
                   - clusterResourceSetName
                   type: object
-                maxItems: 100
                 type: array
               clusterName:
                 description: |-
                   clusterName is the name of the Cluster this binding applies to.
                   Note: this field mandatory in v1beta2.
-                maxLength: 63
-                minLength: 1
                 type: string
             type: object
         type: object

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_clusterresourcesets.addons.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_clusterresourcesets.addons.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -56,11 +56,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of ClusterResourceSet.
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
             properties:
               clusterSelector:
                 description: |-
-                  clusterSelector is the label selector for Clusters. The Clusters that are
+                  Label selector for Clusters. The Clusters that are
                   selected by this will be the ones affected by this ClusterResourceSet.
                   It must match the Cluster labels. This field is immutable.
                 properties:
@@ -140,7 +140,7 @@ spec:
             - clusterSelector
             type: object
           status:
-            description: status is the observed state of ClusterResourceSet.
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
             properties:
               conditions:
                 description: conditions defines current state of the ClusterResourceSet.
@@ -150,19 +150,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -229,11 +229,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of ClusterResourceSet.
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
             properties:
               clusterSelector:
                 description: |-
-                  clusterSelector is the label selector for Clusters. The Clusters that are
+                  Label selector for Clusters. The Clusters that are
                   selected by this will be the ones affected by this ClusterResourceSet.
                   It must match the Cluster labels. This field is immutable.
                   Label selector cannot be empty.
@@ -314,7 +314,7 @@ spec:
             - clusterSelector
             type: object
           status:
-            description: status is the observed state of ClusterResourceSet.
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
             properties:
               conditions:
                 description: conditions defines current state of the ClusterResourceSet.
@@ -324,19 +324,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -379,9 +379,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: |-
-          ClusterResourceSet is the Schema for the clusterresourcesets API.
-          For advanced use cases an add-on provider should be used instead.
+        description: ClusterResourceSet is the Schema for the clusterresourcesets
+          API.
         properties:
           apiVersion:
             description: |-
@@ -401,11 +400,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of ClusterResourceSet.
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
             properties:
               clusterSelector:
                 description: |-
-                  clusterSelector is the label selector for Clusters. The Clusters that are
+                  Label selector for Clusters. The Clusters that are
                   selected by this will be the ones affected by this ClusterResourceSet.
                   It must match the Cluster labels. This field is immutable.
                   Label selector cannot be empty.
@@ -469,14 +468,12 @@ spec:
                     name:
                       description: name of the resource that is in the same namespace
                         with ClusterResourceSet object.
-                      maxLength: 253
                       minLength: 1
                       type: string
                   required:
                   - kind
                   - name
                   type: object
-                maxItems: 100
                 type: array
               strategy:
                 description: strategy is the strategy to be used during applying resources.
@@ -489,7 +486,7 @@ spec:
             - clusterSelector
             type: object
           status:
-            description: status is the observed state of ClusterResourceSet.
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
             properties:
               conditions:
                 description: conditions defines current state of the ClusterResourceSet.
@@ -499,32 +496,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -534,8 +526,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_clusters.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_clusters.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -60,10 +60,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of Cluster.
+            description: ClusterSpec defines the desired state of Cluster.
             properties:
               clusterNetwork:
-                description: clusterNetwork is the cluster network configuration.
+                description: Cluster network configuration.
                 properties:
                   apiServerPort:
                     description: |-
@@ -72,11 +72,9 @@ spec:
                     format: int32
                     type: integer
                   pods:
-                    description: pods is the network ranges from which Pod networks
-                      are allocated.
+                    description: The network ranges from which Pod networks are allocated.
                     properties:
                       cidrBlocks:
-                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -84,14 +82,12 @@ spec:
                     - cidrBlocks
                     type: object
                   serviceDomain:
-                    description: serviceDomain is the domain name for services.
+                    description: Domain name for services.
                     type: string
                   services:
-                    description: services is the network ranges from which service
-                      VIPs are allocated.
+                    description: The network ranges from which service VIPs are allocated.
                     properties:
                       cidrBlocks:
-                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -104,10 +100,10 @@ spec:
                   communicate with the control plane.
                 properties:
                   host:
-                    description: host is the hostname on which the API server is serving.
+                    description: The hostname on which the API server is serving.
                     type: string
                   port:
-                    description: port is the port on which the API server is serving.
+                    description: The port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -210,7 +206,7 @@ spec:
                 type: boolean
             type: object
           status:
-            description: status is the observed state of Cluster.
+            description: ClusterStatus defines the observed state of Cluster.
             properties:
               conditions:
                 description: conditions defines current service state of the cluster.
@@ -220,19 +216,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -350,10 +346,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of Cluster.
+            description: ClusterSpec defines the desired state of Cluster.
             properties:
               clusterNetwork:
-                description: clusterNetwork is the cluster network configuration.
+                description: Cluster network configuration.
                 properties:
                   apiServerPort:
                     description: |-
@@ -362,11 +358,9 @@ spec:
                     format: int32
                     type: integer
                   pods:
-                    description: pods is the network ranges from which Pod networks
-                      are allocated.
+                    description: The network ranges from which Pod networks are allocated.
                     properties:
                       cidrBlocks:
-                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -374,14 +368,12 @@ spec:
                     - cidrBlocks
                     type: object
                   serviceDomain:
-                    description: serviceDomain is the domain name for services.
+                    description: Domain name for services.
                     type: string
                   services:
-                    description: services is the network ranges from which service
-                      VIPs are allocated.
+                    description: The network ranges from which service VIPs are allocated.
                     properties:
                       cidrBlocks:
-                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -394,10 +386,10 @@ spec:
                   communicate with the control plane.
                 properties:
                   host:
-                    description: host is the hostname on which the API server is serving.
+                    description: The hostname on which the API server is serving.
                     type: string
                   port:
-                    description: port is the port on which the API server is serving.
+                    description: The port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -500,14 +492,14 @@ spec:
                 type: boolean
               topology:
                 description: |-
-                  topology encapsulates the topology for the cluster.
+                  This encapsulates the topology for the cluster.
                   NOTE: It is required to enable the ClusterTopology
                   feature gate flag to activate managed topologies support;
                   this feature is highly experimental, and parts of it might still be not implemented.
                 properties:
                   class:
-                    description: class is the name of the ClusterClass object to create
-                      the topology.
+                    description: The name of the ClusterClass object to create the
+                      topology.
                     type: string
                   controlPlane:
                     description: controlPlane describes the cluster control plane.
@@ -533,7 +525,7 @@ spec:
                             additionalProperties:
                               type: string
                             description: |-
-                              labels is a map of string keys and values that can be used to organize and categorize
+                              Map of string keys and values that can be used to organize and categorize
                               (scope and select) objects. May match selectors of replication controllers
                               and services.
                               More info: http://kubernetes.io/docs/user-guide/labels
@@ -555,7 +547,7 @@ spec:
                     format: date-time
                     type: string
                   version:
-                    description: version is the Kubernetes version of the cluster.
+                    description: The Kubernetes version of the cluster.
                     type: string
                   workers:
                     description: |-
@@ -594,7 +586,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
                                     More info: http://kubernetes.io/docs/user-guide/labels
@@ -627,7 +619,7 @@ spec:
                 type: object
             type: object
           status:
-            description: status is the observed state of Cluster.
+            description: ClusterStatus defines the observed state of Cluster.
             properties:
               conditions:
                 description: conditions defines current service state of the cluster.
@@ -637,19 +629,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -768,14 +760,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of Cluster.
+            description: ClusterSpec defines the desired state of Cluster.
             properties:
               availabilityGates:
                 description: |-
                   availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
-
-                  If this field is not defined and the Cluster implements a managed topology, availabilityGates
-                  from the corresponding ClusterClass will be used, if any.
 
                   NOTE: this field is considered only for computing v1beta2 conditions.
                 items:
@@ -784,23 +773,12 @@ spec:
                   properties:
                     conditionType:
                       description: |-
-                        conditionType refers to a condition with matching type in the Cluster's condition list.
+                        conditionType refers to a positive polarity condition (status true means good) with matching type in the Cluster's condition list.
                         If the conditions doesn't exist, it will be treated as unknown.
                         Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
                       maxLength: 316
                       minLength: 1
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                    polarity:
-                      description: |-
-                        polarity of the conditionType specified in this availabilityGate.
-                        Valid values are Positive, Negative and omitted.
-                        When omitted, the default behaviour will be Positive.
-                        A positive polarity means that the condition should report a true status under normal conditions.
-                        A negative polarity means that the condition should report a false status under normal conditions.
-                      enum:
-                      - Positive
-                      - Negative
                       type: string
                   required:
                   - conditionType
@@ -811,7 +789,7 @@ spec:
                 - conditionType
                 x-kubernetes-list-type: map
               clusterNetwork:
-                description: clusterNetwork represents the cluster network configuration.
+                description: Cluster network configuration.
                 properties:
                   apiServerPort:
                     description: |-
@@ -820,36 +798,24 @@ spec:
                     format: int32
                     type: integer
                   pods:
-                    description: pods is the network ranges from which Pod networks
-                      are allocated.
+                    description: The network ranges from which Pod networks are allocated.
                     properties:
                       cidrBlocks:
-                        description: cidrBlocks is a list of CIDR blocks.
                         items:
-                          maxLength: 43
-                          minLength: 1
                           type: string
-                        maxItems: 100
                         type: array
                     required:
                     - cidrBlocks
                     type: object
                   serviceDomain:
-                    description: serviceDomain is the domain name for services.
-                    maxLength: 253
-                    minLength: 1
+                    description: Domain name for services.
                     type: string
                   services:
-                    description: services is the network ranges from which service
-                      VIPs are allocated.
+                    description: The network ranges from which service VIPs are allocated.
                     properties:
                       cidrBlocks:
-                        description: cidrBlocks is a list of CIDR blocks.
                         items:
-                          maxLength: 43
-                          minLength: 1
                           type: string
-                        maxItems: 100
                         type: array
                     required:
                     - cidrBlocks
@@ -860,11 +826,10 @@ spec:
                   communicate with the control plane.
                 properties:
                   host:
-                    description: host is the hostname on which the API server is serving.
-                    maxLength: 512
+                    description: The hostname on which the API server is serving.
                     type: string
                   port:
-                    description: port is the port on which the API server is serving.
+                    description: The port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -967,16 +932,14 @@ spec:
                 type: boolean
               topology:
                 description: |-
-                  topology encapsulates the topology for the cluster.
+                  This encapsulates the topology for the cluster.
                   NOTE: It is required to enable the ClusterTopology
                   feature gate flag to activate managed topologies support;
                   this feature is highly experimental, and parts of it might still be not implemented.
                 properties:
                   class:
-                    description: class is the name of the ClusterClass object to create
-                      the topology.
-                    maxLength: 253
-                    minLength: 1
+                    description: The name of the ClusterClass object to create the
+                      topology.
                     type: string
                   classNamespace:
                     description: |-
@@ -1012,8 +975,7 @@ spec:
                             - type: integer
                             - type: string
                             description: |-
-                              maxUnhealthy specifies the maximum number of unhealthy machines allowed.
-                              Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                              Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
                               "selector" are not healthy.
                             x-kubernetes-int-or-string: true
                           nodeStartupTimeout:
@@ -1092,19 +1054,11 @@ spec:
                                 status for at least the timeout value, a node is considered unhealthy.
                               properties:
                                 status:
-                                  description: status of the condition, one of True,
-                                    False, Unknown.
                                   minLength: 1
                                   type: string
                                 timeout:
-                                  description: |-
-                                    timeout is the duration that a node must be in a given status for,
-                                    after which the node is considered unhealthy.
-                                    For example, with a value of "1h", the node must match the status
-                                    for at least 1 hour before being considered unhealthy.
                                   type: string
                                 type:
-                                  description: type of Node condition
                                   minLength: 1
                                   type: string
                               required:
@@ -1112,18 +1066,14 @@ spec:
                               - timeout
                               - type
                               type: object
-                            maxItems: 100
                             type: array
                           unhealthyRange:
                             description: |-
-                              unhealthyRange specifies the range of unhealthy machines allowed.
                               Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                              is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                              is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
                               Eg. "[3-5]" - This means that remediation will be allowed only when:
                               (a) there are at least 3 unhealthy machines (and)
                               (b) there are at most 5 unhealthy machines
-                            maxLength: 32
-                            minLength: 1
                             pattern: ^\[[0-9]+-[0-9]+\]$
                             type: string
                         type: object
@@ -1147,7 +1097,7 @@ spec:
                             additionalProperties:
                               type: string
                             description: |-
-                              labels is a map of string keys and values that can be used to organize and categorize
+                              Map of string keys and values that can be used to organize and categorize
                               (scope and select) objects. May match selectors of replication controllers
                               and services.
                               More info: http://kubernetes.io/docs/user-guide/labels
@@ -1170,50 +1120,6 @@ spec:
                           nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
                           to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
                         type: string
-                      readinessGates:
-                        description: |-
-                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
-
-                          This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
-                          computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
-
-                          If this field is not defined, readinessGates from the corresponding ControlPlaneClass will be used, if any.
-
-                          NOTE: This field is considered only for computing v1beta2 conditions.
-                          NOTE: Specific control plane provider implementations might automatically extend the list of readinessGates;
-                          e.g. the kubeadm control provider adds ReadinessGates for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
-                        items:
-                          description: MachineReadinessGate contains the type of a
-                            Machine condition to be used as a readiness gate.
-                          properties:
-                            conditionType:
-                              description: |-
-                                conditionType refers to a condition with matching type in the Machine's condition list.
-                                If the conditions doesn't exist, it will be treated as unknown.
-                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
-                              maxLength: 316
-                              minLength: 1
-                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                              type: string
-                            polarity:
-                              description: |-
-                                polarity of the conditionType specified in this readinessGate.
-                                Valid values are Positive, Negative and omitted.
-                                When omitted, the default behaviour will be Positive.
-                                A positive polarity means that the condition should report a true status under normal conditions.
-                                A negative polarity means that the condition should report a false status under normal conditions.
-                              enum:
-                              - Positive
-                              - Negative
-                              type: string
-                          required:
-                          - conditionType
-                          type: object
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - conditionType
-                        x-kubernetes-list-type: map
                       replicas:
                         description: |-
                           replicas is the number of control plane nodes.
@@ -1239,12 +1145,9 @@ spec:
                                     definitionFrom specifies where the definition of this Variable is from.
 
                                     Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
-                                  maxLength: 256
                                   type: string
                                 name:
                                   description: name of the variable.
-                                  maxLength: 256
-                                  minLength: 1
                                   type: string
                                 value:
                                   description: |-
@@ -1260,7 +1163,6 @@ spec:
                               - name
                               - value
                               type: object
-                            maxItems: 1000
                             type: array
                             x-kubernetes-list-map-keys:
                             - name
@@ -1290,12 +1192,9 @@ spec:
                             definitionFrom specifies where the definition of this Variable is from.
 
                             Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
-                          maxLength: 256
                           type: string
                         name:
                           description: name of the variable.
-                          maxLength: 256
-                          minLength: 1
                           type: string
                         value:
                           description: |-
@@ -1311,15 +1210,12 @@ spec:
                       - name
                       - value
                       type: object
-                    maxItems: 1000
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
                   version:
-                    description: version is the Kubernetes version of the cluster.
-                    maxLength: 256
-                    minLength: 1
+                    description: The Kubernetes version of the cluster.
                     type: string
                   workers:
                     description: |-
@@ -1339,15 +1235,11 @@ spec:
                                 class is the name of the MachineDeploymentClass used to create the set of worker nodes.
                                 This should match one of the deployment classes defined in the ClusterClass object
                                 mentioned in the `Cluster.Spec.Class` field.
-                              maxLength: 256
-                              minLength: 1
                               type: string
                             failureDomain:
                               description: |-
                                 failureDomain is the failure domain the machines will be created in.
                                 Must match a key in the FailureDomains map stored on the cluster object.
-                              maxLength: 256
-                              minLength: 1
                               type: string
                             machineHealthCheck:
                               description: |-
@@ -1371,8 +1263,7 @@ spec:
                                   - type: integer
                                   - type: string
                                   description: |-
-                                    maxUnhealthy specifies the maximum number of unhealthy machines allowed.
-                                    Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                                    Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
                                     "selector" are not healthy.
                                   x-kubernetes-int-or-string: true
                                 nodeStartupTimeout:
@@ -1451,19 +1342,11 @@ spec:
                                       status for at least the timeout value, a node is considered unhealthy.
                                     properties:
                                       status:
-                                        description: status of the condition, one
-                                          of True, False, Unknown.
                                         minLength: 1
                                         type: string
                                       timeout:
-                                        description: |-
-                                          timeout is the duration that a node must be in a given status for,
-                                          after which the node is considered unhealthy.
-                                          For example, with a value of "1h", the node must match the status
-                                          for at least 1 hour before being considered unhealthy.
                                         type: string
                                       type:
-                                        description: type of Node condition
                                         minLength: 1
                                         type: string
                                     required:
@@ -1471,18 +1354,14 @@ spec:
                                     - timeout
                                     - type
                                     type: object
-                                  maxItems: 100
                                   type: array
                                 unhealthyRange:
                                   description: |-
-                                    unhealthyRange specifies the range of unhealthy machines allowed.
                                     Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                                    is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                                    is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
                                     Eg. "[3-5]" - This means that remediation will be allowed only when:
                                     (a) there are at least 3 unhealthy machines (and)
                                     (b) there are at most 5 unhealthy machines
-                                  maxLength: 32
-                                  minLength: 1
                                   pattern: ^\[[0-9]+-[0-9]+\]$
                                   type: string
                               type: object
@@ -1504,7 +1383,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
                                     More info: http://kubernetes.io/docs/user-guide/labels
@@ -1512,7 +1391,7 @@ spec:
                               type: object
                             minReadySeconds:
                               description: |-
-                                minReadySeconds is the minimum number of seconds for which a newly created machine should
+                                Minimum number of seconds for which a newly created machine should
                                 be ready.
                                 Defaults to 0 (machine will be considered available as soon as it
                                 is ready)
@@ -1524,8 +1403,6 @@ spec:
                                 The value is used with other unique identifiers to create a MachineDeployment's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 63
-                              minLength: 1
                               type: string
                             nodeDeletionTimeout:
                               description: |-
@@ -1544,49 +1421,6 @@ spec:
                                 nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
                                 to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
                               type: string
-                            readinessGates:
-                              description: |-
-                                readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
-
-                                This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
-                                computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
-
-                                If this field is not defined, readinessGates from the corresponding MachineDeploymentClass will be used, if any.
-
-                                NOTE: This field is considered only for computing v1beta2 conditions.
-                              items:
-                                description: MachineReadinessGate contains the type
-                                  of a Machine condition to be used as a readiness
-                                  gate.
-                                properties:
-                                  conditionType:
-                                    description: |-
-                                      conditionType refers to a condition with matching type in the Machine's condition list.
-                                      If the conditions doesn't exist, it will be treated as unknown.
-                                      Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
-                                    maxLength: 316
-                                    minLength: 1
-                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                    type: string
-                                  polarity:
-                                    description: |-
-                                      polarity of the conditionType specified in this readinessGate.
-                                      Valid values are Positive, Negative and omitted.
-                                      When omitted, the default behaviour will be Positive.
-                                      A positive polarity means that the condition should report a true status under normal conditions.
-                                      A negative polarity means that the condition should report a false status under normal conditions.
-                                    enum:
-                                    - Positive
-                                    - Negative
-                                    type: string
-                                required:
-                                - conditionType
-                                type: object
-                              maxItems: 32
-                              type: array
-                              x-kubernetes-list-map-keys:
-                              - conditionType
-                              x-kubernetes-list-type: map
                             replicas:
                               description: |-
                                 replicas is the number of worker nodes belonging to this set.
@@ -1597,7 +1431,7 @@ spec:
                               type: integer
                             strategy:
                               description: |-
-                                strategy is the deployment strategy to use to replace existing machines with
+                                The deployment strategy to use to replace existing machines with
                                 new ones.
                               properties:
                                 remediation:
@@ -1628,7 +1462,7 @@ spec:
                                   type: object
                                 rollingUpdate:
                                   description: |-
-                                    rollingUpdate is the rolling update config params. Present only if
+                                    Rolling update config params. Present only if
                                     MachineDeploymentStrategyType = RollingUpdate.
                                   properties:
                                     deletePolicy:
@@ -1646,7 +1480,7 @@ spec:
                                       - type: integer
                                       - type: string
                                       description: |-
-                                        maxSurge is the maximum number of machines that can be scheduled above the
+                                        The maximum number of machines that can be scheduled above the
                                         desired number of machines.
                                         Value can be an absolute number (ex: 5) or a percentage of
                                         desired machines (ex: 10%).
@@ -1665,7 +1499,7 @@ spec:
                                       - type: integer
                                       - type: string
                                       description: |-
-                                        maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                                        The maximum number of machines that can be unavailable during the update.
                                         Value can be an absolute number (ex: 5) or a percentage of desired
                                         machines (ex: 10%).
                                         Absolute number is calculated from percentage by rounding down.
@@ -1705,12 +1539,9 @@ spec:
                                           definitionFrom specifies where the definition of this Variable is from.
 
                                           Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
-                                        maxLength: 256
                                         type: string
                                       name:
                                         description: name of the variable.
-                                        maxLength: 256
-                                        minLength: 1
                                         type: string
                                       value:
                                         description: |-
@@ -1726,7 +1557,6 @@ spec:
                                     - name
                                     - value
                                     type: object
-                                  maxItems: 1000
                                   type: array
                                   x-kubernetes-list-map-keys:
                                   - name
@@ -1736,7 +1566,6 @@ spec:
                           - class
                           - name
                           type: object
-                        maxItems: 2000
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1754,18 +1583,13 @@ spec:
                                 class is the name of the MachinePoolClass used to create the pool of worker nodes.
                                 This should match one of the deployment classes defined in the ClusterClass object
                                 mentioned in the `Cluster.Spec.Class` field.
-                              maxLength: 256
-                              minLength: 1
                               type: string
                             failureDomains:
                               description: |-
                                 failureDomains is the list of failure domains the machine pool will be created in.
                                 Must match a key in the FailureDomains map stored on the cluster object.
                               items:
-                                maxLength: 256
-                                minLength: 1
                                 type: string
-                              maxItems: 100
                               type: array
                             metadata:
                               description: |-
@@ -1785,7 +1609,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
                                     More info: http://kubernetes.io/docs/user-guide/labels
@@ -1793,7 +1617,7 @@ spec:
                               type: object
                             minReadySeconds:
                               description: |-
-                                minReadySeconds is the minimum number of seconds for which a newly created machine pool should
+                                Minimum number of seconds for which a newly created machine pool should
                                 be ready.
                                 Defaults to 0 (machine will be considered available as soon as it
                                 is ready)
@@ -1805,8 +1629,6 @@ spec:
                                 The value is used with other unique identifiers to create a MachinePool's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 63
-                              minLength: 1
                               type: string
                             nodeDeletionTimeout:
                               description: |-
@@ -1850,12 +1672,9 @@ spec:
                                           definitionFrom specifies where the definition of this Variable is from.
 
                                           Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
-                                        maxLength: 256
                                         type: string
                                       name:
                                         description: name of the variable.
-                                        maxLength: 256
-                                        minLength: 1
                                         type: string
                                       value:
                                         description: |-
@@ -1871,7 +1690,6 @@ spec:
                                     - name
                                     - value
                                     type: object
-                                  maxItems: 1000
                                   type: array
                                   x-kubernetes-list-map-keys:
                                   - name
@@ -1881,7 +1699,6 @@ spec:
                           - class
                           - name
                           type: object
-                        maxItems: 2000
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1893,7 +1710,7 @@ spec:
                 type: object
             type: object
           status:
-            description: status is the observed state of Cluster.
+            description: ClusterStatus defines the observed state of Cluster.
             properties:
               conditions:
                 description: conditions defines current service state of the cluster.
@@ -1903,32 +1720,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -1938,8 +1750,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -1981,8 +1791,6 @@ spec:
                   state, and will be set to a descriptive error message.
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
-                maxLength: 10240
-                minLength: 1
                 type: string
               failureReason:
                 description: |-
@@ -2002,14 +1810,9 @@ spec:
                 format: int64
                 type: integer
               phase:
-                description: phase represents the current phase of cluster actuation.
-                enum:
-                - Pending
-                - Provisioning
-                - Provisioned
-                - Deleting
-                - Failed
-                - Unknown
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
                 type: string
               v1beta2:
                 description: v1beta2 groups all the fields that will be added or modified

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_extensionconfigs.runtime.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_extensionconfigs.runtime.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: extensionconfigs.runtime.cluster.x-k8s.io
@@ -47,7 +47,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of the ExtensionConfig.
+            description: ExtensionConfigSpec is the desired state of the ExtensionConfig
             properties:
               clientConfig:
                 description: clientConfig defines how to communicate with the Extension
@@ -57,8 +57,6 @@ spec:
                     description: caBundle is a PEM encoded CA bundle which will be
                       used to validate the Extension server's server certificate.
                     format: byte
-                    maxLength: 51200
-                    minLength: 1
                     type: string
                   service:
                     description: |-
@@ -69,20 +67,14 @@ spec:
                     properties:
                       name:
                         description: name is the name of the service.
-                        maxLength: 63
-                        minLength: 1
                         type: string
                       namespace:
                         description: namespace is the namespace of the service.
-                        maxLength: 63
-                        minLength: 1
                         type: string
                       path:
                         description: |-
                           path is an optional URL path and if present may be any string permissible in
                           a URL. If a path is set it will be used as prefix to the hook-specific path.
-                        maxLength: 512
-                        minLength: 1
                         type: string
                       port:
                         description: |-
@@ -112,8 +104,6 @@ spec:
                       Attempting to use a user or basic auth e.g. "user:password@" is not
                       allowed. Fragments ("#...") and query parameters ("?...") are not
                       allowed either.
-                    maxLength: 512
-                    minLength: 1
                     type: string
                 type: object
               namespaceSelector:
@@ -177,7 +167,7 @@ spec:
             - clientConfig
             type: object
           status:
-            description: status is the current state of the ExtensionConfig
+            description: ExtensionConfigStatus is the current state of the ExtensionConfig
             properties:
               conditions:
                 description: conditions define the current service state of the ExtensionConfig.
@@ -187,32 +177,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -222,8 +207,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -242,14 +225,9 @@ spec:
                       description: |-
                         failurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client.
                         Defaults to Fail if not set.
-                      enum:
-                      - Ignore
-                      - Fail
                       type: string
                     name:
                       description: name is the unique name of the ExtensionHandler.
-                      maxLength: 512
-                      minLength: 1
                       type: string
                     requestHook:
                       description: requestHook defines the versioned runtime hook
@@ -258,13 +236,9 @@ spec:
                         apiVersion:
                           description: apiVersion is the group and version of the
                             Hook.
-                          maxLength: 512
-                          minLength: 1
                           type: string
                         hook:
                           description: hook is the name of the hook.
-                          maxLength: 256
-                          minLength: 1
                           type: string
                       required:
                       - apiVersion
@@ -280,80 +254,10 @@ spec:
                   - name
                   - requestHook
                   type: object
-                maxItems: 512
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
-              v1beta2:
-                description: v1beta2 groups all the fields that will be added or modified
-                  in ExtensionConfig's status with the V1Beta2 version.
-                properties:
-                  conditions:
-                    description: |-
-                      conditions represents the observations of a ExtensionConfig's current state.
-                      Known condition types are Discovered, Paused.
-                    items:
-                      description: Condition contains details for one aspect of the
-                        current state of this API Resource.
-                      properties:
-                        lastTransitionTime:
-                          description: |-
-                            lastTransitionTime is the last time the condition transitioned from one status to another.
-                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                          format: date-time
-                          type: string
-                        message:
-                          description: |-
-                            message is a human readable message indicating details about the transition.
-                            This may be an empty string.
-                          maxLength: 32768
-                          type: string
-                        observedGeneration:
-                          description: |-
-                            observedGeneration represents the .metadata.generation that the condition was set based upon.
-                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                            with respect to the current state of the instance.
-                          format: int64
-                          minimum: 0
-                          type: integer
-                        reason:
-                          description: |-
-                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                            Producers of specific condition types may define expected values and meanings for this field,
-                            and whether the values are considered a guaranteed API.
-                            The value should be a CamelCase string.
-                            This field may not be empty.
-                          maxLength: 1024
-                          minLength: 1
-                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                          type: string
-                        status:
-                          description: status of the condition, one of True, False,
-                            Unknown.
-                          enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                          type: string
-                        type:
-                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                          maxLength: 316
-                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                          type: string
-                      required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                      type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - type
-                    x-kubernetes-list-type: map
-                type: object
             type: object
         type: object
     served: true

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinedeployments.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinedeployments.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -80,7 +80,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachineDeployment.
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
@@ -89,18 +89,18 @@ spec:
                 type: string
               minReadySeconds:
                 description: |-
-                  minReadySeconds is the minimum number of seconds for which a newly created machine should
+                  Minimum number of seconds for which a newly created machine should
                   be ready.
                   Defaults to 0 (machine will be considered available as soon as it
                   is ready)
                 format: int32
                 type: integer
               paused:
-                description: paused indicates that the deployment is paused.
+                description: Indicates that the deployment is paused.
                 type: boolean
               progressDeadlineSeconds:
                 description: |-
-                  progressDeadlineSeconds is the maximum time in seconds for a deployment to make progress before it
+                  The maximum time in seconds for a deployment to make progress before it
                   is considered to be failed. The deployment controller will continue to
                   process failed deployments and a condition with a ProgressDeadlineExceeded
                   reason will be surfaced in the deployment status. Note that progress will
@@ -109,20 +109,20 @@ spec:
                 type: integer
               replicas:
                 description: |-
-                  replicas is the number of desired machines. Defaults to 1.
+                  Number of desired machines. Defaults to 1.
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
               revisionHistoryLimit:
                 description: |-
-                  revisionHistoryLimit is the number of old MachineSets to retain to allow rollback.
+                  The number of old MachineSets to retain to allow rollback.
                   This is a pointer to distinguish between explicit zero and not specified.
                   Defaults to 1.
                 format: int32
                 type: integer
               selector:
                 description: |-
-                  selector is the label selector for machines. Existing MachineSets whose machines are
+                  Label selector for machines. Existing MachineSets whose machines are
                   selected by this will be the ones affected by this deployment.
                   It must match the machine template's labels.
                 properties:
@@ -171,12 +171,12 @@ spec:
                 x-kubernetes-map-type: atomic
               strategy:
                 description: |-
-                  strategy is the deployment strategy to use to replace existing machines with
+                  The deployment strategy to use to replace existing machines with
                   new ones.
                 properties:
                   rollingUpdate:
                     description: |-
-                      rollingUpdate is the rolling update config params. Present only if
+                      Rolling update config params. Present only if
                       MachineDeploymentStrategyType = RollingUpdate.
                     properties:
                       maxSurge:
@@ -184,7 +184,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxSurge is the maximum number of machines that can be scheduled above the
+                          The maximum number of machines that can be scheduled above the
                           desired number of machines.
                           Value can be an absolute number (ex: 5) or a percentage of
                           desired machines (ex: 10%).
@@ -203,7 +203,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          The maximum number of machines that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired
                           machines (ex: 10%).
                           Absolute number is calculated from percentage by rounding down.
@@ -229,7 +229,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -265,7 +265,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -296,7 +296,7 @@ spec:
                         type: string
                       ownerReferences:
                         description: |-
-                          ownerReferences is the list of objects depended by this object. If ALL objects in the list have
+                          List of objects depended by this object. If ALL objects in the list have
                           been deleted, this object will be garbage collected. If this object is managed by a controller,
                           then an entry in this list will point to this controller, with the controller field set to true.
                           There cannot be more than one managing controller.
@@ -352,7 +352,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -511,17 +511,16 @@ spec:
             - template
             type: object
           status:
-            description: status is the observed state of MachineDeployment.
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
             properties:
               availableReplicas:
                 description: |-
-                  availableReplicas is the total number of available machines (ready for at least minReadySeconds)
+                  Total number of available machines (ready for at least minReadySeconds)
                   targeted by this deployment.
                 format: int32
                 type: integer
               observedGeneration:
-                description: observedGeneration is the generation observed by the
-                  deployment controller.
+                description: The generation observed by the deployment controller.
                 format: int64
                 type: integer
               phase:
@@ -529,13 +528,12 @@ spec:
                   (ScalingUp, ScalingDown, Running, Failed, or Unknown).
                 type: string
               readyReplicas:
-                description: readyReplicas is the total number of ready machines targeted
-                  by this deployment.
+                description: Total number of ready machines targeted by this deployment.
                 format: int32
                 type: integer
               replicas:
                 description: |-
-                  replicas is the total number of non-terminated machines targeted by this deployment
+                  Total number of non-terminated machines targeted by this deployment
                   (their labels match the selector).
                 format: int32
                 type: integer
@@ -547,7 +545,7 @@ spec:
                 type: string
               unavailableReplicas:
                 description: |-
-                  unavailableReplicas is the total number of unavailable machines targeted by this deployment.
+                  Total number of unavailable machines targeted by this deployment.
                   This is the total number of machines that are still required for
                   the deployment to have 100% available capacity. They may either
                   be machines that are running but not yet available or machines
@@ -556,7 +554,7 @@ spec:
                 type: integer
               updatedReplicas:
                 description: |-
-                  updatedReplicas is the total number of non-terminated machines targeted by this deployment
+                  Total number of non-terminated machines targeted by this deployment
                   that have the desired template spec.
                 format: int32
                 type: integer
@@ -627,7 +625,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachineDeployment.
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
@@ -636,18 +634,18 @@ spec:
                 type: string
               minReadySeconds:
                 description: |-
-                  minReadySeconds is the minimum number of seconds for which a newly created machine should
+                  Minimum number of seconds for which a newly created machine should
                   be ready.
                   Defaults to 0 (machine will be considered available as soon as it
                   is ready)
                 format: int32
                 type: integer
               paused:
-                description: paused indicates that the deployment is paused.
+                description: Indicates that the deployment is paused.
                 type: boolean
               progressDeadlineSeconds:
                 description: |-
-                  progressDeadlineSeconds is the maximum time in seconds for a deployment to make progress before it
+                  The maximum time in seconds for a deployment to make progress before it
                   is considered to be failed. The deployment controller will continue to
                   process failed deployments and a condition with a ProgressDeadlineExceeded
                   reason will be surfaced in the deployment status. Note that progress will
@@ -657,20 +655,20 @@ spec:
               replicas:
                 default: 1
                 description: |-
-                  replicas is the number of desired machines. Defaults to 1.
+                  Number of desired machines. Defaults to 1.
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
               revisionHistoryLimit:
                 description: |-
-                  revisionHistoryLimit is the number of old MachineSets to retain to allow rollback.
+                  The number of old MachineSets to retain to allow rollback.
                   This is a pointer to distinguish between explicit zero and not specified.
                   Defaults to 1.
                 format: int32
                 type: integer
               selector:
                 description: |-
-                  selector is the label selector for machines. Existing MachineSets whose machines are
+                  Label selector for machines. Existing MachineSets whose machines are
                   selected by this will be the ones affected by this deployment.
                   It must match the machine template's labels.
                 properties:
@@ -719,12 +717,12 @@ spec:
                 x-kubernetes-map-type: atomic
               strategy:
                 description: |-
-                  strategy is the deployment strategy to use to replace existing machines with
+                  The deployment strategy to use to replace existing machines with
                   new ones.
                 properties:
                   rollingUpdate:
                     description: |-
-                      rollingUpdate is the rolling update config params. Present only if
+                      Rolling update config params. Present only if
                       MachineDeploymentStrategyType = RollingUpdate.
                     properties:
                       deletePolicy:
@@ -742,7 +740,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxSurge is the maximum number of machines that can be scheduled above the
+                          The maximum number of machines that can be scheduled above the
                           desired number of machines.
                           Value can be an absolute number (ex: 5) or a percentage of
                           desired machines (ex: 10%).
@@ -761,7 +759,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          The maximum number of machines that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired
                           machines (ex: 10%).
                           Absolute number is calculated from percentage by rounding down.
@@ -789,7 +787,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -805,7 +803,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -813,7 +811,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -965,11 +963,11 @@ spec:
             - template
             type: object
           status:
-            description: status is the observed state of MachineDeployment.
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
             properties:
               availableReplicas:
                 description: |-
-                  availableReplicas is the total number of available machines (ready for at least minReadySeconds)
+                  Total number of available machines (ready for at least minReadySeconds)
                   targeted by this deployment.
                 format: int32
                 type: integer
@@ -981,19 +979,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -1018,8 +1016,7 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                description: observedGeneration is the generation observed by the
-                  deployment controller.
+                description: The generation observed by the deployment controller.
                 format: int64
                 type: integer
               phase:
@@ -1027,13 +1024,12 @@ spec:
                   (ScalingUp, ScalingDown, Running, Failed, or Unknown).
                 type: string
               readyReplicas:
-                description: readyReplicas is the total number of ready machines targeted
-                  by this deployment.
+                description: Total number of ready machines targeted by this deployment.
                 format: int32
                 type: integer
               replicas:
                 description: |-
-                  replicas is the total number of non-terminated machines targeted by this deployment
+                  Total number of non-terminated machines targeted by this deployment
                   (their labels match the selector).
                 format: int32
                 type: integer
@@ -1045,7 +1041,7 @@ spec:
                 type: string
               unavailableReplicas:
                 description: |-
-                  unavailableReplicas is the total number of unavailable machines targeted by this deployment.
+                  Total number of unavailable machines targeted by this deployment.
                   This is the total number of machines that are still required for
                   the deployment to have 100% available capacity. They may either
                   be machines that are running but not yet available or machines
@@ -1054,7 +1050,7 @@ spec:
                 type: integer
               updatedReplicas:
                 description: |-
-                  updatedReplicas is the total number of non-terminated machines targeted by this deployment
+                  Total number of non-terminated machines targeted by this deployment
                   that have the desired template spec.
                 format: int32
                 type: integer
@@ -1130,41 +1126,13 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachineDeployment.
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
                   to.
-                maxLength: 63
                 minLength: 1
                 type: string
-              machineNamingStrategy:
-                description: |-
-                  machineNamingStrategy allows changing the naming pattern used when creating Machines.
-                  Note: InfraMachines & BootstrapConfigs will use the same name as the corresponding Machines.
-                properties:
-                  template:
-                    description: |-
-                      template defines the template to use for generating the names of the
-                      Machine objects.
-                      If not defined, it will fallback to `{{ .machineSet.name }}-{{ .random }}`.
-                      If the generated name string exceeds 63 characters, it will be trimmed to
-                      58 characters and will
-                      get concatenated with a random suffix of length 5.
-                      Length of the template string must not exceed 256 characters.
-                      The template allows the following variables `.cluster.name`,
-                      `.machineSet.name` and `.random`.
-                      The variable `.cluster.name` retrieves the name of the cluster object
-                      that owns the Machines being created.
-                      The variable `.machineSet.name` retrieves the name of the MachineSet
-                      object that owns the Machines being created.
-                      The variable `.random` is substituted with random alphanumeric string,
-                      without vowels, of length 5. This variable is required part of the
-                      template. If not provided, validation will fail.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                type: object
               minReadySeconds:
                 description: |-
                   minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.
@@ -1172,11 +1140,11 @@ spec:
                 format: int32
                 type: integer
               paused:
-                description: paused indicates that the deployment is paused.
+                description: Indicates that the deployment is paused.
                 type: boolean
               progressDeadlineSeconds:
                 description: |-
-                  progressDeadlineSeconds is the maximum time in seconds for a deployment to make progress before it
+                  The maximum time in seconds for a deployment to make progress before it
                   is considered to be failed. The deployment controller will continue to
                   process failed deployments and a condition with a ProgressDeadlineExceeded
                   reason will be surfaced in the deployment status. Note that progress will
@@ -1187,7 +1155,7 @@ spec:
                 type: integer
               replicas:
                 description: |-
-                  replicas is the number of desired machines.
+                  Number of desired machines.
                   This is a pointer to distinguish between explicit zero and not specified.
 
                   Defaults to:
@@ -1208,7 +1176,7 @@ spec:
                 type: integer
               revisionHistoryLimit:
                 description: |-
-                  revisionHistoryLimit is the number of old MachineSets to retain to allow rollback.
+                  The number of old MachineSets to retain to allow rollback.
                   This is a pointer to distinguish between explicit zero and not specified.
                   Defaults to 1.
 
@@ -1227,7 +1195,7 @@ spec:
                 type: string
               selector:
                 description: |-
-                  selector is the label selector for machines. Existing MachineSets whose machines are
+                  Label selector for machines. Existing MachineSets whose machines are
                   selected by this will be the ones affected by this deployment.
                   It must match the machine template's labels.
                 properties:
@@ -1276,7 +1244,7 @@ spec:
                 x-kubernetes-map-type: atomic
               strategy:
                 description: |-
-                  strategy is the deployment strategy to use to replace existing machines with
+                  The deployment strategy to use to replace existing machines with
                   new ones.
                 properties:
                   remediation:
@@ -1307,7 +1275,7 @@ spec:
                     type: object
                   rollingUpdate:
                     description: |-
-                      rollingUpdate is the rolling update config params. Present only if
+                      Rolling update config params. Present only if
                       MachineDeploymentStrategyType = RollingUpdate.
                     properties:
                       deletePolicy:
@@ -1325,7 +1293,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxSurge is the maximum number of machines that can be scheduled above the
+                          The maximum number of machines that can be scheduled above the
                           desired number of machines.
                           Value can be an absolute number (ex: 5) or a percentage of
                           desired machines (ex: 10%).
@@ -1344,7 +1312,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          The maximum number of machines that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired
                           machines (ex: 10%).
                           Absolute number is calculated from percentage by rounding down.
@@ -1372,7 +1340,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -1388,7 +1356,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -1396,7 +1364,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -1455,22 +1423,17 @@ spec:
                             description: |-
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
-                            maxLength: 253
-                            minLength: 1
                             type: string
                         type: object
                       clusterName:
                         description: clusterName is the name of the Cluster this object
                           belongs to.
-                        maxLength: 63
                         minLength: 1
                         type: string
                       failureDomain:
                         description: |-
                           failureDomain is the failure domain the machine will be created in.
                           Must match a key in the FailureDomains map stored on the cluster object.
-                        maxLength: 256
-                        minLength: 1
                         type: string
                       infrastructureRef:
                         description: |-
@@ -1546,8 +1509,6 @@ spec:
                           and then a comparison is done to find out unregistered machines and are marked for delete.
                           This field will be set by the actuators and consumed by higher level entities like autoscaler that will
                           be interfacing with cluster-api as generic provider.
-                        maxLength: 512
-                        minLength: 1
                         type: string
                       readinessGates:
                         description: |-
@@ -1571,23 +1532,12 @@ spec:
                           properties:
                             conditionType:
                               description: |-
-                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
                                 If the conditions doesn't exist, it will be treated as unknown.
                                 Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
                               maxLength: 316
                               minLength: 1
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                              type: string
-                            polarity:
-                              description: |-
-                                polarity of the conditionType specified in this readinessGate.
-                                Valid values are Positive, Negative and omitted.
-                                When omitted, the default behaviour will be Positive.
-                                A positive polarity means that the condition should report a true status under normal conditions.
-                                A negative polarity means that the condition should report a false status under normal conditions.
-                              enum:
-                              - Positive
-                              - Negative
                               type: string
                           required:
                           - conditionType
@@ -1601,8 +1551,6 @@ spec:
                         description: |-
                           version defines the desired Kubernetes version.
                           This field is meant to be optionally used by bootstrap providers.
-                        maxLength: 256
-                        minLength: 1
                         type: string
                     required:
                     - bootstrap
@@ -1616,11 +1564,11 @@ spec:
             - template
             type: object
           status:
-            description: status is the observed state of MachineDeployment.
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
             properties:
               availableReplicas:
                 description: |-
-                  availableReplicas is the total number of available machines (ready for at least minReadySeconds)
+                  Total number of available machines (ready for at least minReadySeconds)
                   targeted by this deployment.
                 format: int32
                 type: integer
@@ -1632,32 +1580,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -1667,8 +1610,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -1677,28 +1618,20 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                description: observedGeneration is the generation observed by the
-                  deployment controller.
+                description: The generation observed by the deployment controller.
                 format: int64
                 type: integer
               phase:
                 description: phase represents the current phase of a MachineDeployment
                   (ScalingUp, ScalingDown, Running, Failed, or Unknown).
-                enum:
-                - ScalingUp
-                - ScalingDown
-                - Running
-                - Failed
-                - Unknown
                 type: string
               readyReplicas:
-                description: readyReplicas is the total number of ready machines targeted
-                  by this deployment.
+                description: Total number of ready machines targeted by this deployment.
                 format: int32
                 type: integer
               replicas:
                 description: |-
-                  replicas is the total number of non-terminated machines targeted by this deployment
+                  Total number of non-terminated machines targeted by this deployment
                   (their labels match the selector).
                 format: int32
                 type: integer
@@ -1707,12 +1640,10 @@ spec:
                   selector is the same as the label selector but in the string format to avoid introspection
                   by clients. The string will be in the same format as the query-param syntax.
                   More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
-                maxLength: 4096
-                minLength: 1
                 type: string
               unavailableReplicas:
                 description: |-
-                  unavailableReplicas is the total number of unavailable machines targeted by this deployment.
+                  Total number of unavailable machines targeted by this deployment.
                   This is the total number of machines that are still required for
                   the deployment to have 100% available capacity. They may either
                   be machines that are running but not yet available or machines
@@ -1723,7 +1654,7 @@ spec:
                 type: integer
               updatedReplicas:
                 description: |-
-                  updatedReplicas is the total number of non-terminated machines targeted by this deployment
+                  Total number of non-terminated machines targeted by this deployment
                   that have the desired template spec.
                 format: int32
                 type: integer

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinedrainrules.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinedrainrules.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -246,9 +246,6 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
-                x-kubernetes-validations:
-                - message: entries in machines must be unique
-                  rule: self.all(x, self.exists_one(y, x == y))
               pods:
                 description: |-
                   pods defines to which Pods this MachineDrainRule should be applied.
@@ -394,9 +391,6 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
-                x-kubernetes-validations:
-                - message: entries in pods must be unique
-                  rule: self.all(x, self.exists_one(y, x == y))
             required:
             - drain
             type: object

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinehealthchecks.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinehealthchecks.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -72,7 +72,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the specification of machine health check policy
+            description: Specification of machine health check policy
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
@@ -84,14 +84,13 @@ spec:
                 - type: integer
                 - type: string
                 description: |-
-                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
-                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
                   "selector" are not healthy.
                 x-kubernetes-int-or-string: true
               nodeStartupTimeout:
                 description: |-
-                  nodeStartupTimeout is the duration after which machines without a node will be considered to
-                  have failed and will be remediated.
+                  Machines older than this duration without a node will be considered to have
+                  failed and will be remediated.
                 type: string
               remediationTemplate:
                 description: |-
@@ -143,8 +142,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               selector:
-                description: selector is the label selector to match machines whose
-                  health will be exercised
+                description: Label selector to match machines whose health will be
+                  exercised
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -201,18 +200,11 @@ spec:
                     status for at least the timeout value, a node is considered unhealthy.
                   properties:
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       minLength: 1
                       type: string
                     timeout:
-                      description: |-
-                        timeout is the duration that a node must be in a given status for,
-                        after which the node is considered unhealthy.
-                        For example, with a value of "1h", the node must match the status
-                        for at least 1 hour before being considered unhealthy.
                       type: string
                     type:
-                      description: type of Node condition
                       minLength: 1
                       type: string
                   required:
@@ -228,8 +220,7 @@ spec:
             - unhealthyConditions
             type: object
           status:
-            description: status is the most recently observed status of MachineHealthCheck
-              resource
+            description: Most recently observed status of MachineHealthCheck resource
             properties:
               conditions:
                 description: conditions defines current service state of the MachineHealthCheck.
@@ -239,19 +230,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -276,14 +267,14 @@ spec:
                   type: object
                 type: array
               currentHealthy:
-                description: currentHealthy is the total number of healthy machines
-                  counted by this machine health check
+                description: total number of healthy machines counted by this machine
+                  health check
                 format: int32
                 minimum: 0
                 type: integer
               expectedMachines:
-                description: expectedMachines is the total number of machines counted
-                  by this machine health check
+                description: total number of machines counted by this machine health
+                  check
                 format: int32
                 minimum: 0
                 type: integer
@@ -359,7 +350,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the specification of machine health check policy
+            description: Specification of machine health check policy
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
@@ -371,14 +362,13 @@ spec:
                 - type: integer
                 - type: string
                 description: |-
-                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
-                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
                   "selector" are not healthy.
                 x-kubernetes-int-or-string: true
               nodeStartupTimeout:
                 description: |-
-                  nodeStartupTimeout is the duration after which machines without a node will be considered to
-                  have failed and will be remediated.
+                  Machines older than this duration without a node will be considered to have
+                  failed and will be remediated.
                   If not set, this value is defaulted to 10 minutes.
                   If you wish to disable this feature, set the value explicitly to 0.
                 type: string
@@ -432,8 +422,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               selector:
-                description: selector is the label selector to match machines whose
-                  health will be exercised
+                description: Label selector to match machines whose health will be
+                  exercised
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -490,18 +480,11 @@ spec:
                     status for at least the timeout value, a node is considered unhealthy.
                   properties:
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       minLength: 1
                       type: string
                     timeout:
-                      description: |-
-                        timeout is the duration that a node must be in a given status for,
-                        after which the node is considered unhealthy.
-                        For example, with a value of "1h", the node must match the status
-                        for at least 1 hour before being considered unhealthy.
                       type: string
                     type:
-                      description: type of Node condition
                       minLength: 1
                       type: string
                   required:
@@ -513,9 +496,8 @@ spec:
                 type: array
               unhealthyRange:
                 description: |-
-                  unhealthyRange specifies the range of unhealthy machines allowed.
                   Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                  is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                  is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
                   Eg. "[3-5]" - This means that remediation will be allowed only when:
                   (a) there are at least 3 unhealthy machines (and)
                   (b) there are at most 5 unhealthy machines
@@ -527,8 +509,7 @@ spec:
             - unhealthyConditions
             type: object
           status:
-            description: status is the most recently observed status of MachineHealthCheck
-              resource
+            description: Most recently observed status of MachineHealthCheck resource
             properties:
               conditions:
                 description: conditions defines current service state of the MachineHealthCheck.
@@ -538,19 +519,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -575,14 +556,14 @@ spec:
                   type: object
                 type: array
               currentHealthy:
-                description: currentHealthy is the total number of healthy machines
-                  counted by this machine health check
+                description: total number of healthy machines counted by this machine
+                  health check
                 format: int32
                 minimum: 0
                 type: integer
               expectedMachines:
-                description: expectedMachines is the total number of machines counted
-                  by this machine health check
+                description: total number of machines counted by this machine health
+                  check
                 format: int32
                 minimum: 0
                 type: integer
@@ -655,12 +636,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the specification of machine health check policy
+            description: Specification of machine health check policy
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
                   to.
-                maxLength: 63
                 minLength: 1
                 type: string
               maxUnhealthy:
@@ -668,8 +648,7 @@ spec:
                 - type: integer
                 - type: string
                 description: |-
-                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
-                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
                   "selector" are not healthy.
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
@@ -739,8 +718,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               selector:
-                description: selector is a label selector to match machines whose
-                  health will be exercised
+                description: Label selector to match machines whose health will be
+                  exercised
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -797,18 +776,11 @@ spec:
                     status for at least the timeout value, a node is considered unhealthy.
                   properties:
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       minLength: 1
                       type: string
                     timeout:
-                      description: |-
-                        timeout is the duration that a node must be in a given status for,
-                        after which the node is considered unhealthy.
-                        For example, with a value of "1h", the node must match the status
-                        for at least 1 hour before being considered unhealthy.
                       type: string
                     type:
-                      description: type of Node condition
                       minLength: 1
                       type: string
                   required:
@@ -816,20 +788,16 @@ spec:
                   - timeout
                   - type
                   type: object
-                maxItems: 100
                 type: array
               unhealthyRange:
                 description: |-
-                  unhealthyRange specifies the range of unhealthy machines allowed.
                   Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                  is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                  is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
                   Eg. "[3-5]" - This means that remediation will be allowed only when:
                   (a) there are at least 3 unhealthy machines (and)
                   (b) there are at most 5 unhealthy machines
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
-                maxLength: 32
-                minLength: 1
                 pattern: ^\[[0-9]+-[0-9]+\]$
                 type: string
             required:
@@ -837,8 +805,7 @@ spec:
             - selector
             type: object
           status:
-            description: status is the most recently observed status of MachineHealthCheck
-              resource
+            description: Most recently observed status of MachineHealthCheck resource
             properties:
               conditions:
                 description: conditions defines current service state of the MachineHealthCheck.
@@ -848,32 +815,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -883,8 +845,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -893,14 +853,14 @@ spec:
                   type: object
                 type: array
               currentHealthy:
-                description: currentHealthy is the total number of healthy machines
-                  counted by this machine health check
+                description: total number of healthy machines counted by this machine
+                  health check
                 format: int32
                 minimum: 0
                 type: integer
               expectedMachines:
-                description: expectedMachines is the total number of machines counted
-                  by this machine health check
+                description: total number of machines counted by this machine health
+                  check
                 format: int32
                 minimum: 0
                 type: integer
@@ -920,10 +880,7 @@ spec:
                 description: targets shows the current list of machines the machine
                   health check is watching
                 items:
-                  maxLength: 253
-                  minLength: 1
                   type: string
-                maxItems: 10000
                 type: array
               v1beta2:
                 description: v1beta2 groups all the fields that will be added or modified

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinepools.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinepools.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -72,7 +72,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachinePool.
+            description: MachinePoolSpec defines the desired state of MachinePool.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
@@ -87,7 +87,7 @@ spec:
                 type: array
               minReadySeconds:
                 description: |-
-                  minReadySeconds is the minimum number of seconds for which a newly created machine instances should
+                  Minimum number of seconds for which a newly created machine instances should
                   be ready.
                   Defaults to 0 (machine instance will be considered available as soon as it
                   is ready)
@@ -102,18 +102,18 @@ spec:
                 type: array
               replicas:
                 description: |-
-                  replicas is the number of desired machines. Defaults to 1.
+                  Number of desired machines. Defaults to 1.
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
               strategy:
                 description: |-
-                  strategy is the deployment strategy to use to replace existing machine instances with
+                  The deployment strategy to use to replace existing machine instances with
                   new ones.
                 properties:
                   rollingUpdate:
                     description: |-
-                      rollingUpdate is the rolling update config params. Present only if
+                      Rolling update config params. Present only if
                       MachineDeploymentStrategyType = RollingUpdate.
                     properties:
                       maxSurge:
@@ -121,7 +121,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxSurge is the maximum number of machines that can be scheduled above the
+                          The maximum number of machines that can be scheduled above the
                           desired number of machines.
                           Value can be an absolute number (ex: 5) or a percentage of
                           desired machines (ex: 10%).
@@ -140,7 +140,7 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          The maximum number of machines that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired
                           machines (ex: 10%).
                           Absolute number is calculated from percentage by rounding down.
@@ -166,7 +166,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -202,7 +202,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -233,7 +233,7 @@ spec:
                         type: string
                       ownerReferences:
                         description: |-
-                          ownerReferences is the list of objects depended by this object. If ALL objects in the list have
+                          List of objects depended by this object. If ALL objects in the list have
                           been deleted, this object will be garbage collected. If this object is managed by a controller,
                           then an entry in this list will point to this controller, with the controller field set to true.
                           There cannot be more than one managing controller.
@@ -289,7 +289,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -447,11 +447,11 @@ spec:
             - template
             type: object
           status:
-            description: status is the observed state of MachinePool.
+            description: MachinePoolStatus defines the observed state of MachinePool.
             properties:
               availableReplicas:
-                description: availableReplicas is the number of available replicas
-                  (ready for at least minReadySeconds) for this MachinePool.
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
                 format: int32
                 type: integer
               bootstrapReady:
@@ -465,19 +465,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -574,9 +574,9 @@ spec:
                   E.g. Pending, Running, Terminating, Failed etc.
                 type: string
               readyReplicas:
-                description: readyReplicas is the number of ready replicas for this
-                  MachinePool. A machine is considered ready when the node has been
-                  created and is "Ready".
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
                 format: int32
                 type: integer
               replicas:
@@ -585,7 +585,7 @@ spec:
                 type: integer
               unavailableReplicas:
                 description: |-
-                  unavailableReplicas is the total number of unavailable machine instances targeted by this machine pool.
+                  Total number of unavailable machine instances targeted by this machine pool.
                   This is the total number of machine instances that are still required for
                   the machine pool to have 100% available capacity. They may either
                   be machine instances that are running but not yet available or machine instances
@@ -646,7 +646,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachinePool.
+            description: MachinePoolSpec defines the desired state of MachinePool.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
@@ -661,7 +661,7 @@ spec:
                 type: array
               minReadySeconds:
                 description: |-
-                  minReadySeconds is the minimum number of seconds for which a newly created machine instances should
+                  Minimum number of seconds for which a newly created machine instances should
                   be ready.
                   Defaults to 0 (machine instance will be considered available as soon as it
                   is ready)
@@ -676,7 +676,7 @@ spec:
                 type: array
               replicas:
                 description: |-
-                  replicas is the number of desired machines. Defaults to 1.
+                  Number of desired machines. Defaults to 1.
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
@@ -685,7 +685,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -701,7 +701,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -709,7 +709,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -860,11 +860,11 @@ spec:
             - template
             type: object
           status:
-            description: status is the observed state of MachinePool.
+            description: MachinePoolStatus defines the observed state of MachinePool.
             properties:
               availableReplicas:
-                description: availableReplicas is the number of available replicas
-                  (ready for at least minReadySeconds) for this MachinePool.
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
                 format: int32
                 type: integer
               bootstrapReady:
@@ -878,19 +878,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -987,9 +987,9 @@ spec:
                   E.g. Pending, Running, Terminating, Failed etc.
                 type: string
               readyReplicas:
-                description: readyReplicas is the number of ready replicas for this
-                  MachinePool. A machine is considered ready when the node has been
-                  created and is "Ready".
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
                 format: int32
                 type: integer
               replicas:
@@ -998,7 +998,7 @@ spec:
                 type: integer
               unavailableReplicas:
                 description: |-
-                  unavailableReplicas is the total number of unavailable machine instances targeted by this machine pool.
+                  Total number of unavailable machine instances targeted by this machine pool.
                   This is the total number of machine instances that are still required for
                   the machine pool to have 100% available capacity. They may either
                   be machine instances that are running but not yet available or machine instances
@@ -1064,26 +1064,22 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachinePool.
+            description: MachinePoolSpec defines the desired state of MachinePool.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
                   to.
-                maxLength: 63
                 minLength: 1
                 type: string
               failureDomains:
                 description: failureDomains is the list of failure domains this MachinePool
                   should be attached to.
                 items:
-                  maxLength: 256
-                  minLength: 1
                   type: string
-                maxItems: 100
                 type: array
               minReadySeconds:
                 description: |-
-                  minReadySeconds is the minimum number of seconds for which a newly created machine instances should
+                  Minimum number of seconds for which a newly created machine instances should
                   be ready.
                   Defaults to 0 (machine instance will be considered available as soon as it
                   is ready)
@@ -1094,14 +1090,11 @@ spec:
                   providerIDList are the identification IDs of machine instances provided by the provider.
                   This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
-                  maxLength: 512
-                  minLength: 1
                   type: string
-                maxItems: 10000
                 type: array
               replicas:
                 description: |-
-                  replicas is the number of desired machines. Defaults to 1.
+                  Number of desired machines. Defaults to 1.
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
@@ -1110,7 +1103,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -1126,7 +1119,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -1134,7 +1127,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -1193,22 +1186,17 @@ spec:
                             description: |-
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
-                            maxLength: 253
-                            minLength: 1
                             type: string
                         type: object
                       clusterName:
                         description: clusterName is the name of the Cluster this object
                           belongs to.
-                        maxLength: 63
                         minLength: 1
                         type: string
                       failureDomain:
                         description: |-
                           failureDomain is the failure domain the machine will be created in.
                           Must match a key in the FailureDomains map stored on the cluster object.
-                        maxLength: 256
-                        minLength: 1
                         type: string
                       infrastructureRef:
                         description: |-
@@ -1284,8 +1272,6 @@ spec:
                           and then a comparison is done to find out unregistered machines and are marked for delete.
                           This field will be set by the actuators and consumed by higher level entities like autoscaler that will
                           be interfacing with cluster-api as generic provider.
-                        maxLength: 512
-                        minLength: 1
                         type: string
                       readinessGates:
                         description: |-
@@ -1309,23 +1295,12 @@ spec:
                           properties:
                             conditionType:
                               description: |-
-                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
                                 If the conditions doesn't exist, it will be treated as unknown.
                                 Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
                               maxLength: 316
                               minLength: 1
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                              type: string
-                            polarity:
-                              description: |-
-                                polarity of the conditionType specified in this readinessGate.
-                                Valid values are Positive, Negative and omitted.
-                                When omitted, the default behaviour will be Positive.
-                                A positive polarity means that the condition should report a true status under normal conditions.
-                                A negative polarity means that the condition should report a false status under normal conditions.
-                              enum:
-                              - Positive
-                              - Negative
                               type: string
                           required:
                           - conditionType
@@ -1339,8 +1314,6 @@ spec:
                         description: |-
                           version defines the desired Kubernetes version.
                           This field is meant to be optionally used by bootstrap providers.
-                        maxLength: 256
-                        minLength: 1
                         type: string
                     required:
                     - bootstrap
@@ -1353,11 +1326,11 @@ spec:
             - template
             type: object
           status:
-            description: status is the observed state of MachinePool.
+            description: MachinePoolStatus defines the observed state of MachinePool.
             properties:
               availableReplicas:
-                description: availableReplicas is the number of available replicas
-                  (ready for at least minReadySeconds) for this MachinePool.
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
                 format: int32
                 type: integer
               bootstrapReady:
@@ -1371,32 +1344,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -1406,8 +1374,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -1421,8 +1387,6 @@ spec:
                   and will be set to a descriptive error message.
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
-                maxLength: 10240
-                minLength: 1
                 type: string
               failureReason:
                 description: |-
@@ -1482,7 +1446,6 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
-                maxItems: 10000
                 type: array
               observedGeneration:
                 description: observedGeneration is the latest generation observed
@@ -1490,23 +1453,14 @@ spec:
                 format: int64
                 type: integer
               phase:
-                description: phase represents the current phase of cluster actuation.
-                enum:
-                - Pending
-                - Provisioning
-                - Provisioned
-                - Running
-                - ScalingUp
-                - ScalingDown
-                - Scaling
-                - Deleting
-                - Failed
-                - Unknown
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
                 type: string
               readyReplicas:
-                description: readyReplicas is the number of ready replicas for this
-                  MachinePool. A machine is considered ready when the node has been
-                  created and is "Ready".
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
                 format: int32
                 type: integer
               replicas:
@@ -1515,7 +1469,7 @@ spec:
                 type: integer
               unavailableReplicas:
                 description: |-
-                  unavailableReplicas is the total number of unavailable machine instances targeted by this machine pool.
+                  Total number of unavailable machine instances targeted by this machine pool.
                   This is the total number of machine instances that are still required for
                   the machine pool to have 100% available capacity. They may either
                   be machine instances that are running but not yet available or machine instances

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machines.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machines.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -76,7 +76,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of Machine.
+            description: MachineSpec defines the desired state of Machine.
             properties:
               bootstrap:
                 description: |-
@@ -228,7 +228,7 @@ spec:
             - infrastructureRef
             type: object
           status:
-            description: status is the observed state of Machine.
+            description: MachineStatus defines the observed state of Machine.
             properties:
               addresses:
                 description: |-
@@ -239,11 +239,11 @@ spec:
                     address.
                   properties:
                     address:
-                      description: address is the machine address.
+                      description: The machine address.
                       type: string
                     type:
-                      description: type is the machine address type, one of Hostname,
-                        ExternalIP or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
                       type: string
                   required:
                   - address
@@ -261,19 +261,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -463,7 +463,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of Machine.
+            description: MachineSpec defines the desired state of Machine.
             properties:
               bootstrap:
                 description: |-
@@ -608,7 +608,7 @@ spec:
             - infrastructureRef
             type: object
           status:
-            description: status is the observed state of Machine.
+            description: MachineStatus defines the observed state of Machine.
             properties:
               addresses:
                 description: |-
@@ -619,11 +619,11 @@ spec:
                     address.
                   properties:
                     address:
-                      description: address is the machine address.
+                      description: The machine address.
                       type: string
                     type:
-                      description: type is the machine address type, one of Hostname,
-                        ExternalIP or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
                       type: string
                   required:
                   - address
@@ -641,19 +641,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -894,7 +894,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of Machine.
+            description: MachineSpec defines the desired state of Machine.
             properties:
               bootstrap:
                 description: |-
@@ -952,22 +952,17 @@ spec:
                     description: |-
                       dataSecretName is the name of the secret that stores the bootstrap data script.
                       If nil, the Machine should remain in the Pending state.
-                    maxLength: 253
-                    minLength: 1
                     type: string
                 type: object
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
                   to.
-                maxLength: 63
                 minLength: 1
                 type: string
               failureDomain:
                 description: |-
                   failureDomain is the failure domain the machine will be created in.
                   Must match a key in the FailureDomains map stored on the cluster object.
-                maxLength: 256
-                minLength: 1
                 type: string
               infrastructureRef:
                 description: |-
@@ -1043,8 +1038,6 @@ spec:
                   and then a comparison is done to find out unregistered machines and are marked for delete.
                   This field will be set by the actuators and consumed by higher level entities like autoscaler that will
                   be interfacing with cluster-api as generic provider.
-                maxLength: 512
-                minLength: 1
                 type: string
               readinessGates:
                 description: |-
@@ -1068,23 +1061,12 @@ spec:
                   properties:
                     conditionType:
                       description: |-
-                        conditionType refers to a condition with matching type in the Machine's condition list.
+                        conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
                         If the conditions doesn't exist, it will be treated as unknown.
                         Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
                       maxLength: 316
                       minLength: 1
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                    polarity:
-                      description: |-
-                        polarity of the conditionType specified in this readinessGate.
-                        Valid values are Positive, Negative and omitted.
-                        When omitted, the default behaviour will be Positive.
-                        A positive polarity means that the condition should report a true status under normal conditions.
-                        A negative polarity means that the condition should report a false status under normal conditions.
-                      enum:
-                      - Positive
-                      - Negative
                       type: string
                   required:
                   - conditionType
@@ -1098,8 +1080,6 @@ spec:
                 description: |-
                   version defines the desired Kubernetes version.
                   This field is meant to be optionally used by bootstrap providers.
-                maxLength: 256
-                minLength: 1
                 type: string
             required:
             - bootstrap
@@ -1107,7 +1087,7 @@ spec:
             - infrastructureRef
             type: object
           status:
-            description: status is the observed state of Machine.
+            description: MachineStatus defines the observed state of Machine.
             properties:
               addresses:
                 description: |-
@@ -1118,19 +1098,11 @@ spec:
                     address.
                   properties:
                     address:
-                      description: address is the machine address.
-                      maxLength: 256
-                      minLength: 1
+                      description: The machine address.
                       type: string
                     type:
-                      description: type is the machine address type, one of Hostname,
-                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
-                      enum:
-                      - Hostname
-                      - ExternalIP
-                      - InternalIP
-                      - ExternalDNS
-                      - InternalDNS
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address
@@ -1154,32 +1126,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -1189,8 +1156,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -1240,8 +1205,6 @@ spec:
                   controller's output.
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
-                maxLength: 10240
-                minLength: 1
                 type: string
               failureReason:
                 description: |-
@@ -1378,16 +1341,9 @@ spec:
                 format: int64
                 type: integer
               phase:
-                description: phase represents the current phase of machine actuation.
-                enum:
-                - Pending
-                - Provisioning
-                - Provisioned
-                - Running
-                - Deleting
-                - Deleted
-                - Failed
-                - Unknown
+                description: |-
+                  phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
                 type: string
               v1beta2:
                 description: v1beta2 groups all the fields that will be added or modified

--- a/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinesets.cluster.x-k8s.io.yaml
+++ b/pkg/templates/crds/cluster-api/apiextensions.k8s.io_v1_customresourcedefinition_machinesets.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.16.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -71,7 +71,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachineSet.
+            description: MachineSetSpec defines the desired state of MachineSet.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
@@ -158,7 +158,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -194,7 +194,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -225,7 +225,7 @@ spec:
                         type: string
                       ownerReferences:
                         description: |-
-                          ownerReferences is the list of objects depended by this object. If ALL objects in the list have
+                          List of objects depended by this object. If ALL objects in the list have
                           been deleted, this object will be garbage collected. If this object is managed by a controller,
                           then an entry in this list will point to this controller, with the controller field set to true.
                           There cannot be more than one managing controller.
@@ -281,7 +281,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -439,25 +439,17 @@ spec:
             - selector
             type: object
           status:
-            description: status is the observed state of MachineSet.
+            description: MachineSetStatus defines the observed state of MachineSet.
             properties:
               availableReplicas:
-                description: availableReplicas is the number of available replicas
-                  (ready for at least minReadySeconds) for this MachineSet.
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
                 format: int32
                 type: integer
               failureMessage:
-                description: |-
-                  failureMessage will be set in the event that there is a terminal problem
-                  reconciling the Machine and will contain a more verbose string suitable
-                  for logging and human consumption.
                 type: string
               failureReason:
                 description: |-
-                  failureReason will be set in the event that there is a terminal problem
-                  reconciling the Machine and will contain a succinct value suitable
-                  for machine interpretation.
-
                   In the event that there is a terminal problem reconciling the
                   replicas, both FailureReason and FailureMessage will be set. FailureReason
                   will be populated with a succinct value suitable for machine
@@ -478,8 +470,8 @@ spec:
                   controller's output.
                 type: string
               fullyLabeledReplicas:
-                description: fullyLabeledReplicas is the number of replicas that have
-                  labels matching the labels of the machine template of the MachineSet.
+                description: The number of replicas that have labels matching the
+                  labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
               observedGeneration:
@@ -488,9 +480,8 @@ spec:
                 format: int64
                 type: integer
               readyReplicas:
-                description: readyReplicas is the number of ready replicas for this
-                  MachineSet. A machine is considered ready when the node has been
-                  created and is "Ready".
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
                 format: int32
                 type: integer
               replicas:
@@ -561,7 +552,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachineSet.
+            description: MachineSetSpec defines the desired state of MachineSet.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
@@ -649,7 +640,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -665,7 +656,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -673,7 +664,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -824,11 +815,11 @@ spec:
             - selector
             type: object
           status:
-            description: status is the observed state of MachineSet.
+            description: MachineSetStatus defines the observed state of MachineSet.
             properties:
               availableReplicas:
-                description: availableReplicas is the number of available replicas
-                  (ready for at least minReadySeconds) for this MachineSet.
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
                 format: int32
                 type: integer
               conditions:
@@ -839,19 +830,19 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may not be empty.
                       type: string
@@ -876,17 +867,9 @@ spec:
                   type: object
                 type: array
               failureMessage:
-                description: |-
-                  failureMessage will be set in the event that there is a terminal problem
-                  reconciling the Machine and will contain a more verbose string suitable
-                  for logging and human consumption.
                 type: string
               failureReason:
                 description: |-
-                  failureReason will be set in the event that there is a terminal problem
-                  reconciling the Machine and will contain a succinct value suitable
-                  for machine interpretation.
-
                   In the event that there is a terminal problem reconciling the
                   replicas, both FailureReason and FailureMessage will be set. FailureReason
                   will be populated with a succinct value suitable for machine
@@ -907,8 +890,8 @@ spec:
                   controller's output.
                 type: string
               fullyLabeledReplicas:
-                description: fullyLabeledReplicas is the number of replicas that have
-                  labels matching the labels of the machine template of the MachineSet.
+                description: The number of replicas that have labels matching the
+                  labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
               observedGeneration:
@@ -917,9 +900,8 @@ spec:
                 format: int64
                 type: integer
               readyReplicas:
-                description: readyReplicas is the number of ready replicas for this
-                  MachineSet. A machine is considered ready when the node has been
-                  created and is "Ready".
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
                 format: int32
                 type: integer
               replicas:
@@ -995,12 +977,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec is the desired state of MachineSet.
+            description: MachineSetSpec defines the desired state of MachineSet.
             properties:
               clusterName:
                 description: clusterName is the name of the Cluster this object belongs
                   to.
-                maxLength: 63
                 minLength: 1
                 type: string
               deletePolicy:
@@ -1012,33 +993,6 @@ spec:
                 - Newest
                 - Oldest
                 type: string
-              machineNamingStrategy:
-                description: |-
-                  machineNamingStrategy allows changing the naming pattern used when creating Machines.
-                  Note: InfraMachines & BootstrapConfigs will use the same name as the corresponding Machines.
-                properties:
-                  template:
-                    description: |-
-                      template defines the template to use for generating the names of the
-                      Machine objects.
-                      If not defined, it will fallback to `{{ .machineSet.name }}-{{ .random }}`.
-                      If the generated name string exceeds 63 characters, it will be trimmed to
-                      58 characters and will
-                      get concatenated with a random suffix of length 5.
-                      Length of the template string must not exceed 256 characters.
-                      The template allows the following variables `.cluster.name`,
-                      `.machineSet.name` and `.random`.
-                      The variable `.cluster.name` retrieves the name of the cluster object
-                      that owns the Machines being created.
-                      The variable `.machineSet.name` retrieves the name of the MachineSet
-                      object that owns the Machines being created.
-                      The variable `.random` is substituted with random alphanumeric string,
-                      without vowels, of length 5. This variable is required part of the
-                      template. If not provided, validation will fail.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                type: object
               minReadySeconds:
                 description: |-
                   minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.
@@ -1124,7 +1078,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      metadata is the standard object's metadata.
+                      Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -1140,7 +1094,7 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          labels is a map of string keys and values that can be used to organize and categorize
+                          Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
@@ -1148,7 +1102,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      spec is the specification of the desired behavior of the machine.
+                      Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       bootstrap:
@@ -1207,22 +1161,17 @@ spec:
                             description: |-
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
-                            maxLength: 253
-                            minLength: 1
                             type: string
                         type: object
                       clusterName:
                         description: clusterName is the name of the Cluster this object
                           belongs to.
-                        maxLength: 63
                         minLength: 1
                         type: string
                       failureDomain:
                         description: |-
                           failureDomain is the failure domain the machine will be created in.
                           Must match a key in the FailureDomains map stored on the cluster object.
-                        maxLength: 256
-                        minLength: 1
                         type: string
                       infrastructureRef:
                         description: |-
@@ -1298,8 +1247,6 @@ spec:
                           and then a comparison is done to find out unregistered machines and are marked for delete.
                           This field will be set by the actuators and consumed by higher level entities like autoscaler that will
                           be interfacing with cluster-api as generic provider.
-                        maxLength: 512
-                        minLength: 1
                         type: string
                       readinessGates:
                         description: |-
@@ -1323,23 +1270,12 @@ spec:
                           properties:
                             conditionType:
                               description: |-
-                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list.
                                 If the conditions doesn't exist, it will be treated as unknown.
                                 Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
                               maxLength: 316
                               minLength: 1
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                              type: string
-                            polarity:
-                              description: |-
-                                polarity of the conditionType specified in this readinessGate.
-                                Valid values are Positive, Negative and omitted.
-                                When omitted, the default behaviour will be Positive.
-                                A positive polarity means that the condition should report a true status under normal conditions.
-                                A negative polarity means that the condition should report a false status under normal conditions.
-                              enum:
-                              - Positive
-                              - Negative
                               type: string
                           required:
                           - conditionType
@@ -1353,8 +1289,6 @@ spec:
                         description: |-
                           version defines the desired Kubernetes version.
                           This field is meant to be optionally used by bootstrap providers.
-                        maxLength: 256
-                        minLength: 1
                         type: string
                     required:
                     - bootstrap
@@ -1367,11 +1301,11 @@ spec:
             - selector
             type: object
           status:
-            description: status is the observed state of MachineSet.
+            description: MachineSetStatus defines the observed state of MachineSet.
             properties:
               availableReplicas:
-                description: availableReplicas is the number of available replicas
-                  (ready for at least minReadySeconds) for this MachineSet.
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
                 format: int32
                 type: integer
               conditions:
@@ -1382,32 +1316,27 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        Last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        A human readable message indicating details about the transition.
                         This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
+                        The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
-                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -1417,8 +1346,6 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -1427,21 +1354,12 @@ spec:
                   type: object
                 type: array
               failureMessage:
-                description: |-
-                  failureMessage will be set in the event that there is a terminal problem
-                  reconciling the Machine and will contain a more verbose string suitable
-                  for logging and human consumption.
-
-                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
-                maxLength: 10240
-                minLength: 1
+                description: 'Deprecated: This field is deprecated and is going to
+                  be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md
+                  for more details.'
                 type: string
               failureReason:
                 description: |-
-                  failureReason will be set in the event that there is a terminal problem
-                  reconciling the Machine and will contain a succinct value suitable
-                  for machine interpretation.
-
                   In the event that there is a terminal problem reconciling the
                   replicas, both FailureReason and FailureMessage will be set. FailureReason
                   will be populated with a succinct value suitable for machine
@@ -1465,7 +1383,7 @@ spec:
                 type: string
               fullyLabeledReplicas:
                 description: |-
-                  fullyLabeledReplicas is the number of replicas that have labels matching the labels of the machine template of the MachineSet.
+                  The number of replicas that have labels matching the labels of the machine template of the MachineSet.
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
                 format: int32
@@ -1476,9 +1394,8 @@ spec:
                 format: int64
                 type: integer
               readyReplicas:
-                description: readyReplicas is the number of ready replicas for this
-                  MachineSet. A machine is considered ready when the node has been
-                  created and is "Ready".
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
                 format: int32
                 type: integer
               replicas:
@@ -1490,8 +1407,6 @@ spec:
                   selector is the same as the label selector but in the string format to avoid introspection
                   by clients. The string will be in the same format as the query-param syntax.
                   More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
-                maxLength: 4096
-                minLength: 1
                 type: string
               v1beta2:
                 description: v1beta2 groups all the fields that will be added or modified

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -167,7 +167,6 @@ package main
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,verbs=update;patch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions;customresourcedefinitions/status,verbs=patch;update
 //+kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=create;get;list;update;watch;patch;delete
 //+kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices;apiservices/finalizers,verbs=get;list;watch;create;update;patch;delete
@@ -265,7 +264,7 @@ package main
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets;placementdecisions;placementdecisions/status,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements/finalizers,verbs=update
-//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses;clusterclasses/status;clusters;clusters/finalizers;clusters/status;machinedrainrules;machinehealthchecks/finalizers;machinehealthchecks/status,verbs=get;list;patch;update;watch
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses;clusterclasses/status;clusters;clusters/finalizers;clusters/status;machinehealthchecks/finalizers;machinehealthchecks/status,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
@@ -277,6 +276,7 @@ package main
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=kubeadmcontrolplanes;machinedeployments;machines;machines/status,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments;machinedeployments/finalizers;machinedeployments/status;machinehealthchecks;machinepools;machinepools/finalizers;machinepools/status;machines;machines/finalizers;machines/status;machinesets;machinesets/finalizers;machinesets/status,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedrainrules,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools,verbs=list
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;patch;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=delete;get;list;watch
@@ -395,9 +395,8 @@ package main
 //+kubebuilder:rbac:groups=internal.open-cluster-management.io,resources=managedclusterinfos;managedclusterinfos/status,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=internal.open-cluster-management.io;"",resources=managedclusterinfos;pods;secrets,verbs=get
 //+kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims,verbs=get;list;watch
 //+kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims/status,verbs=get;watch
-//+kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims/status,verbs=patch;update
-//+kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims;ipaddresses,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups=ipam.cluster.x-k8s.io;ipam.metal3.io,resources=ipaddresses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=ipam.cluster.x-k8s.io;ipam.metal3.io,resources=ipaddresses/status,verbs=get
 //+kubebuilder:rbac:groups=ipam.metal3.io,resources=ipaddresses/status;ipclaims/status;ippools/status,verbs=get;patch;update


### PR DESCRIPTION
# Description

Updated cluster-api-installer branch ref to target backplane-2.9 instead of main, as the main branch has already moved on to targeting 2.10

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
