### PR TITLE
Add repository url label to container images

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -42,3 +42,4 @@ COPY --from=builder /workspace/pkg/templates pkg/templates
 USER 65532:65532
 
 ENTRYPOINT ["/app/backplane-operator"]
+LABEL url="https://github.com/stolostron/backplane-operator"


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** backplane-operator

**Branch details:** backplane-operator (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/backplane-operator

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.