### PR TITLE
Fixed rbac permissions for MCE 2.11

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-01-14T16:18:41Z"
+    createdAt: "2026-01-16T21:03:56Z"
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: multicluster-engine.v0.0.1
@@ -2755,6 +2755,18 @@ spec:
           verbs:
           - get
           - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - policy.open-cluster-management.io


### PR DESCRIPTION
# Description

This PR fixes missing RBAC permissions for the `multicluster-engine` operator in MCE 2.11.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Added RBAC permissions for `poddisruptionbudgets` resources in the policy API group to the `ClusterServiceVersion` manifest. This grants the operator the following verbs for managing `PodDisruptionBudgets`:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch

The change ensures the operator has the necessary permissions to manage `PodDisruptionBudgets`, which are required for proper functionality in MCE 2.11.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
