### PR TITLE
 [backplane-2.8][ACM-28712] Add CPE label to MCE operator Dockerfile

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -33,7 +33,8 @@ LABEL org.label-schema.vendor="Red Hat" \
       io.k8s.display-name="MultiClusterEngine operator" \
       io.k8s.description="Installer operator for Red Hat multicluster engine for Kubernetes" \
       com.redhat.component="multicluster-engine-operator-container" \
-      io.openshift.tags="data,images"
+      io.openshift.tags="data,images" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.8::el9"
 
 WORKDIR /app
 COPY --from=builder /workspace/backplane-operator .


### PR DESCRIPTION
# Description

This PR adds the Common Platform Enumeration (CPE) identifier to the MCE operator container for compliance tracking and security scanning requirements.

## Related Issue

https://issues.redhat.com/browse/ACM-28712

## Changes Made

- CPE Label Addition:
  - Added cpe="cpe:/a:redhat:multicluster_engine:2.8::el9" label to build/Dockerfile.rhtap
  - Enables automated security scanning and compliance tracking
  - Follows Red Hat container labeling standards for MCE 2.8

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
