### PR TITLE
[ACM-32255] Update postgres image from postgresql-13 to postgresql-15

### DIFF
--- a/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
@@ -55,7 +55,7 @@ spec:
         - name: IMAGE_SERVICE_IMAGE
           value: '{{ .Values.global.imageOverrides.assisted_image_service }}'
         - name: DATABASE_IMAGE
-          value: '{{ .Values.global.imageOverrides.postgresql_13 }}'
+          value: '{{ .Values.global.imageOverrides.postgresql_15 }}'
         - name: AGENT_IMAGE
           value: '{{ .Values.global.imageOverrides.assisted_installer_agent }}'
         - name: CONTROLLER_IMAGE

--- a/pkg/templates/charts/toggle/assisted-service/values.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/values.yaml
@@ -7,6 +7,7 @@ global:
     assisted_installer_controller: ''
     assisted_service_9: ''
     postgresql_13: ''
+    postgresql_15: ''
   namespace: default
   pullSecret: null
   templateOverrides: {}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -219,7 +219,7 @@ func GetTestImages() []string {
 		"hypershift_operator", "image_based_install_operator", "ip_address_manager", "kube_rbac_proxy_mce",
 		"maestro", "managed_serviceaccount", "managedcluster_import_controller", "mce_capi_webhook_config_rhel9",
 		"multicloud_manager", "openshift_hive", "ose_aws_cluster_api_controllers_rhel9",
-		"ose_baremetal_cluster_api_controllers_rhel9", "ose_cluster_api_rhel9", "postgresql_13",
+		"ose_baremetal_cluster_api_controllers_rhel9", "ose_cluster_api_rhel9", "postgresql_13", "postgresql_15",
 		"provider_credential_controller", "registration", "registration_operator", "work",
 	}
 }


### PR DESCRIPTION
## Summary
Update the PostgreSQL database image for assisted-service from postgresql-13-c9s to postgresql-15-c9s for ACM 2.17 / MCE 2.17.

## Changes Made
- **values.yaml**: Added `postgresql_15` image override alongside existing `postgresql_13`
- **infrastructure-operator.yaml**: Updated `DATABASE_IMAGE` environment variable to use `postgresql_15` instead of `postgresql_13`
- **utils.go**: Added `postgresql_15` to the list of on-components

## Testing
- Modified source template files
- CI will automatically regenerate charts via `make regenerate-charts`
- No additional manual testing required for this image reference update

## Migration Pattern
Following the established pattern from previous PostgreSQL upgrades (see PR #1673):
1. This PR adds postgresql-15 support while keeping postgresql-13 references
2. After merge and deployment, a follow-up PR will remove postgresql-13 references
3. This ensures a smooth transition without breaking existing deployments

## Related Work
- mce-operator-bundle: PR #2731 (merged) - Added postgresql-15 to bundle config
- Reference PRs:
  - Previous upgrade (PG12→PG13): #2379
  - Add PG13 alongside PG12: stolostron/mce-operator-bundle#1673
  - Cleanup PG12: stolostron/mce-operator-bundle#1688

## Files Modified
- pkg/templates/charts/toggle/assisted-service/values.yaml
- pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml  
- pkg/utils/utils.go

## Jira
https://redhat.atlassian.net/browse/ACM-32255

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>