### PR TITLE
[backplane-2.8] add additional permisson to clusterlifecycle-state-metrics

### DIFF
--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/metrics-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/metrics-clusterrole.yaml
@@ -21,10 +21,10 @@ rules:
   - namespaces
   verbs:
   - get
-# Allow hub to monitor and update status of csr
+# Allow hub to monitor clusterdeployments, managedclusterinfos and managedclusters
 - apiGroups: ["hive.openshift.io"]
   resources: ["clusterdeployments"]
-  verbs: ["get"]
+  verbs: ["get","list","watch"]
 - apiGroups: ["internal.open-cluster-management.io"]
   resources: ["managedclusterinfos"]
   verbs: ["get","list","watch"]

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -333,8 +333,8 @@ package main
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterclaims;clusterdeployments;clusterpools;clusterimagesets;clusterprovisions;clusterdeprovisions;machinepools,verbs=list;watch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterclaims;clusterpools,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=create;delete;get;list;patch;update;watch
-//+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;patch;update;watch
+//+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=patch;delete;update
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments/finalizers,verbs=update


### PR DESCRIPTION
# Description

Add additional permission to clusterlifecycle-state-metrics to access Hive ClusterDeployment API.

## Related Issue

https://issues.redhat.com/browse/ACM-21189

## Changes Made

Add list/watch ClusterDeployment permission to clusterlifecycle-state-metrics.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
