### PR TITLE
Updated imageMappings for cluster-api component in MCE 2.9

### DIFF
--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -26,7 +26,7 @@
       always-or-toggle: "toggle"
       imageMappings:
         ose-cluster-api-rhel9: ose_cluster_api_rhel9
-        cluster-api-webhook-config-mce-29: cluster_api_webhook_config_mce_29
+        mce-capi-webhook-config-rhel9: mce_capi_webhook_config_rhel9
       inclusions:
         - "pullSecretOverride"
       skipRBACOverrides: true

--- a/pkg/templates/charts/toggle/cluster-api/templates/mce-capi-webhook-config-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/templates/mce-capi-webhook-config-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - name: NO_PROXY
           value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
 {{- end }}
-        image: '{{ .Values.global.imageOverrides.cluster_api_webhook_config_mce_29 }}'
+        image: '{{ .Values.global.imageOverrides.mce_capi_webhook_config_rhel9 }}'
         imagePullPolicy: '{{ .Values.global.pullPolicy }}'
         name: manager
         ports:

--- a/pkg/templates/charts/toggle/cluster-api/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/values.yaml
@@ -2,7 +2,7 @@ global:
   deployOnOCP: true
   hubSize: Small
   imageOverrides:
-    cluster_api_webhook_config_mce_29: ''
+    mce_capi_webhook_config_rhel9: ''
     ose_cluster_api_rhel9: ''
   namespace: default
   pullSecret: null

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -209,18 +209,20 @@ func GetTestImages() []string {
 		"CLUSTER_API_PROVIDER_AGENT", "CLUSTER_API_PROVIDER_AWS", "CLUSTER_API_PROVIDER_AZURE",
 		"CLUSTER_API_PROVIDER_KUBEVIRT", "KUBE_RBAC_PROXY_MCE", "CLUSTER_PROXY_ADDON", "CLUSTER_PROXY",
 		"CLUSTER_IMAGE_SET_CONTROLLER", "IMAGE_BASED_INSTALL_OPERATOR", "OSE_CLUSTER_API_RHEL9",
-		"OSE_AWS_CLUSTER_API_CONTROLLERS_RHEL9", "registration_operator", "openshift_hive", "multicloud_manager",
-		"managedcluster_import_controller", "registration", "work", "discovery_operator", "cluster_curator_controller",
-		"clusterlifecycle_state_metrics", "clusterclaims_controller", "provider_credential_controller",
-		"managed_serviceaccount", "assisted_service_8", "assisted_service_9", "assisted_image_service",
-		"postgresql_12", "assisted_installer_agent", "assisted_installer_controller", "assisted_installer",
-		"console_mce", "hypershift_addon_operator", "hypershift_operator", "apiserver_network_proxy",
-		"aws_encryption_provider", "cluster_api", "cluster_api_provider_agent", "cluster_api_provider_aws",
-		"cluster_api_provider_azure", "cluster_api_provider_kubevirt", "cluster_api_webhook_config_mce_29", "kube_rbac_proxy_mce", "cluster_proxy_addon",
+		"OSE_AWS_CLUSTER_API_CONTROLLERS_RHEL9", "MCE_CAPI_WEBHOOK_CONFIG_RHEL9", "registration_operator",
+		"openshift_hive", "multicloud_manager", "managedcluster_import_controller", "registration", "work",
+		"discovery_operator", "cluster_curator_controller", "clusterlifecycle_state_metrics",
+		"clusterclaims_controller", "provider_credential_controller", "managed_serviceaccount", "assisted_service_8",
+		"assisted_service_9", "assisted_image_service", "postgresql_12", "assisted_installer_agent",
+		"assisted_installer_controller", "assisted_installer", "console_mce", "hypershift_addon_operator",
+		"hypershift_operator", "apiserver_network_proxy", "aws_encryption_provider", "cluster_api",
+		"cluster_api_provider_agent", "cluster_api_provider_aws", "cluster_api_provider_azure",
+		"cluster_api_provider_kubevirt", "mce_capi_webhook_config_rhel9", "kube_rbac_proxy_mce", "cluster_proxy_addon",
 		"cluster_proxy", "cluster_image_set_controller", "image_based_install_operator", "ose_cluster_api_rhel9",
 		"ose_aws_cluster_api_controllers_rhel9", "cluster_api_bootstrap_provider_openshift_assisted",
 		"cluster_api_provider_openshift_assisted_bootstrap", "cluster_api_provider_openshift_assisted_control_plane",
-		"cluster_api_controlplane_provider_openshift_assisted", "ip_address_manager", "ose_baremetal_cluster_api_controllers_rhel9"}
+		"cluster_api_controlplane_provider_openshift_assisted", "ip_address_manager",
+		"ose_baremetal_cluster_api_controllers_rhel9"}
 }
 
 func IsUnitTest() bool {


### PR DESCRIPTION
# Description

In MCE 2.10, the `cluster-api` component updated its `image-key` reference to use `mce-capi-webhook-config-rhel9` and removed the release version suffix. This PR updates `charts-config.yaml` to incorporate these changes and ensure compatibility.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated `imageMapping` references for `cluster-api` to align with the latest `cluster-api-installer` chart version.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
