### PR TITLE
✨ Add tls-profile-sync sidecar to cluster-manager operator

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -43,7 +43,15 @@
     - readOnlyRootFilesystem
     imageMappings:
       registration-operator: registration_operator
+      managedcluster-import-controller: managedcluster_import_controller
     name: cluster-manager
+    patches:
+    - target: cluster-manager.yaml
+      path: ../patches/cluster-manager-tls-sidecar.yaml
+      type: strategic-merge
+    additional_templates:
+    - ../patches/cluster-manager-tls-sync-clusterrole.yaml
+    - ../patches/cluster-manager-tls-sync-clusterrolebinding.yaml
   repo_name: registration-operator
 
 - branch: backplane-2.17

--- a/hack/patches/cluster-manager-tls-sidecar.yaml
+++ b/hack/patches/cluster-manager-tls-sidecar.yaml
@@ -1,0 +1,39 @@
+# Strategic merge patch: adds tls-profile-sync sidecar to cluster-manager deployment.
+# The sidecar watches OpenShift APIServer.spec.tlsSecurityProfile and syncs it
+# to an ocm-tls-profile ConfigMap for OCM components to consume.
+#
+# This is a pure YAML patch applied before injectRequirements(). The placeholder
+# image 'managedcluster-import-controller' is converted to a Helm template variable
+# by fixImageReferences() via the imageMapping in config.yaml.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: registration-operator
+      - name: tls-profile-sync
+        image: managedcluster-import-controller
+        command:
+        - /usr/local/bin/tls-profile-sync
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true

--- a/hack/patches/cluster-manager-tls-sync-clusterrole.yaml
+++ b/hack/patches/cluster-manager-tls-sync-clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-profile-sync
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/hack/patches/cluster-manager-tls-sync-clusterrolebinding.yaml
+++ b/hack/patches/cluster-manager-tls-sync-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-profile-sync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-profile-sync
+subjects:
+- kind: ServiceAccount
+  name: cluster-manager
+  namespace: '{{ .Values.global.namespace }}'

--- a/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager-tls-sync-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager-tls-sync-clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:tls-profile-sync'
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager-tls-sync-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager-tls-sync-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:tls-profile-sync'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:tls-profile-sync'
+subjects:
+- kind: ServiceAccount
+  name: cluster-manager
+  namespace: '{{ .Values.global.namespace }}'

--- a/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/templates/cluster-manager.yaml
@@ -86,6 +86,39 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmpdir
+      - command:
+        - /usr/local/bin/tls-profile-sync
+        env:
+{{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+{{- end }}
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: '{{ .Values.global.imageOverrides.managedcluster_import_controller
+          }}'
+        imagePullPolicy: '{{ .Values.global.pullPolicy }}'
+        name: tls-profile-sync
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
       hostIPC: false
       hostNetwork: false
       hostPID: false

--- a/pkg/templates/charts/toggle/cluster-manager/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/values.yaml
@@ -1,6 +1,7 @@
 global:
   deployOnOCP: true
   imageOverrides:
+    managedcluster_import_controller: ''
     registration_operator: ''
   namespace: default
   pullSecret: null

--- a/pkg/templates/crds/cluster-manager/operator.open-cluster-management.io_clustermanagers.yaml
+++ b/pkg/templates/crds/cluster-manager/operator.open-cluster-management.io_clustermanagers.yaml
@@ -398,6 +398,41 @@ spec:
                       type: object
                     type: array
                 type: object
+              placementConfiguration:
+                description: placementConfiguration contains the configuration of
+                  placement
+                properties:
+                  featureGates:
+                    description: "FeatureGates represents the list of feature gates
+                      for placement\nIf it is set empty, default feature gates will
+                      be used.\nIf it is set, featuregate/Foo is an example of one
+                      item in FeatureGates:\n  1. If featuregate/Foo does not exist,
+                      registration-operator will discard it\n  2. If featuregate/Foo
+                      exists and is false by default. It is now possible to set featuregate/Foo=[false|true]\n
+                      \ 3. If featuregate/Foo exists and is true by default. If a
+                      cluster-admin upgrading from 1 to 2 wants to continue having
+                      featuregate/Foo=false,\n \the can set featuregate/Foo=false
+                      before upgrading. Let's say the cluster-admin wants featuregate/Foo=false."
+                    items:
+                      properties:
+                        feature:
+                          description: Feature is the key of feature gate. e.g. featuregate/Foo.
+                          type: string
+                        mode:
+                          default: Disable
+                          description: |-
+                            Mode is either Enable, Disable, "" where "" is Disable by default.
+                            In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true".
+                            In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                          enum:
+                          - Enable
+                          - Disable
+                          type: string
+                      required:
+                      - feature
+                      type: object
+                    type: array
+                type: object
               placementImagePullSpec:
                 default: quay.io/open-cluster-management/placement
                 description: placementImagePullSpec represents the desired image configuration

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -12,6 +12,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;patch;update;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
@@ -391,6 +392,7 @@ package main
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;get;list;patch;update
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=get;list;watch;create;update;delete;patch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch


### PR DESCRIPTION
# Description

Add a `tls-profile-sync` sidecar container to the cluster-manager operator deployment for TLS profile compliance (OpenShift 4.22 requirement, ACM-26882).

The sidecar watches `APIServer.spec.tlsSecurityProfile` and syncs TLS settings to an `ocm-tls-profile` ConfigMap that upstream OCM components can consume, enabling dynamic TLS configuration without depending on OpenShift APIs.

## Related Issue

- [ACM-26882: Central TLS Profile consistency](https://issues.redhat.com/browse/ACM-26882)
- Design doc: https://github.com/stolostron/managedcluster-import-controller/pull/1027
- Sidecar implementation (spoke-side): https://github.com/stolostron/managedcluster-import-controller/pull/1032

## Changes Made

- **`hack/patches/cluster-manager-tls-sidecar.yaml`** — Strategic merge patch adding the `tls-profile-sync` sidecar container to the cluster-manager deployment. Uses `managedcluster-import-controller` image which bundles the sidecar binary.
- **`hack/patches/cluster-manager-tls-sync-clusterrole.yaml`** — RBAC ClusterRole for watching `config.openshift.io/apiservers` and managing configmaps.
- **`hack/patches/cluster-manager-tls-sync-clusterrolebinding.yaml`** — ClusterRoleBinding binding the role to the `cluster-manager` ServiceAccount.
- **`hack/bundle-automation/config.yaml`** — Added `patches`, `additional_templates`, and `imageMappings` entries for the sidecar.
- **`pkg/templates/charts/toggle/cluster-manager/`** — Regenerated chart templates with sidecar container, RBAC, and updated values.yaml.
- **`pkg/templates/crds/cluster-manager/`** — Updated CRD from upstream OCM bundle.

### How it works

The chart generation pipeline (`installer-dev-tools`) applies the strategic merge patch to the cluster-manager deployment template **before** `injectRequirements()` runs. This means:
1. The sidecar container is merged into the deployment as pure YAML
2. `fixImageReferences()` converts the placeholder image to a Helm template variable
3. `updateDeployments()` adds standard Helm flow control (proxy env vars, security context, etc.)

### Dependencies

- Requires [installer-dev-tools: add-helm-chart-patching-support](https://github.com/zhujian7/installer-dev-tools/tree/add-helm-chart-patching-support) for the `patches` and `additional_templates` support in `bundles-to-charts.py`.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- The sidecar gracefully handles non-OpenShift clusters (detects missing CRD, sleeps instead of crash-looping) — handled in the sidecar implementation itself.
- The sidecar image is the same `managedcluster-import-controller` image used on the spoke side, which bundles the `tls-profile-sync` binary.

Assisted by Claude