### PR TITLE
Removed assisted service el8 image from MCE 2.10

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -29,7 +29,6 @@
       assisted-installer-agent: assisted_installer_agent
       assisted-installer-controller: assisted_installer_controller
       assisted-service: assisted_service_9
-      assisted-service-el8: assisted_service_8
       postgresql-12-c8s: postgresql_12
     name: assisted-service
   repo_name: assisted-service

--- a/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
@@ -52,8 +52,6 @@ spec:
 {{- end }}
         - name: SERVICE_IMAGE
           value: '{{ .Values.global.imageOverrides.assisted_service_9 }}'
-        - name: SERVICE_EL8_IMAGE
-          value: '{{ .Values.global.imageOverrides.assisted_service_8 }}'
         - name: IMAGE_SERVICE_IMAGE
           value: '{{ .Values.global.imageOverrides.assisted_image_service }}'
         - name: DATABASE_IMAGE

--- a/pkg/templates/charts/toggle/assisted-service/values.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/values.yaml
@@ -6,7 +6,6 @@ global:
     assisted_installer: ''
     assisted_installer_agent: ''
     assisted_installer_controller: ''
-    assisted_service_8: ''
     assisted_service_9: ''
     postgresql_12: ''
   namespace: default

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -229,7 +229,7 @@ func GetTestImages() []string {
 	return []string{
 		"REGISTRATION_OPERATOR", "OPENSHIFT_HIVE", "MULTICLOUD_MANAGER", "MANAGEDCLUSTER_IMPORT_CONTROLLER",
 		"REGISTRATION", "WORK", "DISCOVERY_OPERATOR", "CLUSTER_CURATOR_CONTROLLER", "CLUSTERLIFECYCLE_STATE_METRICS",
-		"CLUSTERCLAIMS_CONTROLLER", "PROVIDER_CREDENTIAL_CONTROLLER", "MANAGED_SERVICEACCOUNT", "ASSISTED_SERVICE_8",
+		"CLUSTERCLAIMS_CONTROLLER", "PROVIDER_CREDENTIAL_CONTROLLER", "MANAGED_SERVICEACCOUNT",
 		"ASSISTED_SERVICE_9", "ASSISTED_IMAGE_SERVICE", "POSTGRESQL_12", "ASSISTED_INSTALLER_AGENT",
 		"ASSISTED_INSTALLER_CONTROLLER", "ASSISTED_INSTALLER", "CONSOLE_MCE", "HYPERSHIFT_ADDON_OPERATOR",
 		"HYPERSHIFT_OPERATOR", "APISERVER_NETWORK_PROXY", "AWS_ENCRYPTION_PROVIDER", "CLUSTER_API",
@@ -239,7 +239,7 @@ func GetTestImages() []string {
 		"OSE_AWS_CLUSTER_API_CONTROLLERS_RHEL9", "MCE_CAPI_WEBHOOK_CONFIG_RHEL9",
 		"registration_operator", "openshift_hive", "multicloud_manager", "managedcluster_import_controller",
 		"registration", "work", "discovery_operator", "cluster_curator_controller", "clusterlifecycle_state_metrics",
-		"clusterclaims_controller", "provider_credential_controller", "managed_serviceaccount", "assisted_service_8",
+		"clusterclaims_controller", "provider_credential_controller", "managed_serviceaccount",
 		"assisted_service_9", "assisted_image_service", "postgresql_12", "assisted_installer_agent",
 		"assisted_installer_controller", "assisted_installer", "console_mce", "hypershift_addon_operator",
 		"hypershift_operator", "apiserver_network_proxy", "aws_encryption_provider", "cluster_api",


### PR DESCRIPTION
# Description

This PR removes the `assisted-service-8-rhel8` image, which is no longer required. The last OpenShift version that depended on this image for installing FIPS-enabled clusters was `4.15`. Since OCP `4.15` is no longer supported as a managed cluster with newer versions, the `el8` image can safely be removed.

## Related Issue

https://issues.redhat.com/browse/ACM-24680

## Changes Made

Removed the `assisted-service-8` external image reference from the MCE 2.10.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
