### PR TITLE
fix: Add k8s variant CAPI CRD directories to skip list

### DIFF
--- a/main.go
+++ b/main.go
@@ -242,10 +242,13 @@ func main() {
 	// cluster-api and cluster-api-provider-aws CRDs are conditionally applied in the reconciler
 	setupLog.Info("Applying component CRDs")
 	skipCRDDirs := []string{
-		backplanev1.ClusterAPI,
-		backplanev1.ClusterAPIProviderAWS,
-		backplanev1.ClusterAPIProviderMetal,
-		backplanev1.ClusterAPIProviderOA,
+		backplanev1.ClusterAPICRDDir,
+		backplanev1.ClusterAPIK8SCRDDir,
+		backplanev1.ClusterAPIProviderAWSCRDDir,
+		backplanev1.ClusterAPIProviderMetalCRDDir,
+		backplanev1.ClusterAPIProviderMetalK8SCRDDir,
+		backplanev1.ClusterAPIProviderOACRDDir,
+		backplanev1.ClusterAPIProviderOAK8SCRDDir,
 	}
 
 	crds, errs := renderer.RenderCRDs(crdsDir, nil, skipCRDDirs)


### PR DESCRIPTION
# Description

The skipCRDDirs list in `main.go` was missing the Kubernetes variant CRD directories (cluster-api-k8s, cluster-api-provider-metal3-k8s, and cluster-api-provider-openshift-assisted-k8s), causing CAPI CRDs to be created at operator startup even when CAPI components are disabled.

This was happening because:
- The operator has both OCP and k8s variants of CAPI CRDs
- `main.go` walks ALL CRD directories during startup
- Only OCP variant directories were in the skip list
- Kubernetes variant directories were being processed and CRDs created

This ensures CAPI CRDs are only created when components are explicitly enabled, regardless of whether the cluster is OCP or vanilla Kubernetes.

## Related Issue

Related commits: 64533a1, 1ba5e8d, c40ad79

## Changes Made

Changes:
- Added ClusterAPIK8SCRDDir to skip list
- Added ClusterAPIProviderMetalK8SCRDDir to skip list
- Added ClusterAPIProviderOAK8SCRDDir to skip list
- Changed to use *CRDDir constants instead of component name constants for consistency

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
