### PR TITLE
[backplane-2.6] Updated gen-hive-bundle script to include --skip-release-config flag

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -1,11 +1,11 @@
-- branch: mce-2.6
+- branch: master
   bundlePath: /tmp/hive-operator-manifests
   gen_command: ./hack/bundle-automation/gen-hive-bundle.sh
   imageMappings:
     hive: openshift_hive
   name: hive-operator
   repo_name: hive
-  sha: 3f49f26197ffdfe78c7a270cb466d9a15a23cf08
+  sha: 76a65b6f3c5d04b90081f90eb901ad9a9c1d90cd
 - branch: backplane-2.6
   github_ref: https://github.com/openshift/image-based-install-operator.git
   operators:

--- a/hack/bundle-automation/gen-hive-bundle.sh
+++ b/hack/bundle-automation/gen-hive-bundle.sh
@@ -102,7 +102,7 @@ mkdir bundle
 cd bundle
 echo "Running Hive bundle-gen tool ($gen_tool)."
 python3 ../hive/$gen_tool --hive-repo "$hive_repo_spot" --commit "$commit_ish" --dummy-bundle "$branch" \
-   --image-repo dummy.io/disable-image-validation/hive
+   --image-repo dummy.io/disable-image-validation/hive --skip-release-config
 
 # Note: We point the bundle-gen tool at the local repo we already checked out
 # since we know that it contains the Git SHA we are using for input.


### PR DESCRIPTION
# Description

To use the latest `hive` commit in our automation, we’ll need to add the new script flag, `--skip-release-config`. This ensures we can continue relying on the dummy release configuration for their component.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated `gen-hive-bundle.sh` with new flag support

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
