### PR TITLE
Sort MCE status conditions by lastTransitionTime

### DIFF
--- a/pkg/status/condition.go
+++ b/pkg/status/condition.go
@@ -74,9 +74,9 @@ func setCondition(conditions []v1.MultiClusterEngineCondition, c v1.MultiCluster
 	newConditions := filterOutCondition(conditions, c.Type)
 	newConditions = append(newConditions, c)
 
-	// Sort conditions by lastUpdateTime so the most recently updated is always last
+	// Sort conditions by lastTransitionTime so the most recently transitioned is always last
 	sort.Slice(newConditions, func(i, j int) bool {
-		return newConditions[i].LastUpdateTime.Before(&newConditions[j].LastUpdateTime)
+		return newConditions[i].LastTransitionTime.Before(&newConditions[j].LastTransitionTime)
 	})
 
 	return newConditions


### PR DESCRIPTION
# Description

Sort conditions by `lastTransitionTime` instead of `lastUpdateTime` to ensure the most recently transitioned condition appears last in the status array.

This ensures the Message column in 'oc get mce' displays the message from the condition that most recently changed state, which is more meaningful than displaying the message from the most recently updated condition.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the ordering of status conditions to ensure consistent and predictable sequencing based on transition timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->