### PR TITLE
Updated CAP(x) branch reference to 2.17 for chart automation

### DIFF
--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -21,7 +21,7 @@ components:
 
   - repo_name: "cluster-api-installer"
     github_ref: "https://github.com/stolostron/cluster-api-installer.git"
-    branch: "backplane-2.11"
+    branch: "backplane-2.17"
     charts:
       - name: "cluster-api"
         chart-path: "charts/cluster-api"
@@ -100,7 +100,7 @@ components:
 
   - repo_name: "cluster-api-installer-k8s"
     github_ref: "https://github.com/stolostron/cluster-api-installer.git"
-    branch: "backplane-2.11"
+    branch: "backplane-2.17"
     charts:
       - name: "cluster-api-k8s"
         chart-path: "charts/cluster-api-k8s"


### PR DESCRIPTION
# Description

This PR updates the Cluster API installer branch reference from `backplane-2.11` to `backplane-2.17` in the chart automation configuration. This enables the `make regenerate-charts` command to sync with the latest Cluster API changes from the correct branch.

## Related Issue

Related to https://github.com/stolostron/cluster-api-installer/pull/612 - which contains CAPI v4.22 updates that need to be synced to this repository.

## Changes Made

- Updated `cluster-api-installer` component branch from `backplane-2.11` to `backplane-2.17` in `hack/bundle-automation/charts-config.yaml`
- Updated `cluster-api-installer-k8s` component branch from `backplane-2.11` to `backplane-2.17` in `hack/bundle-automation/charts-config.yaml`

This allows the chart generation automation to pull from the correct upstream branch that contains the CAPI v4.22 fixes.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected. (`make regenerate-charts` now syncs correctly)
- [x] I have updated the documentation (if necessary) to reflect the changes. (N/A - config change only)
- [ ] I have added/updated relevant unit tests (if applicable). (N/A - config change only)
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them. (N/A - config change only)
- [ ] I have added necessary comments to the code, especially in complex or unclear sections. (N/A - config change only)
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

After this change, running `make regenerate-charts` will properly sync the Cluster API charts from the `backplane-2.17` branch instead of the outdated `backplane-2.11` branch. This resolves the issue where chart regeneration wasn't picking up the latest changes from the cluster-api-installer repository.

The branch reference update aligns with the MCE release version 2.17 as indicated in the `mce-release-version` field at the top of the config file.

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested. (`make regenerate-charts` verified to work correctly)
- [ ] Documentation is updated. (N/A for this change)
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.