### PR TITLE
[ACM-21450] Added missing CRD check to backplane uninstall

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1741,7 +1741,7 @@ func (r *MultiClusterEngineReconciler) finalizeBackplaneConfig(ctx context.Conte
 		return ctrl.Result{}, fmt.Errorf(
 			"waiting for '%v' ManagedCluster to be terminated before proceeding with uninstallation", backplaneConfig.Spec.LocalClusterName)
 
-	} else if !apierrors.IsNotFound(err) { // Return error, if error is not not found error
+	} else if !apierrors.IsNotFound(err) && !errors.Is(err, errors.New("no matches for kind \"ManagedCluster\" in version \"cluster.open-cluster-management.io/v1\"")) { // Return error, if error is not not found error
 		log.Error(err, fmt.Sprintf("error while looking for %v ManagedCluster CR", backplaneConfig.Spec.LocalClusterName))
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
# Description

ACM-21450: MCE operator fails to uninstall when the ManagedCluster CRD is missing from the cluster. Add specific error check to catch this during uninstall.

## Related Issue

https://issues.redhat.com/browse/ACM-21450

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
