### PR TITLE
Add Message column to MultiClusterEngine output

### DIFF
--- a/api/v1/multiclusterengine_types.go
+++ b/api/v1/multiclusterengine_types.go
@@ -261,6 +261,7 @@ type MultiClusterEngineCondition struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="CurrentVersion",type="string",JSONPath=".status.currentVersion",description="The current version of the MultiClusterEngine"
 // +kubebuilder:printcolumn:name="DesiredVersion",type="string",JSONPath=".status.desiredVersion",description="The desired version of the MultiClusterEngine"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[-1:].message",description="Message from the most recent condition"
 // +operator-sdk:csv:customresourcedefinitions:displayName="MultiCluster Engine"
 type MultiClusterEngine struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/bundle/manifests/multicluster.openshift.io_multiclusterengines.yaml
+++ b/bundle/manifests/multicluster.openshift.io_multiclusterengines.yaml
@@ -32,6 +32,10 @@ spec:
       jsonPath: .status.desiredVersion
       name: DesiredVersion
       type: string
+    - description: Message from the most recent condition
+      jsonPath: .status.conditions[-1:].message
+      name: Message
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
+++ b/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
@@ -32,6 +32,10 @@ spec:
       jsonPath: .status.desiredVersion
       name: DesiredVersion
       type: string
+    - description: Message from the most recent condition
+      jsonPath: .status.conditions[-1:].message
+      name: Message
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/pkg/status/condition.go
+++ b/pkg/status/condition.go
@@ -2,6 +2,7 @@
 package status
 
 import (
+	"sort"
 	"strings"
 
 	v1 "github.com/stolostron/backplane-operator/api/v1"
@@ -71,7 +72,14 @@ func setCondition(conditions []v1.MultiClusterEngineCondition, c v1.MultiCluster
 	}
 
 	newConditions := filterOutCondition(conditions, c.Type)
-	return append(newConditions, c)
+	newConditions = append(newConditions, c)
+
+	// Sort conditions by lastUpdateTime so the most recently updated is always last
+	sort.Slice(newConditions, func(i, j int) bool {
+		return newConditions[i].LastUpdateTime.Before(&newConditions[j].LastUpdateTime)
+	})
+
+	return newConditions
 }
 
 // GetCondition returns the condition you're looking for by type


### PR DESCRIPTION
# Description

- Add Message column to CRD additionalPrinterColumns displaying the most recently updated condition message
- Sort conditions by lastUpdateTime in setCondition() to ensure the most recent condition is always last in the array
- Add kubebuilder printcolumn marker to preserve column in generated CRDs

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
