### PR TITLE
[ACM-31185] Add image key validation workflow

### DIFF
--- a/.github/workflows/validate-image-keys.yml
+++ b/.github/workflows/validate-image-keys.yml
@@ -17,44 +17,13 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Determine bundle branch
-        id: bundle-branch
-        run: |
-          TARGET_BRANCH="${{ github.base_ref }}"
-          echo "PR target branch: $TARGET_BRANCH"
-
-          # Check if target branch exists in bundle repo
-          if git ls-remote --exit-code --heads https://github.com/stolostron/mce-operator-bundle.git "$TARGET_BRANCH" > /dev/null 2>&1; then
-            BUNDLE_BRANCH="$TARGET_BRANCH"
-            echo "Bundle branch found: $BUNDLE_BRANCH"
-          else
-            # Extract version from branch name (e.g., backplane-2.17 → 2.17)
-            if [[ "$TARGET_BRANCH" =~ backplane-([0-9]+\.[0-9]+) ]]; then
-              VERSION="${BASH_REMATCH[1]}"
-              # Try backplane-VERSION format in bundle repo
-              if git ls-remote --exit-code --heads https://github.com/stolostron/mce-operator-bundle.git "backplane-$VERSION" > /dev/null 2>&1; then
-                BUNDLE_BRANCH="backplane-$VERSION"
-                echo "Bundle branch found via version mapping: $BUNDLE_BRANCH"
-              else
-                echo "ERROR: No matching bundle branch found for backplane-operator branch '$TARGET_BRANCH'"
-                echo "Expected bundle branch 'backplane-$VERSION' or '$TARGET_BRANCH' not found"
-                exit 1
-              fi
-            else
-              echo "ERROR: Cannot determine bundle branch for target '$TARGET_BRANCH'"
-              echo "Expected branch format: backplane-X.Y or a branch that exists in mce-operator-bundle"
-              exit 1
-            fi
-          fi
-
-          echo "bundle-branch=$BUNDLE_BRANCH" >> $GITHUB_OUTPUT
-
       - name: Install dependencies
         run: |
           pip3 install -r hack/bundle-automation/requirements.txt
 
       - name: Validate image keys
         env:
-          BUNDLE_BRANCH: ${{ steps.bundle-branch.outputs.bundle-branch }}
+          # Pass PR target branch to Makefile, which maps 'main' to current dev version
+          GITHUB_BASE_REF: ${{ github.base_ref }}
         run: |
           make -f Makefile.dev validate-image-keys

--- a/.github/workflows/validate-image-keys.yml
+++ b/.github/workflows/validate-image-keys.yml
@@ -17,12 +17,44 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Determine bundle branch
+        id: bundle-branch
+        run: |
+          TARGET_BRANCH="${{ github.base_ref }}"
+          echo "PR target branch: $TARGET_BRANCH"
+
+          # Check if target branch exists in bundle repo
+          if git ls-remote --exit-code --heads https://github.com/stolostron/mce-operator-bundle.git "$TARGET_BRANCH" > /dev/null 2>&1; then
+            BUNDLE_BRANCH="$TARGET_BRANCH"
+            echo "Bundle branch found: $BUNDLE_BRANCH"
+          else
+            # Extract version from branch name (e.g., backplane-2.17 → 2.17)
+            if [[ "$TARGET_BRANCH" =~ backplane-([0-9]+\.[0-9]+) ]]; then
+              VERSION="${BASH_REMATCH[1]}"
+              # Try backplane-VERSION format in bundle repo
+              if git ls-remote --exit-code --heads https://github.com/stolostron/mce-operator-bundle.git "backplane-$VERSION" > /dev/null 2>&1; then
+                BUNDLE_BRANCH="backplane-$VERSION"
+                echo "Bundle branch found via version mapping: $BUNDLE_BRANCH"
+              else
+                echo "ERROR: No matching bundle branch found for backplane-operator branch '$TARGET_BRANCH'"
+                echo "Expected bundle branch 'backplane-$VERSION' or '$TARGET_BRANCH' not found"
+                exit 1
+              fi
+            else
+              echo "ERROR: Cannot determine bundle branch for target '$TARGET_BRANCH'"
+              echo "Expected branch format: backplane-X.Y or a branch that exists in mce-operator-bundle"
+              exit 1
+            fi
+          fi
+
+          echo "bundle-branch=$BUNDLE_BRANCH" >> $GITHUB_OUTPUT
+
       - name: Install dependencies
         run: |
           pip3 install -r hack/bundle-automation/requirements.txt
 
       - name: Validate image keys
         env:
-          BUNDLE_BRANCH: ${{ github.base_ref }}
+          BUNDLE_BRANCH: ${{ steps.bundle-branch.outputs.bundle-branch }}
         run: |
           make -f Makefile.dev validate-image-keys

--- a/.github/workflows/validate-image-keys.yml
+++ b/.github/workflows/validate-image-keys.yml
@@ -1,0 +1,66 @@
+name: Validate Image Keys
+
+on:
+  pull_request:
+    paths:
+      - 'pkg/templates/charts/toggle/**/values.yaml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout backplane-operator
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Determine bundle branch
+        id: bundle-branch
+        run: |
+          # Try to match the target branch naming convention
+          TARGET_BRANCH="${{ github.base_ref }}"
+          echo "Target branch: $TARGET_BRANCH"
+
+          # Check if bundle branch exists
+          if git ls-remote --heads https://github.com/stolostron/mce-operator-bundle.git "$TARGET_BRANCH" | grep -q "$TARGET_BRANCH"; then
+            echo "Bundle branch $TARGET_BRANCH exists"
+            echo "branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "Bundle branch $TARGET_BRANCH does not exist, using main"
+            echo "branch=main" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout mce-operator-bundle
+        uses: actions/checkout@v4
+        with:
+          repository: stolostron/mce-operator-bundle
+          path: mce-operator-bundle
+          ref: ${{ steps.bundle-branch.outputs.branch }}
+
+      - name: Determine MCE version from bundle
+        id: mce-version
+        run: |
+          cd mce-operator-bundle/extras
+          # Find the latest version file (e.g., 2.17.0.json)
+          LATEST_VERSION=$(ls -1 *.json | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.json$' | sort -V | tail -1 | sed 's/\.json$//')
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "Error: No version files found in mce-operator-bundle/extras"
+            exit 1
+          fi
+          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          echo "Detected MCE version from bundle: $LATEST_VERSION"
+          cd ../..
+
+      - name: Install dependencies
+        run: |
+          pip3 install -r hack/bundle-automation/requirements.txt
+
+      - name: Validate image keys
+        env:
+          BUNDLE_PATH: mce-operator-bundle
+          MCE_VERSION: ${{ steps.mce-version.outputs.version }}
+        run: |
+          make -f Makefile.dev validate-image-keys

--- a/.github/workflows/validate-image-keys.yml
+++ b/.github/workflows/validate-image-keys.yml
@@ -17,50 +17,12 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Determine bundle branch
-        id: bundle-branch
-        run: |
-          # Try to match the target branch naming convention
-          TARGET_BRANCH="${{ github.base_ref }}"
-          echo "Target branch: $TARGET_BRANCH"
-
-          # Check if bundle branch exists
-          if git ls-remote --heads https://github.com/stolostron/mce-operator-bundle.git "$TARGET_BRANCH" | grep -q "$TARGET_BRANCH"; then
-            echo "Bundle branch $TARGET_BRANCH exists"
-            echo "branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
-          else
-            echo "Bundle branch $TARGET_BRANCH does not exist, using main"
-            echo "branch=main" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout mce-operator-bundle
-        uses: actions/checkout@v4
-        with:
-          repository: stolostron/mce-operator-bundle
-          path: mce-operator-bundle
-          ref: ${{ steps.bundle-branch.outputs.branch }}
-
-      - name: Determine MCE version from bundle
-        id: mce-version
-        run: |
-          cd mce-operator-bundle/extras
-          # Find the latest version file (e.g., 2.17.0.json)
-          LATEST_VERSION=$(ls -1 *.json | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.json$' | sort -V | tail -1 | sed 's/\.json$//')
-          if [ -z "$LATEST_VERSION" ]; then
-            echo "Error: No version files found in mce-operator-bundle/extras"
-            exit 1
-          fi
-          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
-          echo "Detected MCE version from bundle: $LATEST_VERSION"
-          cd ../..
-
       - name: Install dependencies
         run: |
           pip3 install -r hack/bundle-automation/requirements.txt
 
       - name: Validate image keys
         env:
-          BUNDLE_PATH: mce-operator-bundle
-          MCE_VERSION: ${{ steps.mce-version.outputs.version }}
+          BUNDLE_BRANCH: ${{ github.base_ref }}
         run: |
           make -f Makefile.dev validate-image-keys

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ hack/bundle-automation/tmp/
 
 # Ignore partial workflow directory
 workflow/
+mce-operator-bundle/

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -80,10 +80,9 @@ validate-image-keys: install-requirements
 		rm -rf mce-operator-bundle; \
 	fi
 	@git clone https://github.com/stolostron/mce-operator-bundle.git mce-operator-bundle
-	@echo "Attempting to checkout branch: $(BUNDLE_BRANCH)"
-	@cd mce-operator-bundle && \
-		(git checkout $(BUNDLE_BRANCH) 2>/dev/null || git checkout main) && \
-		echo "Checked out branch: $$(git branch --show-current)"
+	@echo "Checking out bundle branch: $(BUNDLE_BRANCH)"
+	@cd mce-operator-bundle && git checkout $(BUNDLE_BRANCH)
+	@echo "Successfully checked out branch: $$(cd mce-operator-bundle && git branch --show-current)"
 	@echo "Auto-detecting MCE version from bundle..."
 	@MCE_VERSION=$$(cd mce-operator-bundle/extras && ls -1 *.json | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.json$$' | sort -V | tail -1 | sed 's/\.json$$//'); \
 	if [ -z "$$MCE_VERSION" ]; then \

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -31,6 +31,9 @@ ifeq ($(BUNDLE_BRANCH),main)
   BUNDLE_BRANCH := $(BUNDLE_BRANCH_MAIN)
 endif
 
+# Bundle repo to validate against
+BUNDLE ?= mce-operator-bundle
+
 ##@ Dev. targets
 
 .PHONY: subscriptions
@@ -94,26 +97,18 @@ onboard-new-component: install-requirements
 ## Validate that all required image keys exist in the bundle
 .PHONY: validate-image-keys
 validate-image-keys: install-requirements
-	@echo "Cloning mce-operator-bundle..."
-	@if [ -d "mce-operator-bundle" ]; then \
-		echo "Removing existing mce-operator-bundle directory..."; \
-		rm -rf mce-operator-bundle; \
+	@echo "Cloning $(BUNDLE)..."
+	@if [ -d "$(BUNDLE)" ]; then \
+		echo "Removing existing $(BUNDLE) directory..."; \
+		rm -rf $(BUNDLE); \
 	fi
-	@git clone https://github.com/stolostron/mce-operator-bundle.git mce-operator-bundle
+	@git clone https://github.com/$(ORG)/$(BUNDLE).git $(BUNDLE)
 	@echo "Checking out bundle branch: $(BUNDLE_BRANCH)"
-	@cd mce-operator-bundle && git checkout $(BUNDLE_BRANCH)
-	@echo "Successfully checked out branch: $$(cd mce-operator-bundle && git branch --show-current)"
-	@echo "Auto-detecting MCE version from bundle..."
-	@MCE_VERSION=$$(cd mce-operator-bundle/extras && ls -1 *.json | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.json$$' | sort -V | tail -1 | sed 's/\.json$$//'); \
-	if [ -z "$$MCE_VERSION" ]; then \
-		echo "Error: No version files found in mce-operator-bundle/extras"; \
-		rm -rf mce-operator-bundle; \
-		exit 1; \
-	fi; \
-	echo "Detected MCE version: $$MCE_VERSION"; \
-	python3 ./hack/bundle-automation/generate-shell.py --validate-image-keys --org $(ORG) --repo $(REPO) --branch $(BRANCH) --bundle-path mce-operator-bundle --mce-version $$MCE_VERSION
+	@cd $(BUNDLE) && git checkout $(BUNDLE_BRANCH)
+	@echo "Successfully checked out branch: $$(cd $(BUNDLE) && git branch --show-current)"
+	@python3 ./hack/bundle-automation/generate-shell.py --validate-image-keys --org $(ORG) --repo $(REPO) --branch $(BRANCH) --bundle $(BUNDLE)
 	@echo "Cleaning up cloned bundle..."
-	@rm -rf mce-operator-bundle
+	@rm -rf $(BUNDLE)
 
 .PHONY: catalog-deploy
 catalog-deploy: ## Deploys backplane operator via subscription

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -9,6 +9,7 @@ CONFIG ?= ""
 PIPELINE_REPO ?= backplane-pipeline
 PIPELINE_BRANCH ?= 2.9-integration
 
+BUNDLE_BRANCH ?= $(shell git branch --show-current)
 
 ##@ Dev. targets
 
@@ -69,6 +70,31 @@ copy-charts: install-requirements
 .PHONY: onboard-new-component
 onboard-new-component: install-requirements
 	python3 ./hack/bundle-automation/generate-shell.py --onboard-new-component --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component $(COMPONENT)
+
+## Validate that all required image keys exist in the bundle
+.PHONY: validate-image-keys
+validate-image-keys: install-requirements
+	@echo "Cloning mce-operator-bundle..."
+	@if [ -d "mce-operator-bundle" ]; then \
+		echo "Removing existing mce-operator-bundle directory..."; \
+		rm -rf mce-operator-bundle; \
+	fi
+	@git clone https://github.com/stolostron/mce-operator-bundle.git mce-operator-bundle
+	@echo "Attempting to checkout branch: $(BUNDLE_BRANCH)"
+	@cd mce-operator-bundle && \
+		(git checkout $(BUNDLE_BRANCH) 2>/dev/null || git checkout main) && \
+		echo "Checked out branch: $$(git branch --show-current)"
+	@echo "Auto-detecting MCE version from bundle..."
+	@MCE_VERSION=$$(cd mce-operator-bundle/extras && ls -1 *.json | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.json$$' | sort -V | tail -1 | sed 's/\.json$$//'); \
+	if [ -z "$$MCE_VERSION" ]; then \
+		echo "Error: No version files found in mce-operator-bundle/extras"; \
+		rm -rf mce-operator-bundle; \
+		exit 1; \
+	fi; \
+	echo "Detected MCE version: $$MCE_VERSION"; \
+	python3 ./hack/bundle-automation/generate-shell.py --validate-image-keys --org $(ORG) --repo $(REPO) --branch $(BRANCH) --bundle-path mce-operator-bundle --mce-version $$MCE_VERSION
+	@echo "Cleaning up cloned bundle..."
+	@rm -rf mce-operator-bundle
 
 .PHONY: catalog-deploy
 catalog-deploy: ## Deploys backplane operator via subscription

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -9,7 +9,27 @@ CONFIG ?= ""
 PIPELINE_REPO ?= backplane-pipeline
 PIPELINE_BRANCH ?= 2.9-integration
 
+# Bundle branch configuration
+# Derive current development version from COMPONENT_VERSION file
+COMPONENT_VERSION := $(shell cat COMPONENT_VERSION)
+BUNDLE_BRANCH_MAIN ?= backplane-$(shell echo $(COMPONENT_VERSION) | cut -d. -f1,2)
+
+# Default to current branch for local development
 BUNDLE_BRANCH ?= $(shell git branch --show-current)
+
+# Override for CI: map main to current development version
+ifdef GITHUB_BASE_REF
+  ifeq ($(GITHUB_BASE_REF),main)
+    BUNDLE_BRANCH := $(BUNDLE_BRANCH_MAIN)
+  else
+    BUNDLE_BRANCH := $(GITHUB_BASE_REF)
+  endif
+endif
+
+# For local development on main, also use current development version
+ifeq ($(BUNDLE_BRANCH),main)
+  BUNDLE_BRANCH := $(BUNDLE_BRANCH_MAIN)
+endif
 
 ##@ Dev. targets
 

--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -57,6 +57,11 @@ SUPPORTED_OPERATIONS = {
         "args": "--repo {pipeline_repo} --branch {pipeline_branch}",
         "help": "Synchronize commit SHA values in operator bundles with the latest repository changes",
     },
+    "validate-image-keys": {
+        "script": "bundle-generation/validate-image-keys.py",
+        "args": "--operator . --bundle {bundle_path} --version {mce_version}",
+        "help": "Validate that all required image keys exist in the bundle extras file",
+    },
 }
 
 def clone_repository(git_url, repo_path, branch):
@@ -140,7 +145,9 @@ def prepare_and_execute(operation, operation_data, args):
 
     operations_args = operation_data.get("args", "").format(
         pipeline_repo=args.pipeline_repo,
-        pipeline_branch=args.pipeline_branch
+        pipeline_branch=args.pipeline_branch,
+        bundle_path=getattr(args, 'bundle_path', '../mce-operator-bundle'),
+        mce_version=getattr(args, 'mce_version', '2.17.0')
     ) if "args" in operation_data else ""
     
     if args.component:
@@ -220,6 +227,8 @@ if __name__ == "__main__":
     parser.add_argument("--config", help="Target Config file")
     parser.add_argument("--pipeline-repo", help="Pipeline Repository name")
     parser.add_argument("--pipeline-branch", help="Pipeline Repository Branch name")
+    parser.add_argument("--bundle-path", help="Path to bundle repo (mce-operator-bundle or acm-operator-bundle)")
+    parser.add_argument("--mce-version", help="MCE version to validate against (e.g., 2.17.0)")
 
     # Set default values for unspecified arguments
     parser.set_defaults(bundle=False, commit=False, lint=False)

--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -59,7 +59,7 @@ SUPPORTED_OPERATIONS = {
     },
     "validate-image-keys": {
         "script": "bundle-generation/validate-image-keys.py",
-        "args": "--operator . --bundle {bundle_path} --version {mce_version}",
+        "args": "--bundle {bundle}",
         "help": "Validate that all required image keys exist in the bundle extras file",
     },
 }
@@ -146,8 +146,7 @@ def prepare_and_execute(operation, operation_data, args):
     operations_args = operation_data.get("args", "").format(
         pipeline_repo=args.pipeline_repo,
         pipeline_branch=args.pipeline_branch,
-        bundle_path=getattr(args, 'bundle_path', '../mce-operator-bundle'),
-        mce_version=getattr(args, 'mce_version', '2.17.0')
+        bundle=getattr(args, 'bundle', '../mce-operator-bundle')
     ) if "args" in operation_data else ""
     
     if args.component:
@@ -227,8 +226,7 @@ if __name__ == "__main__":
     parser.add_argument("--config", help="Target Config file")
     parser.add_argument("--pipeline-repo", help="Pipeline Repository name")
     parser.add_argument("--pipeline-branch", help="Pipeline Repository Branch name")
-    parser.add_argument("--bundle-path", help="Path to bundle repo (mce-operator-bundle or acm-operator-bundle)")
-    parser.add_argument("--mce-version", help="MCE version to validate against (e.g., 2.17.0)")
+    parser.add_argument("--bundle", help="Path to bundle repo (mce-operator-bundle or acm-operator-bundle)")
 
     # Set default values for unspecified arguments
     parser.set_defaults(bundle=False, commit=False, lint=False)

--- a/pkg/templates/charts/toggle/hypershift/values.yaml
+++ b/pkg/templates/charts/toggle/hypershift/values.yaml
@@ -1,7 +1,6 @@
 global:
   imageOverrides:
     hypershift_addon_operator: ""
-    cluster_api: ""
     cluster_api_provider_agent: ""
     hypershift_operator: ""
     cluster_api_provider_kubevirt: ""


### PR DESCRIPTION
# Description

This PR adds automated validation to ensure all image keys required by operator Helm charts exist in the MCE bundle before installation. This prevents runtime failures caused by missing image references.

## Related Issue

Fixes https://redhat.atlassian.net/browse/ACM-31185

## Changes Made

1. **Added GitHub workflow** (`.github/workflows/validate-image-keys.yml`)
   - Triggers on PRs that modify `pkg/templates/charts/toggle/**/values.yaml` files
   - Automatically validates image keys against the appropriate bundle branch
   - Uses PR target branch to determine which bundle to validate against
   - Maps `main` → `backplane-X.Y` based on COMPONENT_VERSION file

2. **Updated Makefile.dev** with validation target and bundle branch mapping
   - Added `validate-image-keys` target
   - Auto-detects bundle repo: `BUNDLE ?= mce-operator-bundle`
   - Derives bundle branch from `COMPONENT_VERSION` file for main branch
   - Maps `main` → `backplane-2.17` (auto-updates when COMPONENT_VERSION changes)
   - Maps `backplane-*` → same branch directly
   - Works for both CI (via `GITHUB_BASE_REF`) and local development
   - Clones bundle repo, checks out correct branch, validates, cleans up

3. **Updated generate-shell.py** to support validation
   - Simplified args: `--bundle` instead of `--bundle-path` and `--mce-version`
   - Script auto-detects operator path (current directory) and version
   - Integrates with installer-dev-tools validation script

4. **Removed unused image key** from hypershift chart
   - Removed `cluster_api: ""` from `pkg/templates/charts/toggle/hypershift/values.yaml`
   - This key was declared but never referenced in templates

5. **Updated .gitignore** to exclude `mce-operator-bundle/` directory

## How It Works

### Local Development
```bash
# From backplane-operator repo
make -f Makefile.dev validate-image-keys

# Override bundle branch if needed
make -f Makefile.dev validate-image-keys BUNDLE_BRANCH=backplane-2.18
```

### CI/CD Flow
1. PR modifies `values.yaml` file
2. Workflow triggers and passes `GITHUB_BASE_REF` (PR target branch)
3. Makefile derives correct bundle branch:
   - PR to `main` → validates against `backplane-2.17` (from COMPONENT_VERSION)
   - PR to `backplane-2.11` → validates against `backplane-2.11`
4. Clones `mce-operator-bundle` at determined branch
5. Validation script auto-detects version and validates
6. Build fails if validation fails

### Branch Mapping Logic
```makefile
# Read COMPONENT_VERSION file (e.g., "2.17.0")
COMPONENT_VERSION := $(shell cat COMPONENT_VERSION)
# Derive bundle branch (e.g., "backplane-2.17")
BUNDLE_BRANCH_MAIN ?= backplane-$(shell echo $(COMPONENT_VERSION) | cut -d. -f1,2)

# CI: Use PR target branch, mapping main to current dev version
# Local: Use current branch, mapping main to current dev version
```

## Dependency

⚠️ **This PR depends on https://github.com/stolostron/installer-dev-tools/pull/136 being merged first**

The workflow will fail until that dependency is merged because it clones installer-dev-tools from `main` branch.

## Validation Example

### Passing Validation
```
✅ SUCCESS: All 32 required image keys are present in bundle
   Bundle contains 42 total images
```

### Failing Validation (Placeholder Image)
```
⚠️  PLACEHOLDER IMAGES DETECTED: Images with placeholder digest
   These image keys exist but have not been built yet

Placeholder keys and their components:
  - cluster_permission (used by: cluster-permission)
    Image: registry.redhat.io/multicluster-engine/acm-cluster-permission-rhel9
    Digest: sha256:0000...0000 (PLACEHOLDER)

To fix this issue:
  2. Build and publish the placeholder images
  3. Update mce-operator-bundle/extras/2.17.0.json with real image digests
  4. Ensure the CSV includes OPERAND_IMAGE_* or RELATED_IMAGE_* environment variables
```

## Testing

Tested locally with:
- `make -f Makefile.dev validate-image-keys BRANCH=add-image-key-validation BUNDLE_BRANCH=backplane-2.17`
- Auto-detection of version 2.17.0 from bundle
- Detection of placeholder `cluster_permission` image
- Passing validation when all images valid
- Branch mapping logic (main → backplane-2.17)

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- The workflow only runs when values.yaml files are modified, reducing unnecessary CI runs
- When COMPONENT_VERSION is updated to 2.18.0, bundle branch automatically becomes backplane-2.18
- The same pattern can be applied to ACM repos (using `release-*` branches)
- All validation logic is in the validation script - Makefile just handles cloning and cleanup

## Reviewers

/cc @reviewer1 @reviewer2
