### PR TITLE
ACM-24682: configure ACM to import MCE

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -227,6 +227,14 @@ rules:
   resources:
   - namespaces
   - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
   - pods/portforward
   - secrets
   verbs:

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager_clusterrole.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager_clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.org }}:{{ .Chart.Name }}:hypershift-addon-manager
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "namespaces"]
   verbs: ["get", "list"]
 - apiGroups: [""]
   resources: ["secrets", "configmaps", "events", "services"]
@@ -46,7 +46,7 @@ rules:
   verbs: ["get", "create"]
 - apiGroups: ["addon.open-cluster-management.io"]
   resources: ["addondeploymentconfigs"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["create", "delete","get", "list", "watch", "update", "patch"]
 - apiGroups: ["operators.coreos.com"]
   resources: ["clusterserviceversions"]
   verbs: ["get", "list"]
@@ -65,3 +65,6 @@ rules:
 - apiGroups: [ "discovery.open-cluster-management.io" ]
   resources: [ "discoveredclusters" ]
   verbs: ["get", "list", "watch", "create", "update", "delete", "deletecollection", "patch"]
+- apiGroups: ["config.open-cluster-management.io"]
+  resources: ["klusterletconfigs"]
+  verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -63,9 +63,9 @@ package main
 //+kubebuilder:rbac:groups="",resources=nodes;pods;endpoints;services;secrets,verbs=get;watch;list
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get
-//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 //+kubebuilder:rbac:groups="",resources=pods,verbs=list
 //+kubebuilder:rbac:groups="",resources=pods,verbs=list
+//+kubebuilder:rbac:groups="",resources=pods;namespaces,verbs=get;list
 //+kubebuilder:rbac:groups="",resources=pods;nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods;pods/log,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch
@@ -106,7 +106,7 @@ package main
 //+kubebuilder:rbac:groups=action.open-cluster-management.io,resources=managedclusteractions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=action.open-cluster-management.io,resources=managedclusteractions/status,verbs=update;patch
 //+kubebuilder:rbac:groups=action.open-cluster-management.io,resources=managedclusteractions;managedclusteractions/status,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=create;delete;get;list;watch;update;patch
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs;addontemplates,verbs=get;list;watch
@@ -278,6 +278,7 @@ package main
 //+kubebuilder:rbac:groups=clusterview.open-cluster-management.io,resources=managedclusters;managedclustersets,verbs=list;get;watch
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;get;list;patch;update
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=get;list;watch;create;update;delete;patch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get


### PR DESCRIPTION
# Description

This is related to ACM-24682: configure ACM to import MCE, expanding the hypershift addon manager's permissions to handle namespace operations, manage addon deployment configurations, and work with klusterlet configurations - all necessary for the ACM to MCE import functionality.

## Related Issue

https://issues.redhat.com/browse/ACM-24682

## Changes Made

- Added namespace permissions 
- Expanded addondeploymentconfigs permissions
- Added klusterletconfigs permissions 

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
