### PR TITLE
[backplane-2.9] Fix CRD error logging bugs

### DIFF
--- a/main.go
+++ b/main.go
@@ -293,7 +293,7 @@ func main() {
 	crds, errs := renderer.RenderCRDs(crdsDir, backplaneConfig)
 	if len(errs) > 0 {
 		for _, err := range errs {
-			setupLog.Info(err.Error())
+			setupLog.Error(err, "Failed to render CRD")
 		}
 		os.Exit(1)
 	}
@@ -306,7 +306,7 @@ func main() {
 			return e
 		})
 		if retryErr != nil {
-			setupLog.Error(err, "unable to ensure CRD exists in alloted time. Failing.")
+			setupLog.Error(retryErr, "Failed to apply CRD", "CRD", crds[i].GetName())
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
# Description

Fixes two critical error logging bugs in CRD application:

1. CRD application error logged wrong variable
   - Was: setupLog.Error(err, ...) where err was stale loop variable
   - Now: setupLog.Error(retryErr, ...) logs the actual error
   - Added CRD name to error output for easier debugging

2. CRD render errors logged at Info level instead of Error
   - Changed setupLog.Info to setupLog.Error for consistency

These bugs caused misleading error messages when CRD application failed, making it difficult to diagnose issues like missing webhook services for CAPI CRDs.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
