### PR TITLE
[ACM-27552] Added ClusterPool as prerequisite for MCE deletion

### DIFF
--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -63,19 +63,27 @@ var (
 
 	blockDeletionResources = []BlockDeletionResource{
 		{
-			Name: "DiscoveryConfig",
-			GVK: schema.GroupVersionKind{
-				Group:   "discovery.open-cluster-management.io",
-				Version: "v1",
-				Kind:    "DiscoveryConfigList",
-			},
-		},
-		{
 			Name: "AgentServiceConfig",
 			GVK: schema.GroupVersionKind{
 				Group:   "agent-install.openshift.io",
 				Version: "v1beta1",
 				Kind:    "AgentServiceConfigList",
+			},
+		},
+		{
+			Name: "ClusterPool",
+			GVK: schema.GroupVersionKind{
+				Group:   "hive.openshift.io",
+				Version: "v1",
+				Kind:    "ClusterPoolList",
+			},
+		},
+		{
+			Name: "DiscoveryConfig",
+			GVK: schema.GroupVersionKind{
+				Group:   "discovery.open-cluster-management.io",
+				Version: "v1",
+				Kind:    "DiscoveryConfigList",
 			},
 		},
 	}
@@ -325,6 +333,7 @@ func (r *MultiClusterEngine) ValidateDelete() (admission.Warnings, error) {
 	// TODO(user): fill in your validation logic upon object deletion.
 	backplaneconfiglog.Info("validate delete", "Kind", r.Kind, "Name", r.GetName())
 	ctx := context.Background()
+
 	if val, ok := os.LookupEnv("ENV_TEST"); !ok || val == "false" {
 		var err error
 		cfg, err = config.GetConfig()

--- a/api/v1/multiclusterengine_webhook_test.go
+++ b/api/v1/multiclusterengine_webhook_test.go
@@ -171,6 +171,144 @@ var _ = Describe("Multiclusterengine webhook", func() {
 			})
 		})
 
+		It("Should fail to delete multiclusterengine when AgentServiceConfig exists", func() {
+			mce := &MultiClusterEngine{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())
+
+			By("Creating an AgentServiceConfig resource", func() {
+				agentServiceConfig := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "agent-install.openshift.io/v1beta1",
+						"kind":       "AgentServiceConfig",
+						"metadata": map[string]interface{}{
+							"name": "test-agent-service-config",
+						},
+						"spec": map[string]interface{}{
+							"databaseStorage": map[string]interface{}{
+								"storageClassName": "test-storage",
+							},
+							"filesystemStorage": map[string]interface{}{
+								"storageClassName": "test-storage",
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, agentServiceConfig)).To(Succeed())
+			})
+
+			By("Attempting to delete MCE should fail", func() {
+				err := k8sClient.Delete(ctx, mce)
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("Existing AgentServiceConfig resources must first be deleted"))
+			})
+
+			By("Cleaning up AgentServiceConfig", func() {
+				agentServiceConfig := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "agent-install.openshift.io/v1beta1",
+						"kind":       "AgentServiceConfig",
+						"metadata": map[string]interface{}{
+							"name": "test-agent-service-config",
+						},
+					},
+				}
+				Expect(k8sClient.Delete(ctx, agentServiceConfig)).To(Succeed())
+			})
+		})
+
+		It("Should fail to delete multiclusterengine when ClusterPool exists", func() {
+			mce := &MultiClusterEngine{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())
+
+			By("Creating a ClusterPool resource", func() {
+				clusterPool := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "hive.openshift.io/v1",
+						"kind":       "ClusterPool",
+						"metadata": map[string]interface{}{
+							"name":      "test-pool",
+							"namespace": "default",
+						},
+						"spec": map[string]interface{}{
+							"size":       1,
+							"baseDomain": "test.example.com",
+							"imageSetRef": map[string]interface{}{
+								"name": "test-imageset",
+							},
+							"platform": map[string]interface{}{
+								"aws": map[string]interface{}{
+									"region": "us-east-1",
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, clusterPool)).To(Succeed())
+			})
+
+			By("Attempting to delete MCE should fail", func() {
+				err := k8sClient.Delete(ctx, mce)
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("Existing ClusterPool resources must first be deleted"))
+			})
+
+			By("Cleaning up ClusterPool", func() {
+				clusterPool := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "hive.openshift.io/v1",
+						"kind":       "ClusterPool",
+						"metadata": map[string]interface{}{
+							"name":      "test-pool",
+							"namespace": "default",
+						},
+					},
+				}
+				Expect(k8sClient.Delete(ctx, clusterPool)).To(Succeed())
+			})
+		})
+
+		It("Should fail to delete multiclusterengine when DiscoveryConfig exists", func() {
+			mce := &MultiClusterEngine{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())
+
+			By("Creating a DiscoveryConfig resource", func() {
+				discoveryConfig := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "discovery.open-cluster-management.io/v1",
+						"kind":       "DiscoveryConfig",
+						"metadata": map[string]interface{}{
+							"name":      "test-discovery",
+							"namespace": "default",
+						},
+						"spec": map[string]interface{}{
+							"credential": "test-credential",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, discoveryConfig)).To(Succeed())
+			})
+
+			By("Attempting to delete MCE should fail", func() {
+				err := k8sClient.Delete(ctx, mce)
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("Existing DiscoveryConfig resources must first be deleted"))
+			})
+
+			By("Cleaning up DiscoveryConfig", func() {
+				discoveryConfig := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "discovery.open-cluster-management.io/v1",
+						"kind":       "DiscoveryConfig",
+						"metadata": map[string]interface{}{
+							"name":      "test-discovery",
+							"namespace": "default",
+						},
+					},
+				}
+				Expect(k8sClient.Delete(ctx, discoveryConfig)).To(Succeed())
+			})
+		})
+
 		It("Should succeed in deleting multiclusterengine", func() {
 			mce := &MultiClusterEngine{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())

--- a/hack/unit-test-crds/agentserviceconfigs.yaml
+++ b/hack/unit-test-crds/agentserviceconfigs.yaml
@@ -1,0 +1,837 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  creationTimestamp: null
+  name: agentserviceconfigs.agent-install.openshift.io
+spec:
+  group: agent-install.openshift.io
+  names:
+    kind: AgentServiceConfig
+    listKind: AgentServiceConfigList
+    plural: agentserviceconfigs
+    singular: agentserviceconfig
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AgentServiceConfig represents an Assisted Service deployment.
+          Only an AgentServiceConfig with name="agent" will be reconciled. All other
+          names will be rejected.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentServiceConfigSpec defines the desired state of AgentServiceConfig.
+            properties:
+              OSImageAdditionalParamsRef:
+                description: OSImageAdditionalParamsRef is a reference to a secret
+                  containing a headers and query parameters to be used during OS image
+                  fetch.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              OSImageCACertRef:
+                description: |-
+                  OSImageCACertRef is a reference to a config map containing a certificate authority certificate
+                  this is an optional certificate to allow a user to add a certificate authority for a HTTPS source of images
+                  this certificate will be used by the assisted-image-service when pulling OS images.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              databaseStorage:
+                description: |-
+                  DatabaseStorage defines the spec of the PersistentVolumeClaim to be
+                  created for the database's filesystem.
+                  With respect to the resource requests, minimum 10GiB is recommended.
+                properties:
+                  accessModes:
+                    description: |-
+                      accessModes contains the desired access modes the volume should have.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                    items:
+                      type: string
+                    type: array
+                  dataSource:
+                    description: |-
+                      dataSource field can be used to specify either:
+                      * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                      * An existing PVC (PersistentVolumeClaim)
+                      If the provisioner or an external controller can support the specified data source,
+                      it will create a new volume based on the contents of the specified data source.
+                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                      If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSourceRef:
+                    description: |-
+                      dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                      volume is desired. This may be any object from a non-empty API group (non
+                      core object) or a PersistentVolumeClaim object.
+                      When this field is specified, volume binding will only succeed if the type of
+                      the specified object matches some installed volume populator or dynamic
+                      provisioner.
+                      This field will replace the functionality of the dataSource field and as such
+                      if both fields are non-empty, they must have the same value. For backwards
+                      compatibility, when namespace isn't specified in dataSourceRef,
+                      both fields (dataSource and dataSourceRef) will be set to the same
+                      value automatically if one of them is empty and the other is non-empty.
+                      When namespace is specified in dataSourceRef,
+                      dataSource isn't set to the same value and must be empty.
+                      There are three important differences between dataSource and dataSourceRef:
+                      * While dataSource only allows two specific types of objects, dataSourceRef
+                        allows any non-core object, as well as PersistentVolumeClaim objects.
+                      * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                        preserves all values, and generates an error if a disallowed value is
+                        specified.
+                      * While dataSource only allows local objects, dataSourceRef allows objects
+                        in any namespaces.
+                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                      (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of resource being referenced
+                          Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                          (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  resources:
+                    description: |-
+                      resources represents the minimum resources the volume should have.
+                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                      that are lower than previous value but must still be higher than capacity recorded in the
+                      status field of the claim.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  selector:
+                    description: selector is a label query over volumes to consider
+                      for binding.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  storageClassName:
+                    description: |-
+                      storageClassName is the name of the StorageClass required by the claim.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                    type: string
+                  volumeAttributesClassName:
+                    description: |-
+                      volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                      If specified, the CSI driver will create or update the volume with the attributes defined
+                      in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                      will be set by the persistentvolume controller if it exists.
+                      If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                      set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                      exists.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                    type: string
+                  volumeMode:
+                    description: |-
+                      volumeMode defines what type of volume is required by the claim.
+                      Value of Filesystem is implied when not included in claim spec.
+                    type: string
+                  volumeName:
+                    description: volumeName is the binding reference to the PersistentVolume
+                      backing this claim.
+                    type: string
+                type: object
+              filesystemStorage:
+                description: |-
+                  FileSystemStorage defines the spec of the PersistentVolumeClaim to be
+                  created for the assisted-service's filesystem (logs, etc).
+                  With respect to the resource requests, the amount of filesystem storage
+                  consumed will depend largely on the number of clusters created (~200MB
+                  per cluster and ~2-3GiB per supported OpenShift version). Minimum 100GiB
+                  recommended.
+                properties:
+                  accessModes:
+                    description: |-
+                      accessModes contains the desired access modes the volume should have.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                    items:
+                      type: string
+                    type: array
+                  dataSource:
+                    description: |-
+                      dataSource field can be used to specify either:
+                      * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                      * An existing PVC (PersistentVolumeClaim)
+                      If the provisioner or an external controller can support the specified data source,
+                      it will create a new volume based on the contents of the specified data source.
+                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                      If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSourceRef:
+                    description: |-
+                      dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                      volume is desired. This may be any object from a non-empty API group (non
+                      core object) or a PersistentVolumeClaim object.
+                      When this field is specified, volume binding will only succeed if the type of
+                      the specified object matches some installed volume populator or dynamic
+                      provisioner.
+                      This field will replace the functionality of the dataSource field and as such
+                      if both fields are non-empty, they must have the same value. For backwards
+                      compatibility, when namespace isn't specified in dataSourceRef,
+                      both fields (dataSource and dataSourceRef) will be set to the same
+                      value automatically if one of them is empty and the other is non-empty.
+                      When namespace is specified in dataSourceRef,
+                      dataSource isn't set to the same value and must be empty.
+                      There are three important differences between dataSource and dataSourceRef:
+                      * While dataSource only allows two specific types of objects, dataSourceRef
+                        allows any non-core object, as well as PersistentVolumeClaim objects.
+                      * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                        preserves all values, and generates an error if a disallowed value is
+                        specified.
+                      * While dataSource only allows local objects, dataSourceRef allows objects
+                        in any namespaces.
+                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                      (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of resource being referenced
+                          Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                          (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  resources:
+                    description: |-
+                      resources represents the minimum resources the volume should have.
+                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                      that are lower than previous value but must still be higher than capacity recorded in the
+                      status field of the claim.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  selector:
+                    description: selector is a label query over volumes to consider
+                      for binding.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  storageClassName:
+                    description: |-
+                      storageClassName is the name of the StorageClass required by the claim.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                    type: string
+                  volumeAttributesClassName:
+                    description: |-
+                      volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                      If specified, the CSI driver will create or update the volume with the attributes defined
+                      in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                      will be set by the persistentvolume controller if it exists.
+                      If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                      set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                      exists.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                    type: string
+                  volumeMode:
+                    description: |-
+                      volumeMode defines what type of volume is required by the claim.
+                      Value of Filesystem is implied when not included in claim spec.
+                    type: string
+                  volumeName:
+                    description: volumeName is the binding reference to the PersistentVolume
+                      backing this claim.
+                    type: string
+                type: object
+              iPXEHTTPRoute:
+                description: |-
+                  IPXEHTTPRoute is controlling whether the operator is creating plain HTTP routes
+                  iPXE hosts may not work with router cyphers and may access artifacts via HTTP only
+                  This setting accepts "enabled,disabled", defaults to disabled. Empty value defaults to disabled
+                  The following endpoints would be exposed via http:
+                  * api/assisted-installer/v2/infra-envs/<id>/downloads/files?file_name=ipxe-script in assisted-service
+                  * boot-artifacts/ and images/<infra-enf id>/pxe-initrd in -image-service
+                enum:
+                - enabled
+                - disabled
+                type: string
+              imageStorage:
+                description: |-
+                  ImageStorage defines the spec of the PersistentVolumeClaim to be
+                  created for each replica of the image service.
+                  If a PersistentVolumeClaim is provided 2GiB per OSImage entry is required
+                properties:
+                  accessModes:
+                    description: |-
+                      accessModes contains the desired access modes the volume should have.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                    items:
+                      type: string
+                    type: array
+                  dataSource:
+                    description: |-
+                      dataSource field can be used to specify either:
+                      * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                      * An existing PVC (PersistentVolumeClaim)
+                      If the provisioner or an external controller can support the specified data source,
+                      it will create a new volume based on the contents of the specified data source.
+                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                      If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSourceRef:
+                    description: |-
+                      dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                      volume is desired. This may be any object from a non-empty API group (non
+                      core object) or a PersistentVolumeClaim object.
+                      When this field is specified, volume binding will only succeed if the type of
+                      the specified object matches some installed volume populator or dynamic
+                      provisioner.
+                      This field will replace the functionality of the dataSource field and as such
+                      if both fields are non-empty, they must have the same value. For backwards
+                      compatibility, when namespace isn't specified in dataSourceRef,
+                      both fields (dataSource and dataSourceRef) will be set to the same
+                      value automatically if one of them is empty and the other is non-empty.
+                      When namespace is specified in dataSourceRef,
+                      dataSource isn't set to the same value and must be empty.
+                      There are three important differences between dataSource and dataSourceRef:
+                      * While dataSource only allows two specific types of objects, dataSourceRef
+                        allows any non-core object, as well as PersistentVolumeClaim objects.
+                      * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                        preserves all values, and generates an error if a disallowed value is
+                        specified.
+                      * While dataSource only allows local objects, dataSourceRef allows objects
+                        in any namespaces.
+                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                      (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of resource being referenced
+                          Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                          (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  resources:
+                    description: |-
+                      resources represents the minimum resources the volume should have.
+                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                      that are lower than previous value but must still be higher than capacity recorded in the
+                      status field of the claim.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  selector:
+                    description: selector is a label query over volumes to consider
+                      for binding.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  storageClassName:
+                    description: |-
+                      storageClassName is the name of the StorageClass required by the claim.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                    type: string
+                  volumeAttributesClassName:
+                    description: |-
+                      volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                      If specified, the CSI driver will create or update the volume with the attributes defined
+                      in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                      will be set by the persistentvolume controller if it exists.
+                      If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                      set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                      exists.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                    type: string
+                  volumeMode:
+                    description: |-
+                      volumeMode defines what type of volume is required by the claim.
+                      Value of Filesystem is implied when not included in claim spec.
+                    type: string
+                  volumeName:
+                    description: volumeName is the binding reference to the PersistentVolume
+                      backing this claim.
+                    type: string
+                type: object
+              ingress:
+                description: |-
+                  Ingress contains configuration for the ingress resources.
+                  Has no effect when running on an OpenShift cluster.
+                properties:
+                  assistedServiceHostname:
+                    description: |-
+                      AssistedServiceHostname is the hostname to be assigned to the assisted-service ingress.
+                      Has no effect when running on an OpenShift cluster.
+                    type: string
+                  className:
+                    description: |-
+                      ClassName is the name of the ingress class to be used when configuring ingress resources.
+                      Has no effect when running on an OpenShift cluster.
+                    type: string
+                  imageServiceHostname:
+                    description: |-
+                      ImageServiceHostname is the hostname to be assigned to the assisted-image-service ingress.
+                      Has no effect when running on an OpenShift cluster.
+                    type: string
+                required:
+                - assistedServiceHostname
+                - imageServiceHostname
+                type: object
+              mirrorRegistryRef:
+                description: |-
+                  MirrorRegistryRef is the reference to the configmap that contains mirror registry configuration
+                  In case no configuration is need, this field will be nil. ConfigMap must contain to entries:
+                  ca-bundle.crt - hold the contents of mirror registry certificate/s
+                  registries.conf - holds the content of registries.conf file configured with mirror registries
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              mustGatherImages:
+                description: |-
+                  MustGatherImages defines a collection of operator related must-gather images
+                  that are used if one the operators fails to be successfully deployed
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        Name specifies the name of the component (e.g. operator)
+                        that the image is used to collect information about.
+                      type: string
+                    openshiftVersion:
+                      description: |-
+                        OpenshiftVersion is the Major.Minor version of OpenShift that this image
+                        is to be associated with.
+                      type: string
+                    url:
+                      description: Url specifies the path to the Operating System
+                        image.
+                      type: string
+                  required:
+                  - name
+                  - openshiftVersion
+                  - url
+                  type: object
+                type: array
+              osImages:
+                description: |-
+                  OSImages defines a collection of Operating System images (ie. RHCOS images)
+                  that the assisted-service should use as the base when generating discovery ISOs.
+                items:
+                  description: |-
+                    OSImage defines an Operating System image and the OpenShift version it
+                    is associated with.
+                  properties:
+                    cpuArchitecture:
+                      description: The CPU architecture of the image (x86_64/arm64/etc).
+                      type: string
+                    openshiftVersion:
+                      description: |-
+                        OpenshiftVersion is the Major.Minor version of OpenShift that this image
+                        is to be associated with.
+                      type: string
+                    rootFSUrl:
+                      description: |-
+                        rootFSUrl specifies the path to the root filesystem.
+                        Deprecated: this field is ignored (will be removed in a future release).
+                      type: string
+                    url:
+                      description: Url specifies the path to the Operating System
+                        image.
+                      type: string
+                    version:
+                      description: Version is the Operating System version of the
+                        image.
+                      type: string
+                  required:
+                  - openshiftVersion
+                  - url
+                  - version
+                  type: object
+                type: array
+              unauthenticatedRegistries:
+                description: |-
+                  UnauthenticatedRegistries is a list of registries from which container images can be pulled
+                  without authentication. They will be appended to the default list (quay.io,
+                  registry.ci.openshift.org). Any registry on this list will not require credentials
+                  to be in the pull secret validated by the assisted-service.
+                items:
+                  type: string
+                type: array
+            required:
+            - databaseStorage
+            - filesystemStorage
+            type: object
+          status:
+            description: AgentServiceConfigStatus defines the observed state of AgentServiceConfig
+            properties:
+              conditions:
+                items:
+                  description: |-
+                    Condition represents the state of the operator's
+                    reconciliation functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              immutableAnnotations:
+                additionalProperties:
+                  type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/hack/unit-test-crds/clusterpools.yaml
+++ b/hack/unit-test-crds/clusterpools.yaml
@@ -1,0 +1,1005 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: clusterpools.hive.openshift.io
+spec:
+  group: hive.openshift.io
+  names:
+    kind: ClusterPool
+    listKind: ClusterPoolList
+    plural: clusterpools
+    shortNames:
+      - cp
+    singular: clusterpool
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.size
+          name: Size
+          type: string
+        - jsonPath: .status.standby
+          name: Standby
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: string
+        - jsonPath: .spec.baseDomain
+          name: BaseDomain
+          type: string
+        - jsonPath: .spec.imageSetRef.name
+          name: ImageSet
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ClusterPool represents a pool of clusters that should be kept ready to be given out to users. Clusters are removed
+            from the pool once claimed and then automatically replaced with a new one.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterPoolSpec defines the desired state of the ClusterPool.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Annotations to be applied to new ClusterDeployments created for the pool. ClusterDeployments that have already been
+                    claimed will not be affected when this value is modified.
+                  type: object
+                baseDomain:
+                  description: BaseDomain is the base domain to use for all clusters created in this pool.
+                  type: string
+                claimLifetime:
+                  description: ClaimLifetime defines the lifetimes for claims for the cluster pool.
+                  properties:
+                    default:
+                      description: |-
+                        Default is the default lifetime of the claim when no lifetime is set on the claim itself.
+                        This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+                        Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+                        https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+                        https://github.com/kubernetes/apimachinery/issues/131
+                        https://github.com/kubernetes/apiextensions-apiserver/issues/56
+                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                      type: string
+                    maximum:
+                      description: |-
+                        Maximum is the maximum lifetime of the claim after it is assigned a cluster. If the claim still exists
+                        when the lifetime has elapsed, the claim will be deleted by Hive.
+                        The lifetime of a claim is the mimimum of the lifetimes set by the cluster pool and the claim itself.
+                        This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+                        Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+                        https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+                        https://github.com/kubernetes/apimachinery/issues/131
+                        https://github.com/kubernetes/apiextensions-apiserver/issues/56
+                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                      type: string
+                  type: object
+                customizationRef:
+                  description: |-
+                    CustomizationRef refers to a ClusterDeploymentCustomization object whose InstallerManifestPatches should
+                    be applied to *all* ClusterDeployments created by this ClusterPool. This is in addition to any CDC from
+                    Inventory. The CDC must exist in the ClusterPool's namespace. It will be copied to the namespace of each
+                    ClusterDeployment generated by the ClusterPool.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                hibernateAfter:
+                  description: |-
+                    HibernateAfter will be applied to new ClusterDeployments created for the pool. HibernateAfter will transition
+                    clusters in the clusterpool to hibernating power state after it has been running for the given duration. The time
+                    that a cluster has been running is the time since the cluster was installed or the time since the cluster last came
+                    out of hibernation.
+                    This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+                    Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+                    https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+                    https://github.com/kubernetes/apimachinery/issues/131
+                    https://github.com/kubernetes/apiextensions-apiserver/issues/56
+                  pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                  type: string
+                hibernationConfig:
+                  description: HibernationConfig configures the hibernation/resume behavior of ClusterDeployments owned by the ClusterPool.
+                  properties:
+                    resumeTimeout:
+                      description: |-
+                        ResumeTimeout is the maximum amount of time we will wait for an unclaimed ClusterDeployment to resume from
+                        hibernation (e.g. at the behest of runningCount, or in preparation for being claimed). If this time is
+                        exceeded, the ClusterDeployment will be considered Broken and we will replace it. The default (unspecified
+                        or zero) means no timeout -- we will allow the ClusterDeployment to continue trying to resume "forever".
+                        This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+                        Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+                        https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+                        https://github.com/kubernetes/apimachinery/issues/131
+                        https://github.com/kubernetes/apiextensions-apiserver/issues/56
+                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                      type: string
+                  type: object
+                imageSetRef:
+                  description: |-
+                    ImageSetRef is a reference to a ClusterImageSet. The release image specified in the ClusterImageSet will be used
+                    by clusters created for this cluster pool.
+                  properties:
+                    name:
+                      description: Name is the name of the ClusterImageSet that this refers to
+                      type: string
+                  required:
+                    - name
+                  type: object
+                installAttemptsLimit:
+                  description: InstallAttemptsLimit is the maximum number of times Hive will attempt to install the cluster.
+                  format: int32
+                  type: integer
+                installConfigSecretTemplateRef:
+                  description: |-
+                    InstallConfigSecretTemplateRef is a secret with the key install-config.yaml consisting of the content of the install-config.yaml
+                    to be used as a template for all clusters in this pool.
+                    Cluster specific settings (name, basedomain) will be injected dynamically when the ClusterDeployment install-config Secret is generated.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                installerEnv:
+                  description: |-
+                    InstallerEnv are extra environment variables to pass through to the installer. This may be used to enable
+                    additional features of the installer.
+                  items:
+                    description: EnvVar represents an environment variable present in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: |-
+                          Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the container and
+                          any service environment variables. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of whether the variable
+                          exists or not.
+                          Defaults to "".
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified API version.
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes, optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                inventory:
+                  description: |-
+                    Inventory maintains a list of entries consumed by the ClusterPool
+                    to customize the default ClusterDeployment.
+                  items:
+                    description: InventoryEntry maintains a reference to a custom resource consumed by a clusterpool to customize the cluster deployment.
+                    properties:
+                      kind:
+                        default: ClusterDeploymentCustomization
+                        description: Kind denotes the kind of the referenced resource. The default is ClusterDeploymentCustomization, which is also currently the only supported value.
+                        enum:
+                          - ""
+                          - ClusterDeploymentCustomization
+                        type: string
+                      name:
+                        description: Name is the name of the referenced resource.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Labels to be applied to new ClusterDeployments created for the pool. ClusterDeployments that have already been
+                    claimed will not be affected when this value is modified.
+                  type: object
+                maxConcurrent:
+                  description: |-
+                    MaxConcurrent is the maximum number of clusters that will be provisioned or deprovisioned at an time. This includes the
+                    claimed clusters being deprovisioned.
+                    By default there is no limit.
+                  format: int32
+                  type: integer
+                maxSize:
+                  description: |-
+                    MaxSize is the maximum number of clusters that will be provisioned including clusters that have been claimed
+                    and ones waiting to be used.
+                    By default there is no limit.
+                  format: int32
+                  type: integer
+                platform:
+                  description: Platform encompasses the desired platform for the cluster.
+                  properties:
+                    agentBareMetal:
+                      description: |-
+                        AgentBareMetal is the configuration used when performing an Assisted Agent based installation
+                        to bare metal.
+                      properties:
+                        agentSelector:
+                          description: |-
+                            AgentSelector is a label selector used for associating relevant custom resources with this cluster.
+                            (Agent, BareMetalHost, etc)
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - agentSelector
+                      type: object
+                    aws:
+                      description: AWS is the configuration used when installing on AWS.
+                      properties:
+                        credentialsAssumeRole:
+                          description: |-
+                            CredentialsAssumeRole refers to the IAM role that must be assumed to obtain
+                            AWS account access for the cluster operations.
+                          properties:
+                            externalID:
+                              description: |-
+                                ExternalID is random string generated by platform so that assume role
+                                is protected from confused deputy problem.
+                                more info: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+                              type: string
+                            roleARN:
+                              type: string
+                          required:
+                            - roleARN
+                          type: object
+                        credentialsSecretRef:
+                          description: |-
+                            CredentialsSecretRef refers to a secret that contains the AWS account access
+                            credentials.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        privateLink:
+                          description: |-
+                            PrivateLink allows uses to enable access to the cluster's API server using AWS
+                            PrivateLink. AWS PrivateLink includes a pair of VPC Endpoint Service and VPC
+                            Endpoint accross AWS accounts and allows clients to connect to services using AWS's
+                            internal networking instead of the Internet.
+                          properties:
+                            additionalAllowedPrincipals:
+                              description: |-
+                                AdditionalAllowedPrincipals is a list of additional allowed principal ARNs to be configured
+                                for the Private Link cluster's VPC Endpoint Service.
+                                ARNs provided as AdditionalAllowedPrincipals will be configured for the cluster's VPC Endpoint
+                                Service in addition to the IAM entity used by Hive.
+                              items:
+                                type: string
+                              type: array
+                            enabled:
+                              type: boolean
+                          required:
+                            - enabled
+                          type: object
+                        region:
+                          description: Region specifies the AWS region where the cluster will be created.
+                          type: string
+                        userTags:
+                          additionalProperties:
+                            type: string
+                          description: UserTags specifies additional tags for AWS resources created for the cluster.
+                          type: object
+                      required:
+                        - region
+                      type: object
+                    azure:
+                      description: Azure is the configuration used when installing on Azure.
+                      properties:
+                        baseDomainResourceGroupName:
+                          description: BaseDomainResourceGroupName specifies the resource group where the azure DNS zone for the base domain is found
+                          type: string
+                        cloudName:
+                          description: |-
+                            cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
+                            with the appropriate Azure API endpoints.
+                            If empty, the value is equal to "AzurePublicCloud".
+                          enum:
+                            - ""
+                            - AzurePublicCloud
+                            - AzureUSGovernmentCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                          type: string
+                        credentialsSecretRef:
+                          description: |-
+                            CredentialsSecretRef refers to a secret that contains the Azure account access
+                            credentials.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        region:
+                          description: Region specifies the Azure region where the cluster will be created.
+                          type: string
+                      required:
+                        - credentialsSecretRef
+                        - region
+                      type: object
+                    baremetal:
+                      description: BareMetal is the configuration used when installing on bare metal.
+                      properties:
+                        libvirtSSHPrivateKeySecretRef:
+                          description: |-
+                            LibvirtSSHPrivateKeySecretRef is the reference to the secret that contains the private SSH key to use
+                            for access to the libvirt provisioning host.
+                            The SSH private key is expected to be in the secret data under the "ssh-privatekey" key.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - libvirtSSHPrivateKeySecretRef
+                      type: object
+                    gcp:
+                      description: GCP is the configuration used when installing on Google Cloud Platform.
+                      properties:
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that contains the GCP account access credentials.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        discardLocalSsdOnHibernate:
+                          description: |-
+                            DiscardLocalSsdOnHibernate passes the specified value through to the GCP API to indicate
+                            whether the content of any local SSDs should be preserved or discarded. See
+                            https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance
+                            This field is required when attempting to hibernate clusters with instances possessing
+                            SSDs -- e.g. those with GPUs.
+                          type: boolean
+                        privateServiceConnect:
+                          description: |-
+                            PrivateSericeConnect allows users to enable access to the cluster's API server using GCP
+                            Private Service Connect. It includes a forwarding rule paired with a Service Attachment
+                            across GCP accounts and allows clients to connect to services using GCP internal networking
+                            of using public load balancers.
+                          properties:
+                            enabled:
+                              description: Enabled specifies if Private Service Connect is to be enabled on the cluster.
+                              type: boolean
+                            serviceAttachment:
+                              description: ServiceAttachment configures the service attachment to be used by the cluster.
+                              properties:
+                                subnet:
+                                  description: Subnet configures the subnetwork that contains the service attachment.
+                                  properties:
+                                    cidr:
+                                      description: Cidr specifies the cidr to use when creating a service attachment subnet.
+                                      type: string
+                                    existing:
+                                      description: |-
+                                        Existing specifies a pre-existing subnet to use instead of creating a new service attachment subnet.
+                                        This is required when using BYO VPCs. It must be in the same region as the api-int load balancer, be
+                                        configured with a purpose of "Private Service Connect", and have sufficient routing and firewall rules
+                                        to access the api-int load balancer.
+                                      properties:
+                                        name:
+                                          description: Name specifies the name of the existing subnet.
+                                          type: string
+                                        project:
+                                          description: |-
+                                            Project specifies the project the subnet exists in.
+                                            This is required for Shared VPC.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                              type: object
+                          required:
+                            - enabled
+                          type: object
+                        region:
+                          description: Region specifies the GCP region where the cluster will be created.
+                          type: string
+                      required:
+                        - region
+                      type: object
+                    ibmcloud:
+                      description: IBMCloud is the configuration used when installing on IBM Cloud
+                      properties:
+                        accountID:
+                          description: |-
+                            AccountID is the IBM Cloud Account ID.
+                            AccountID is DEPRECATED and is gathered via the IBM Cloud API for the provided
+                            credentials. This field will be ignored.
+                          type: string
+                        cisInstanceCRN:
+                          description: |-
+                            CISInstanceCRN is the IBM Cloud Internet Services Instance CRN
+                            CISInstanceCRN is DEPRECATED and gathered via the IBM Cloud API for the provided
+                            credentials and cluster deployment base domain. This field will be ignored.
+                          type: string
+                        credentialsSecretRef:
+                          description: |-
+                            CredentialsSecretRef refers to a secret that contains IBM Cloud account access
+                            credentials.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        region:
+                          description: |-
+                            Region specifies the IBM Cloud region where the cluster will be
+                            created.
+                          type: string
+                      required:
+                        - credentialsSecretRef
+                        - region
+                      type: object
+                    none:
+                      description: |-
+                        None indicates platform-agnostic install.
+                        https://docs.openshift.com/container-platform/4.7/installing/installing_platform_agnostic/installing-platform-agnostic.html
+                      type: object
+                    nutanix:
+                      description: Nutanix is the configuration used when installing on Nutanix Prism Central.
+                      properties:
+                        certificatesSecretRef:
+                          description: |-
+                            CertificatesSecretRef refers to a secret that contains the Prism Central CA certificates
+                            necessary for communicating with the Prism Central.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        credentialsSecretRef:
+                          description: |-
+                            CredentialsSecretRef refers to a secret that contains the Nutanix account access
+                            credentials.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        failureDomains:
+                          description: |-
+                            FailureDomains configures failure domains for the Nutanix platform.
+                            Required for using MachinePools
+                          items:
+                            description: FailureDomain configures failure domain information for the Nutanix platform.
+                            properties:
+                              dataSourceImages:
+                                description: DataSourceImages identifies the datasource images in the Prism Element.
+                                items:
+                                  description: StorageResourceReference holds reference information of a storage resource (storage container, data source image, etc.)
+                                  properties:
+                                    name:
+                                      description: Name is the name of the storage container resource in the Prism Element.
+                                      type: string
+                                    referenceName:
+                                      description: ReferenceName is the identifier of the storage resource configured in the FailureDomain.
+                                      type: string
+                                    uuid:
+                                      description: UUID is the UUID of the storage container resource in the Prism Element.
+                                      type: string
+                                  required:
+                                    - uuid
+                                  type: object
+                                type: array
+                              name:
+                                description: Name defines the unique name of a failure domain.
+                                maxLength: 64
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.-@/]+$
+                                type: string
+                              prismElement:
+                                description: |-
+                                  PrismElement holds the identification (name, UUID) and the optional endpoint address and
+                                  port of the Nutanix Prism Element. When a cluster-wide proxy is installed, this endpoint will,
+                                  by default, be accessed through the cluster-wide proxy configured for the platform.
+                                  If communication with this endpoint should bypass the proxy, add the endpoint to the install-config
+                                  `spec.noProxy` list in the proxy configuration.
+                                properties:
+                                  endpoint:
+                                    description: Endpoint holds the address and port of the Prism Element
+                                    properties:
+                                      address:
+                                        description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                                        type: string
+                                      port:
+                                        description: port is the port number to access the Nutanix Prism Central or Element (cluster)
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - address
+                                      - port
+                                    type: object
+                                  name:
+                                    description: Name is the Prism Element (cluster) name.
+                                    type: string
+                                  uuid:
+                                    description: UUID is the UUID of the Prism Element (cluster)
+                                    type: string
+                                required:
+                                  - uuid
+                                type: object
+                              storageContainers:
+                                description: StorageContainers identifies the storage containers in the Prism Element.
+                                items:
+                                  description: StorageResourceReference holds reference information of a storage resource (storage container, data source image, etc.)
+                                  properties:
+                                    name:
+                                      description: Name is the name of the storage container resource in the Prism Element.
+                                      type: string
+                                    referenceName:
+                                      description: ReferenceName is the identifier of the storage resource configured in the FailureDomain.
+                                      type: string
+                                    uuid:
+                                      description: UUID is the UUID of the storage container resource in the Prism Element.
+                                      type: string
+                                  required:
+                                    - uuid
+                                  type: object
+                                type: array
+                              subnetUUIDs:
+                                description: |-
+                                  SubnetUUIDs identifies the network subnets of the Prism Element.
+                                  Currently we only support one subnet for a failure domain.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                              - name
+                              - prismElement
+                              - subnetUUIDs
+                            type: object
+                          type: array
+                        prismCentral:
+                          description: |-
+                            PrismCentral is the endpoint (address and port) to connect to the Prism Central.
+                            This serves as the default Prism-Central.
+                          properties:
+                            address:
+                              description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                              type: string
+                            port:
+                              description: port is the port number to access the Nutanix Prism Central or Element (cluster)
+                              format: int32
+                              type: integer
+                          required:
+                            - address
+                            - port
+                          type: object
+                      required:
+                        - credentialsSecretRef
+                        - prismCentral
+                      type: object
+                    openstack:
+                      description: OpenStack is the configuration used when installing on OpenStack
+                      properties:
+                        certificatesSecretRef:
+                          description: |-
+                            CertificatesSecretRef refers to a secret that contains CA certificates
+                            necessary for communicating with the OpenStack.
+                            There is additional configuration required for the OpenShift cluster to trust
+                            the certificates provided in this secret.
+                            The "clouds.yaml" file included in the credentialsSecretRef Secret must also include
+                            a reference to the certificate bundle file for the OpenShift cluster being created to
+                            trust the OpenStack endpoints.
+                            The "clouds.yaml" file must set the "cacert" field to
+                            either "/etc/openstack-ca/<key name containing the trust bundle in credentialsSecretRef Secret>" or
+                            "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem".
+
+                            For example,
+                            """clouds.yaml
+                            clouds:
+                              shiftstack:
+                                auth: ...
+                                cacert: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+                            """
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        cloud:
+                          description: |-
+                            Cloud will be used to indicate the OS_CLOUD value to use the right section
+                            from the clouds.yaml in the CredentialsSecretRef.
+                          type: string
+                        credentialsSecretRef:
+                          description: |-
+                            CredentialsSecretRef refers to a secret that contains the OpenStack account access
+                            credentials.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        trunkSupport:
+                          description: TrunkSupport indicates whether or not to use trunk ports in your OpenShift cluster.
+                          type: boolean
+                      required:
+                        - cloud
+                        - credentialsSecretRef
+                      type: object
+                    vsphere:
+                      description: VSphere is the configuration used when installing on vSphere
+                      properties:
+                        certificatesSecretRef:
+                          description: |-
+                            CertificatesSecretRef refers to a secret that contains the vSphere CA certificates
+                            necessary for communicating with the VCenter.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        cluster:
+                          description: Cluster is the name of the cluster virtual machines will be cloned into.
+                          type: string
+                        credentialsSecretRef:
+                          description: |-
+                            CredentialsSecretRef refers to a secret that contains the vSphere account access
+                            credentials: GOVC_USERNAME, GOVC_PASSWORD fields.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        datacenter:
+                          description: Datacenter is the name of the datacenter to use in the vCenter.
+                          type: string
+                        defaultDatastore:
+                          description: DefaultDatastore is the default datastore to use for provisioning volumes.
+                          type: string
+                        folder:
+                          description: |-
+                            Folder is the name of the folder that will be used and/or created for
+                            virtual machines.
+                          type: string
+                        network:
+                          description: Network specifies the name of the network to be used by the cluster.
+                          type: string
+                        vCenter:
+                          description: VCenter is the domain name or IP address of the vCenter.
+                          type: string
+                      required:
+                        - certificatesSecretRef
+                        - credentialsSecretRef
+                        - datacenter
+                        - defaultDatastore
+                        - vCenter
+                      type: object
+                  type: object
+                pullSecretRef:
+                  description: PullSecretRef is the reference to the secret to use when pulling images.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                runningCount:
+                  description: |-
+                    RunningCount is the number of clusters we should keep running. The remainder will be kept hibernated until claimed.
+                    By default no clusters will be kept running (all will be hibernated).
+                  format: int32
+                  minimum: 0
+                  type: integer
+                size:
+                  description: Size is the default number of clusters that we should keep provisioned and waiting for use.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                skipMachinePools:
+                  description: SkipMachinePools allows creating clusterpools where the machinepools are not managed by hive after cluster creation
+                  type: boolean
+              required:
+                - baseDomain
+                - imageSetRef
+                - platform
+                - size
+              type: object
+            status:
+              description: ClusterPoolStatus defines the observed state of ClusterPool
+              properties:
+                conditions:
+                  description: Conditions includes more detailed status for the cluster pool
+                  items:
+                    description: ClusterPoolCondition contains details for the current condition of a cluster pool
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                ready:
+                  description: Ready is the number of unclaimed clusters that are installed and are running and ready to be claimed.
+                  format: int32
+                  type: integer
+                size:
+                  description: Size is the number of unclaimed clusters that have been created for the pool.
+                  format: int32
+                  type: integer
+                standby:
+                  description: Standby is the number of unclaimed clusters that are installed, but not running.
+                  format: int32
+                  type: integer
+              required:
+                - ready
+                - size
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.size
+          statusReplicasPath: .status.size
+        status: {}

--- a/hack/unit-test-crds/discoveryconfigs.yaml
+++ b/hack/unit-test-crds/discoveryconfigs.yaml
@@ -1,0 +1,165 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  creationTimestamp: null
+  name: discoveryconfigs.discovery.open-cluster-management.io
+spec:
+  group: discovery.open-cluster-management.io
+  names:
+    kind: DiscoveryConfig
+    listKind: DiscoveryConfigList
+    plural: discoveryconfigs
+    singular: discoveryconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: DiscoveryConfig is the Schema for the discoveryconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DiscoveryConfigSpec defines the desired state of DiscoveryConfig
+            properties:
+              credential:
+                description: Credential is the secret containing credentials to connect
+                  to the OCM api on behalf of a user
+                type: string
+              filters:
+                description: Sets restrictions on what kind of clusters to discover
+                properties:
+                  clusterTypes:
+                    description: |-
+                      ClusterTypes is the list of cluster types to discover. These types represent the platform
+                      the cluster is running on, such as OpenShift Container Platform (OCP), Azure Red Hat OpenShift (ARO),
+                      or others.
+                    items:
+                      type: string
+                    type: array
+                  infrastructureProviders:
+                    description: |-
+                      InfrastructureProviders is the list of infrastructure providers to discover. This can be
+                      a list of cloud providers or platforms (e.g., AWS, Azure, GCP) where clusters might be running.
+                    items:
+                      type: string
+                    type: array
+                  lastActive:
+                    description: LastActive is the last active in days of clusters
+                      to discover, determined by activity timestamp
+                    type: integer
+                  openShiftVersions:
+                    description: OpenShiftVersions is the list of release versions
+                      of OpenShift of the form "<Major>.<Minor>"
+                    items:
+                      description: |-
+                        Semver represents a partial semver string with the major and minor version
+                        in the form "<Major>.<Minor>". For example: "4.5"
+                      pattern: ^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$
+                      type: string
+                    type: array
+                  regions:
+                    description: |-
+                      Regions is the list of regions where OpenShift clusters are located. This helps in filtering
+                      clusters based on geographic location or data center region, useful for compliance or latency
+                      requirements.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - credential
+            type: object
+          status:
+            description: DiscoveryConfigStatus defines the observed state of DiscoveryConfig
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: discovery.open-cluster-management.io/v1alpha1 DiscoveryConfig
+      is deprecated in v2.5+, unavailable in v2.6+; use discovery.open-cluster-management.io/v1
+      DiscoveryConfig
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DiscoveryConfig is the Schema for the discoveryconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DiscoveryConfigSpec defines the desired state of DiscoveryConfig
+            properties:
+              credential:
+                description: Credential is the secret containing credentials to connect
+                  to the OCM api on behalf of a user
+                type: string
+              filters:
+                description: Sets restrictions on what kind of clusters to discover
+                properties:
+                  lastActive:
+                    description: LastActive is the last active in days of clusters
+                      to discover, determined by activity timestamp
+                    type: integer
+                  openShiftVersions:
+                    description: OpenShiftVersions is the list of release versions
+                      of OpenShift of the form "<Major>.<Minor>"
+                    items:
+                      description: |-
+                        Semver represents a partial semver string with the major and minor version
+                        in the form "<Major>.<Minor>". For example: "4.5"
+                      pattern: ^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$
+                      type: string
+                    type: array
+                type: object
+            required:
+            - credential
+            type: object
+          status:
+            description: DiscoveryConfigStatus defines the observed state of DiscoveryConfig
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null


### PR DESCRIPTION
# Description

In MCE 2.11, `ClusterPool` resources must be manually uninstalled before users can proceed with uninstalling MCE on the cluster. This change adds `ClusterPool` to the `blockDeletionResources` list to enforce this requirement.

## Related Issue

https://issues.redhat.com/browse/ACM-27552

## Changes Made

Added `ClusterPool` to the list of `blockDeletionResources`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
