### PR TITLE
[backplane-2.9][ACM-29475] Update Go to 1.25.7

### DIFF
--- a/.github/workflows/rbac-gen.yml
+++ b/.github/workflows/rbac-gen.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.25.2'
+          - '1.25.7'
     name: Generate role permissions
     steps:
     - name: Checkout backplane

--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# Use toolchain from go.mod so Go uses a complete install (with covdata); avoids
+# "no such tool covdata" when auto-downloaded minimal toolchain is used (golang/go#75031).
+GOTOOLCHAIN ?= $(shell (grep '^toolchain ' go.mod | cut -d' ' -f2) || echo "go$$(grep '^go ' go.mod | cut -d' ' -f2)")
+export GOTOOLCHAIN
+
 test-prep: manifests generate fmt vet envtest ## prepare to run tests.
 	echo "Ready to run tests"
 
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt vet envtest ## Run tests (with coverage).
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" DIRECTORY_OVERRIDE="../" UNIT_TEST=true ENV_TEST=true go test $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
 
 ##@ Build

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/stolostron/backplane-operator
 
-go 1.25.0
-
-toolchain go1.25.2
+go 1.25.7
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
# Description

Updated Go toolchain to resolve CVE-2025-61726 (HIGH - CVSS 7.5).

For backplane-2.9, upgrading from toolchain go1.25.2 to go1.25.6.

## Related Issues

- JIRA: [ACM-29475](https://issues.redhat.com/browse/ACM-29475) - CVE-2025-61726 for mce-2.9
- CVE-2025-61726: https://nvd.nist.gov/vuln/detail/cve-2025-61726

## Changes Made

### Dependency Upgrades
- **go.mod**: toolchain go1.25.2 → go1.25.6
- **go.sum**: Updated dependencies

## Testing

All unit tests pass locally.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have rebased my branch on top of the latest backplane-2.9 branch.

## Additional Notes

CVE-2025-61726 is a high-severity vulnerability in Go's net/url package involving memory exhaustion through unbounded query parameter parsing. The fix requires Go toolchain 1.24.12 or 1.25.6.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the backplane-2.9 branch.