### PR TITLE
Refactor: return all CRD directory variants for CAPI components

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1463,7 +1463,9 @@ func (r *MultiClusterEngineReconciler) getExternallyManagedCRDDirectories(mce *b
 	dirMap := make(map[string]bool) // Track unique directories
 
 	for _, comp := range components {
-		if crdDir, exists := utils.ComponentToCRDDirectory()[comp]; exists {
+		// Get all CRD directory variants for this component
+		crdDirs := utils.ComponentCRDDirectories(comp)
+		for _, crdDir := range crdDirs {
 			// Only add if not already in the list
 			if !dirMap[crdDir] {
 				skipDirs = append(skipDirs, crdDir)
@@ -1499,8 +1501,9 @@ func (r *MultiClusterEngineReconciler) getDisabledComponentCRDDirectories(mce *b
 			continue
 		}
 
-		// Component is disabled - add its CRD directory to skip list
-		if crdDir, exists := utils.ComponentToCRDDirectory()[comp]; exists {
+		// Component is disabled - add all its CRD directory variants to skip list
+		crdDirs := utils.ComponentCRDDirectories(comp)
+		for _, crdDir := range crdDirs {
 			// Only add if not already in the list
 			if !dirMap[crdDir] {
 				skipDirs = append(skipDirs, crdDir)

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -2463,7 +2463,7 @@ func Test_getExternallyManagedCRDDirectories(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"cluster-api", "hive-operator"},
+			want: []string{"cluster-api", "cluster-api-k8s", "hive-operator"},
 		},
 		{
 			name: "single externally managed component",
@@ -2475,7 +2475,7 @@ func Test_getExternallyManagedCRDDirectories(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"cluster-api"},
+			want: []string{"cluster-api", "cluster-api-k8s"},
 		},
 		{
 			name: "no externally managed components",
@@ -2508,7 +2508,7 @@ func Test_getExternallyManagedCRDDirectories(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"cluster-api"},
+			want: []string{"cluster-api", "cluster-api-k8s"},
 		},
 	}
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -302,160 +302,134 @@ func TestIsEUSUpgrading(t *testing.T) {
 	}
 }
 
-func TestComponentToCRDDirectory(t *testing.T) {
+func TestComponentCRDDirectories(t *testing.T) {
 	tests := []struct {
-		name        string
-		deployOnOCP bool
-		assertions  []struct {
-			component      string
-			expectedCRDDir string
-			description    string
-		}
+		name         string
+		component    string
+		expectedDirs []string
+		description  string
 	}{
+		// CAPI components with platform variants - should return both OCP and K8s
 		{
-			name:        "OCP deployment - uses OCP CRD directories",
-			deployOnOCP: true,
-			assertions: []struct {
-				component      string
-				expectedCRDDir string
-				description    string
-			}{
-				{
-					component:      backplanev1.ClusterAPI,
-					expectedCRDDir: backplanev1.ClusterAPICRDDir,
-					description:    "ClusterAPI should use OCP CRD directory",
-				},
-				{
-					component:      backplanev1.ClusterAPIPreview,
-					expectedCRDDir: backplanev1.ClusterAPICRDDir,
-					description:    "ClusterAPIPreview should use OCP CRD directory",
-				},
-				{
-					component:      backplanev1.ClusterAPIProviderOA,
-					expectedCRDDir: backplanev1.ClusterAPIProviderOACRDDir,
-					description:    "ClusterAPIProviderOA should use OCP CRD directory",
-				},
-				{
-					component:      backplanev1.ClusterAPIProviderOAPreview,
-					expectedCRDDir: backplanev1.ClusterAPIProviderOACRDDir,
-					description:    "ClusterAPIProviderOAPreview should use OCP CRD directory",
-				},
-				{
-					component:      backplanev1.ClusterAPIProviderMetal,
-					expectedCRDDir: backplanev1.ClusterAPIProviderMetalCRDDir,
-					description:    "ClusterAPIProviderMetal should use OCP CRD directory",
-				},
-				{
-					component:      backplanev1.ClusterAPIProviderMetalPreview,
-					expectedCRDDir: backplanev1.ClusterAPIProviderMetalCRDDir,
-					description:    "ClusterAPIProviderMetalPreview should use OCP CRD directory",
-				},
-				{
-					component:      backplanev1.AssistedService,
-					expectedCRDDir: backplanev1.AssistedServiceCRDDir,
-					description:    "AssistedService should use correct CRD directory",
-				},
-				{
-					component:      backplanev1.ClusterLifecycle,
-					expectedCRDDir: backplanev1.ClusterLifecycleCRDDir,
-					description:    "ClusterLifecycle should use correct CRD directory",
-				},
-				{
-					component:      backplanev1.ClusterManager,
-					expectedCRDDir: backplanev1.ClusterManagerCRDDir,
-					description:    "ClusterManager should use correct CRD directory",
-				},
+			name:      "ClusterAPI returns both variants",
+			component: backplanev1.ClusterAPI,
+			expectedDirs: []string{
+				backplanev1.ClusterAPICRDDir,
+				backplanev1.ClusterAPIK8SCRDDir,
 			},
+			description: "ClusterAPI should return both OCP and K8s CRD directories",
 		},
 		{
-			name:        "Non-OCP deployment - uses K8S CRD directories",
-			deployOnOCP: false,
-			assertions: []struct {
-				component      string
-				expectedCRDDir string
-				description    string
-			}{
-				{
-					component:      backplanev1.ClusterAPI,
-					expectedCRDDir: backplanev1.ClusterAPIK8SCRDDir,
-					description:    "ClusterAPI should use K8S CRD directory on non-OCP",
-				},
-				{
-					component:      backplanev1.ClusterAPIPreview,
-					expectedCRDDir: backplanev1.ClusterAPIK8SCRDDir,
-					description:    "ClusterAPIPreview should use K8S CRD directory on non-OCP",
-				},
-				{
-					component:      backplanev1.ClusterAPIProviderOA,
-					expectedCRDDir: backplanev1.ClusterAPIProviderOAK8SCRDDir,
-					description:    "ClusterAPIProviderOA should use K8S CRD directory on non-OCP",
-				},
-				{
-					component:      backplanev1.ClusterAPIProviderOAPreview,
-					expectedCRDDir: backplanev1.ClusterAPIProviderOAK8SCRDDir,
-					description:    "ClusterAPIProviderOAPreview should use K8S CRD directory on non-OCP",
-				},
-				{
-					component:      backplanev1.ClusterAPIProviderMetal,
-					expectedCRDDir: backplanev1.ClusterAPIProviderMetalK8SCRDDir,
-					description:    "ClusterAPIProviderMetal should use K8S CRD directory on non-OCP",
-				},
-				{
-					component:      backplanev1.ClusterAPIProviderMetalPreview,
-					expectedCRDDir: backplanev1.ClusterAPIProviderMetalK8SCRDDir,
-					description:    "ClusterAPIProviderMetalPreview should use K8S CRD directory on non-OCP",
-				},
-				{
-					component:      backplanev1.AssistedService,
-					expectedCRDDir: backplanev1.AssistedServiceCRDDir,
-					description:    "AssistedService should use correct CRD directory",
-				},
-				{
-					component:      backplanev1.ClusterLifecycle,
-					expectedCRDDir: backplanev1.ClusterLifecycleCRDDir,
-					description:    "ClusterLifecycle should use correct CRD directory",
-				},
+			name:      "ClusterAPIPreview returns both variants",
+			component: backplanev1.ClusterAPIPreview,
+			expectedDirs: []string{
+				backplanev1.ClusterAPICRDDir,
+				backplanev1.ClusterAPIK8SCRDDir,
 			},
+			description: "ClusterAPIPreview should return both OCP and K8s CRD directories",
+		},
+		{
+			name:      "ClusterAPIProviderMetal returns both variants",
+			component: backplanev1.ClusterAPIProviderMetal,
+			expectedDirs: []string{
+				backplanev1.ClusterAPIProviderMetalCRDDir,
+				backplanev1.ClusterAPIProviderMetalK8SCRDDir,
+			},
+			description: "ClusterAPIProviderMetal should return both OCP and K8s CRD directories",
+		},
+		{
+			name:      "ClusterAPIProviderMetalPreview returns both variants",
+			component: backplanev1.ClusterAPIProviderMetalPreview,
+			expectedDirs: []string{
+				backplanev1.ClusterAPIProviderMetalCRDDir,
+				backplanev1.ClusterAPIProviderMetalK8SCRDDir,
+			},
+			description: "ClusterAPIProviderMetalPreview should return both OCP and K8s CRD directories",
+		},
+		{
+			name:      "ClusterAPIProviderOA returns both variants",
+			component: backplanev1.ClusterAPIProviderOA,
+			expectedDirs: []string{
+				backplanev1.ClusterAPIProviderOACRDDir,
+				backplanev1.ClusterAPIProviderOAK8SCRDDir,
+			},
+			description: "ClusterAPIProviderOA should return both OCP and K8s CRD directories",
+		},
+		{
+			name:      "ClusterAPIProviderOAPreview returns both variants",
+			component: backplanev1.ClusterAPIProviderOAPreview,
+			expectedDirs: []string{
+				backplanev1.ClusterAPIProviderOACRDDir,
+				backplanev1.ClusterAPIProviderOAK8SCRDDir,
+			},
+			description: "ClusterAPIProviderOAPreview should return both OCP and K8s CRD directories",
+		},
+
+		// Non-CAPI components - should return single directory
+		{
+			name:      "AssistedService returns single directory",
+			component: backplanev1.AssistedService,
+			expectedDirs: []string{
+				backplanev1.AssistedServiceCRDDir,
+			},
+			description: "AssistedService should return single CRD directory",
+		},
+		{
+			name:      "ClusterAPIProviderAWS returns single directory",
+			component: backplanev1.ClusterAPIProviderAWS,
+			expectedDirs: []string{
+				backplanev1.ClusterAPIProviderAWSCRDDir,
+			},
+			description: "ClusterAPIProviderAWS should return single CRD directory",
+		},
+		{
+			name:      "ClusterLifecycle returns single directory",
+			component: backplanev1.ClusterLifecycle,
+			expectedDirs: []string{
+				backplanev1.ClusterLifecycleCRDDir,
+			},
+			description: "ClusterLifecycle should return single CRD directory",
+		},
+		{
+			name:      "ClusterManager returns single directory",
+			component: backplanev1.ClusterManager,
+			expectedDirs: []string{
+				backplanev1.ClusterManagerCRDDir,
+			},
+			description: "ClusterManager should return single CRD directory",
+		},
+		{
+			name:         "Unknown component returns empty slice",
+			component:    "unknown-component",
+			expectedDirs: []string{},
+			description:  "Unknown component should return empty slice",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set the deployment type
-			originalDeployOnOCP := GlobalDeployOnOCP
-			SetDeployOnOCP(tt.deployOnOCP)
-			defer SetDeployOnOCP(originalDeployOnOCP) // Restore original value after test
+			result := ComponentCRDDirectories(tt.component)
 
-			// Get the component to CRD directory mapping
-			result := ComponentToCRDDirectory()
-
-			// Verify the result is not nil
-			if result == nil {
-				t.Fatal("ComponentToCRDDirectory() returned nil")
+			// Check if the length matches
+			if len(result) != len(tt.expectedDirs) {
+				t.Errorf("%s: got %d directories, want %d", tt.description, len(result), len(tt.expectedDirs))
+				t.Errorf("  got: %v", result)
+				t.Errorf("  want: %v", tt.expectedDirs)
+				return
 			}
 
-			// Run all assertions for this test case
-			for _, assertion := range tt.assertions {
-				if got, ok := result[assertion.component]; !ok {
-					t.Errorf("%s: component %s not found in result map", assertion.description, assertion.component)
-				} else if got != assertion.expectedCRDDir {
-					t.Errorf("%s: got %v, want %v", assertion.description, got, assertion.expectedCRDDir)
+			// Check if all expected directories are present in order
+			for i, expected := range tt.expectedDirs {
+				if result[i] != expected {
+					t.Errorf("%s: directory[%d] = %v, want %v", tt.description, i, result[i], expected)
 				}
 			}
 		})
 	}
 }
 
-func TestComponentToCRDDirectory_AllComponents(t *testing.T) {
-	// Store original value
-	originalDeployOnOCP := GlobalDeployOnOCP
-	defer SetDeployOnOCP(originalDeployOnOCP)
-
-	// Test on OCP
-	SetDeployOnOCP(true)
-	ocpResult := ComponentToCRDDirectory()
-
-	// Verify all expected components are present in OCP mode
+func TestComponentCRDDirectories_AllComponents(t *testing.T) {
+	// Verify all expected components return at least one directory
 	expectedComponents := []string{
 		backplanev1.AssistedService,
 		backplanev1.ClusterAPI,
@@ -479,42 +453,51 @@ func TestComponentToCRDDirectory_AllComponents(t *testing.T) {
 	}
 
 	for _, component := range expectedComponents {
-		if _, ok := ocpResult[component]; !ok {
-			t.Errorf("Component %s not found in OCP result map", component)
+		result := ComponentCRDDirectories(component)
+		if len(result) == 0 {
+			t.Errorf("Component %s returned no CRD directories", component)
 		}
 	}
 
-	// Test on non-OCP (K8S)
-	SetDeployOnOCP(false)
-	k8sResult := ComponentToCRDDirectory()
+	// Verify that CAPI components return exactly 2 directories (OCP and K8s variants)
+	capiComponents := []string{
+		backplanev1.ClusterAPI,
+		backplanev1.ClusterAPIPreview,
+		backplanev1.ClusterAPIProviderMetal,
+		backplanev1.ClusterAPIProviderMetalPreview,
+		backplanev1.ClusterAPIProviderOA,
+		backplanev1.ClusterAPIProviderOAPreview,
+	}
 
-	// Verify all expected components are present in K8S mode
-	for _, component := range expectedComponents {
-		if _, ok := k8sResult[component]; !ok {
-			t.Errorf("Component %s not found in K8S result map", component)
+	for _, component := range capiComponents {
+		result := ComponentCRDDirectories(component)
+		if len(result) != 2 {
+			t.Errorf("CAPI component %s should return 2 directories, got %d: %v", component, len(result), result)
 		}
 	}
 
-	// Verify that ClusterAPI components use different directories on OCP vs K8S
-	if ocpResult[backplanev1.ClusterAPI] == k8sResult[backplanev1.ClusterAPI] {
-		t.Error("ClusterAPI should use different CRD directories on OCP vs K8S")
+	// Verify that non-CAPI components return exactly 1 directory
+	nonCapiComponents := []string{
+		backplanev1.AssistedService,
+		backplanev1.ClusterAPIProviderAWS,
+		backplanev1.ClusterAPIProviderAWSPreview,
+		backplanev1.ClusterLifecycle,
+		backplanev1.ClusterManager,
+		backplanev1.ClusterProxyAddon,
+		backplanev1.Discovery,
+		backplanev1.Hive,
+		backplanev1.ImageBasedInstallOperator,
+		backplanev1.ImageBasedInstallOperatorPreview,
+		backplanev1.ManagedServiceAccount,
+		backplanev1.ManagedServiceAccountPreview,
+		backplanev1.ServerFoundation,
 	}
 
-	if ocpResult[backplanev1.ClusterAPIProviderOA] == k8sResult[backplanev1.ClusterAPIProviderOA] {
-		t.Error("ClusterAPIProviderOA should use different CRD directories on OCP vs K8S")
-	}
-
-	if ocpResult[backplanev1.ClusterAPIProviderMetal] == k8sResult[backplanev1.ClusterAPIProviderMetal] {
-		t.Error("ClusterAPIProviderMetal should use different CRD directories on OCP vs K8S")
-	}
-
-	// Verify that non-ClusterAPI components use the same directories on both platforms
-	if ocpResult[backplanev1.AssistedService] != k8sResult[backplanev1.AssistedService] {
-		t.Error("AssistedService should use the same CRD directory on OCP and K8S")
-	}
-
-	if ocpResult[backplanev1.ClusterAPIProviderAWS] != k8sResult[backplanev1.ClusterAPIProviderAWS] {
-		t.Error("ClusterAPIProviderAWS should use the same CRD directory on OCP and K8S")
+	for _, component := range nonCapiComponents {
+		result := ComponentCRDDirectories(component)
+		if len(result) != 1 {
+			t.Errorf("Non-CAPI component %s should return 1 directory, got %d: %v", component, len(result), result)
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

Replace ComponentToCRDDirectory() map with ComponentCRDDirectories() function that returns all platform variants (OCP and K8s) for CAPI components. This ensures proper CRD handling across platforms by including all variant directories in skip lists, preventing issues when CRDs exist in non-primary variant paths.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

- Replace map-based ComponentToCRDDirectory() with ComponentCRDDirectories()
- Return slice of directories instead of single directory from map lookup
- Update controller to iterate over all returned CRD directory variants
- Update tests to validate both platform variants are returned for CAPI components

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
