### PR TITLE
[backplane-2.9][ACM-25191] Reverted requirement for MCE CRD status component message

### DIFF
--- a/bundle/manifests/multicluster.openshift.io_multiclusterengines.yaml
+++ b/bundle/manifests/multicluster.openshift.io_multiclusterengines.yaml
@@ -240,11 +240,6 @@ spec:
                     type:
                       description: Type is the type of the cluster condition.
                       type: string
-                  required:
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
                 type: array
               conditions:
@@ -274,11 +269,6 @@ spec:
                     type:
                       description: Type is the type of the cluster condition.
                       type: string
-                  required:
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
                 type: array
               currentVersion:

--- a/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
+++ b/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
@@ -240,11 +240,6 @@ spec:
                     type:
                       description: Type is the type of the cluster condition.
                       type: string
-                  required:
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
                 type: array
               conditions:
@@ -274,11 +269,6 @@ spec:
                     type:
                       description: Type is the type of the cluster condition.
                       type: string
-                  required:
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
                 type: array
               currentVersion:


### PR DESCRIPTION
# Description

After upgrading to Go version 1.24, we also updated the `controller-runtime` and `controller-gen` packages. These updates introduced a hard requirement for status messages on components in the CR, which is now causing issues in our current upgrade path. To resolve this, we will revert those changes and remove the introduced requirement.

## Related Issue

https://issues.redhat.com/browse/ACM-25191

## Changes Made

Removed `status.components[x].message` requirement in MCE CRD.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
