### PR TITLE
[ACM-23856] Added remaining CAPI components to skipDirs list for CRD creation

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1497,10 +1497,12 @@ func (r *MultiClusterEngineReconciler) getDisabledComponentCRDDirectories(mce *b
 	skipDirs := []string{}
 	dirMap := make(map[string]bool) // Track unique directories
 
-	// Only check cluster-api and cluster-api-provider-aws components
+	// Only check CAPI components
 	componentsToCheck := []string{
 		backplanev1.ClusterAPI,
 		backplanev1.ClusterAPIProviderAWS,
+		backplanev1.ClusterAPIProviderMetal,
+		backplanev1.ClusterAPIProviderOA,
 	}
 
 	for _, comp := range componentsToCheck {

--- a/main.go
+++ b/main.go
@@ -242,8 +242,10 @@ func main() {
 	// cluster-api and cluster-api-provider-aws CRDs are conditionally applied in the reconciler
 	setupLog.Info("Applying component CRDs")
 	skipCRDDirs := []string{
-		"cluster-api",
-		"cluster-api-provider-aws",
+		backplanev1.ClusterAPI,
+		backplanev1.ClusterAPIProviderAWS,
+		backplanev1.ClusterAPIProviderMetal,
+		backplanev1.ClusterAPIProviderOA,
 	}
 
 	crds, errs := renderer.RenderCRDs(crdsDir, nil, skipCRDDirs)


### PR DESCRIPTION
# Description

In the MCE 2.10 release, we introduced a feature that allows skipping the creation of certain component CRDs. This PR extends that functionality to include the remaining CAP(x) components, helping prevent conflicts when installing MCE alongside CAPI or Hypershift.

## Related Issue

https://issues.redhat.com/browse/ACM-23856

## Changes Made

Added `CAPOA` and `CAPMetal3` component to skip CRD list.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
