### PR TITLE
[ACM-25574] Added remaining CAPI components to enable Hypershift safely via exclusion list

### DIFF
--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -410,6 +410,10 @@ func (r *MultiClusterEngine) validateComponentExclusivity() error {
 		ClusterAPIPreview,
 		ClusterAPIProviderAWS,
 		ClusterAPIProviderAWSPreview,
+		ClusterAPIProviderMetal,
+		ClusterAPIProviderMetalPreview,
+		ClusterAPIProviderOA,
+		ClusterAPIProviderOAPreview,
 	}
 
 	hypershiftEnabled := false
@@ -433,8 +437,8 @@ func (r *MultiClusterEngine) validateComponentExclusivity() error {
 
 	// Reject if both are enabled
 	if hypershiftEnabled && clusterAPIEnabled {
-		return fmt.Errorf("%w: HyperShift components (hypershift, hypershift-preview, hypershift-local-hosting) "+
-			"and Cluster API components (cluster-api, cluster-api-preview, cluster-api-provider-aws, cluster-api-provider-aws-preview) "+
+		return fmt.Errorf("%w: HyperShift components (hypershift, hypershift-local-hosting) "+
+			"and Cluster API components (cluster-api, cluster-api-provider-aws, cluster-api-provider-metal, cluster-api-provider-oa) "+
 			"cannot be enabled simultaneously. Please enable only one set of components",
 			ErrComponentExclusivity)
 	}

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -265,7 +265,7 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 	if err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	/*----------------------------------------------------------------
@@ -315,7 +315,7 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 	if err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	/*
@@ -335,7 +335,7 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 	if err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	// Attempt to retrieve image overrides from environmental variables.


### PR DESCRIPTION
# Description

This PR completes the CAPI/Hypershift component exclusion implementation by adding the remaining Cluster API provider components to the mutual exclusivity validation.

## Related Issue

https://issues.redhat.com/browse/ACM-25574

## Changes Made

  1. **Extended CAPI/Hypershift Exclusivity Validation** (`api/v1/multiclusterengine_webhook.go:410-445`)
     - Added `ClusterAPIProviderMetal`, `ClusterAPIProviderMetalPreview`, `ClusterAPIProviderOA`, and `ClusterAPIProviderOAPreview` to the list of CAPI components that cannot be enabled simultaneously with HyperShift  components.
     - Updated error message to reflect the complete set of excluded CAPI providers (cluster-api-provider-aws, cluster-api-provider-metal, cluster-api-provider-oa)
     - Simplified error message by removing specific preview component versions for clarity.

  2. **Fixed Error Handling** (`controllers/backplaneconfig_controller.go:268, 318, 338`)
     - Removed automatic requeue behavior (`Requeue: true`) from error returns in three reconciliation error paths.
     - This allows the controller to rely on standard controller-runtime error handling instead of forcing immediate requeues.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
