### PR TITLE
[ACM-24342] Bump go version to v1.24.6 to resolve CVE-2025-47907

### DIFF
--- a/.github/workflows/rbac-gen.yml
+++ b/.github/workflows/rbac-gen.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.24.4'
+          - '1.24.6'
     name: Generate role permissions
     steps:
     - name: Checkout backplane

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-
-
 # Backplane Operator
 
 Operator for managing installation of Backplane components
 
 ## Prerequisites
 
-- Go v1.24.4+
+- Go v1.24.6+
 - kubectl 1.19+
 - Operator-sdk v1.17.0+
 - Docker or Podman

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/backplane-operator
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
# Description

To address CVE-2024-47907, it is recommended that we upgrade Go to version `go1.24.6`.

https://www.cve.org/CVERecord?id=CVE-2025-47907

## Related Issue

https://issues.redhat.com/browse/ACM-24342

## Changes Made

Updated `Go` version.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
