### PR TITLE
ACM-30181 ACM-31240  Inherit TLS profile from OpenShift APIServer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ test-prep: manifests generate fmt vet envtest ## prepare to run tests.
 	echo "Ready to run tests"
 
 test: manifests generate fmt vet envtest ## Run tests (with coverage).
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" DIRECTORY_OVERRIDE="../" UNIT_TEST=true ENV_TEST=true go test $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --use-deprecated-gcs=false -p path)" DIRECTORY_OVERRIDE="../" UNIT_TEST=true ENV_TEST=true go test $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
 
 ##@ Build
 

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -813,7 +813,7 @@ func (r *MultiClusterEngineReconciler) createMetricsServiceMonitor(ctx context.C
 			Spec: monitorv1.ServiceMonitorSpec{
 				Endpoints: []monitorv1.Endpoint{
 					{
-						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token", // #nosec G101 -- Standard Kubernetes service account token path, not a hardcoded credential
 						BearerTokenSecret: &corev1.SecretKeySelector{
 							Key: "",
 						},

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -108,8 +108,7 @@ var (
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs,verbs=get
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs,verbs=list
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs;discoveredclusters,verbs=create;get;list;watch;update;delete;deletecollection;patch;approve;escalate;bind
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch;
-// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update;patch
 

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -169,7 +169,6 @@ var (
 func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (retRes ctrl.Result, retErr error) {
 	r.Log = log
 	r.Log.Info("Reconciling MultiClusterEngine")
-	r.Log.Info("DEBUG: TLS profile ConfigMap code active")
 
 	// Fetch the BackplaneConfig instance
 	backplaneConfig, err := r.getBackplaneConfig(ctx, req)

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -170,6 +170,7 @@ var (
 func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (retRes ctrl.Result, retErr error) {
 	r.Log = log
 	r.Log.Info("Reconciling MultiClusterEngine")
+	r.Log.Info("DEBUG: TLS profile ConfigMap code active")
 
 	// Fetch the BackplaneConfig instance
 	backplaneConfig, err := r.getBackplaneConfig(ctx, req)

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1951,14 +1951,6 @@ func (r *MultiClusterEngineReconciler) applyTemplate(ctx context.Context,
 				}
 				return ctrl.Result{}, err
 			}
-
-			// Ensure TLS profile ConfigMap exists in namespaces that require it
-			if renderer.NamespaceRequiresTLSProfile(template.GetNamespace()) {
-				if err := renderer.EnsureTLSProfileConfigMap(ctx, r.Client, backplaneConfig, template.GetNamespace(), r.Scheme); err != nil {
-					r.Log.Error(err, "Failed to ensure TLS profile ConfigMap", "Namespace", template.GetNamespace())
-					return ctrl.Result{}, err
-				}
-			}
 		}
 
 		existing := template.DeepCopy()

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -109,6 +109,7 @@ var (
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs,verbs=list
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs;discoveredclusters,verbs=create;get;list;watch;update;delete;deletecollection;patch;approve;escalate;bind
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update;patch
 
@@ -1949,6 +1950,14 @@ func (r *MultiClusterEngineReconciler) applyTemplate(ctx context.Context,
 					return ctrl.Result{}, nil
 				}
 				return ctrl.Result{}, err
+			}
+
+			// Ensure TLS profile ConfigMap exists in namespaces that require it
+			if renderer.NamespaceRequiresTLSProfile(template.GetNamespace()) {
+				if err := renderer.EnsureTLSProfileConfigMap(ctx, r.Client, backplaneConfig, template.GetNamespace(), r.Scheme); err != nil {
+					r.Log.Error(err, "Failed to ensure TLS profile ConfigMap", "Namespace", template.GetNamespace())
+					return ctrl.Result{}, err
+				}
 			}
 		}
 

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -1279,10 +1279,9 @@ func (r *MultiClusterEngineReconciler) ensureClusterManager(ctx context.Context,
 		return ctrl.Result{}, errors.Wrapf(err, "error applying object Name: %s Kind: %s", cmTemplate.GetName(), cmTemplate.GetKind())
 	}
 
-	// Ensure TLS profile ConfigMap exists in ClusterManager namespaces
-	// This namespace is created by the ClusterManager operator
+	// Ensure TLS profile ConfigMap exists in operator namespace where cluster-manager runs
 	clusterManagerNamespaces := []string{
-		"open-cluster-management-hub", // ClusterManager Default mode namespace
+		mce.Spec.TargetNamespace, // Operator namespace (multicluster-engine)
 	}
 	if err := renderer.EnsureTLSProfileConfigMaps(ctx, r.Client, mce, clusterManagerNamespaces, r.Scheme); err != nil {
 		return ctrl.Result{}, err

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -1279,6 +1279,15 @@ func (r *MultiClusterEngineReconciler) ensureClusterManager(ctx context.Context,
 		return ctrl.Result{}, errors.Wrapf(err, "error applying object Name: %s Kind: %s", cmTemplate.GetName(), cmTemplate.GetKind())
 	}
 
+	// Ensure TLS profile ConfigMap exists in ClusterManager namespaces
+	// This namespace is created by the ClusterManager operator
+	clusterManagerNamespaces := []string{
+		"open-cluster-management-hub", // ClusterManager Default mode namespace
+	}
+	if err := renderer.EnsureTLSProfileConfigMaps(ctx, r.Client, mce, clusterManagerNamespaces, r.Scheme); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -166,14 +166,6 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
-		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: 9443,
-			TLSOpts: []func(*tls.Config){
-				func(config *tls.Config) {
-					config.MinVersion = tls.VersionTLS12
-				},
-			},
-		}),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "797f9276.open-cluster-management.io",
@@ -185,6 +177,37 @@ func main() {
 		},
 		// LeaderElectionNamespace: "backplane-operator-system", // Ensure this is commented out. Uncomment only for running operator locally.
 	}
+
+	// Create uncached client early for TLS profile fetching and other setup tasks
+	ctx := context.Background()
+	uncachedClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to create uncached client")
+		os.Exit(1)
+	}
+
+	// Get TLS configuration from OpenShift APIServer profile
+	tlsProfile, err := utils.GetAPIServerTLSProfile(ctx, uncachedClient)
+	if err != nil {
+		setupLog.Error(err, "unable to get APIServer TLS profile, using default TLS 1.2")
+		// Continue with default if we can't get the profile
+		tlsProfile = &configv1.TLSProfileSpec{
+			MinTLSVersion: configv1.VersionTLS12,
+		}
+	}
+
+	minTLSVersion := utils.ConvertTLSVersion(tlsProfile.MinTLSVersion)
+	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion)
+
+	// Configure webhook server with dynamic TLS settings from OpenShift
+	mgrOptions.WebhookServer = webhook.NewServer(webhook.Options{
+		Port: 9443,
+		TLSOpts: []func(*tls.Config){func(config *tls.Config) {
+			config.MinVersion = minTLSVersion
+		}},
+	})
 
 	setupLog.Info("Disabling Operator Client Cache for high-memory resources")
 	mgrOptions.Client.Cache.DisableFor = []client.Object{
@@ -199,15 +222,6 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	// use uncached client for setup before manager starts
-	uncachedClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
-		Scheme: mgr.GetScheme(),
-	})
-	if err != nil {
-		setupLog.Error(err, "unable to create uncached client")
 		os.Exit(1)
 	}
 	err = utils.DetectOpenShift(uncachedClient)

--- a/main.go
+++ b/main.go
@@ -188,6 +188,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Detect if running on OpenShift before checking for OCP-specific resources
+	err = utils.DetectOpenShift(uncachedClient)
+	if err != nil {
+		setupLog.Error(err, "unable to detect if cluster is openShift")
+		os.Exit(1)
+	}
+
 	// Get TLS configuration from OpenShift APIServer profile
 	tlsProfile, err := utils.GetAPIServerTLSProfile(ctx, uncachedClient)
 	if err != nil {
@@ -242,11 +249,6 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-	err = utils.DetectOpenShift(uncachedClient)
-	if err != nil {
-		setupLog.Error(err, "unable to detect if cluster is openShift")
 		os.Exit(1)
 	}
 	ctx = ctrl.SetupSignalHandler()

--- a/main.go
+++ b/main.go
@@ -193,19 +193,39 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to get APIServer TLS profile, using default TLS 1.2")
 		// Continue with default if we can't get the profile
+		// Use Intermediate profile ciphers as secure default for TLS 1.2
 		tlsProfile = &configv1.TLSProfileSpec{
 			MinTLSVersion: configv1.VersionTLS12,
+			Ciphers: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+				"ECDHE-ECDSA-AES128-GCM-SHA256",
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"ECDHE-ECDSA-AES256-GCM-SHA384",
+				"ECDHE-RSA-AES256-GCM-SHA384",
+				"ECDHE-ECDSA-CHACHA20-POLY1305",
+				"ECDHE-RSA-CHACHA20-POLY1305",
+				"DHE-RSA-AES128-GCM-SHA256",
+				"DHE-RSA-AES256-GCM-SHA384",
+			},
 		}
 	}
 
 	minTLSVersion := utils.ConvertTLSVersion(tlsProfile.MinTLSVersion)
-	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion)
+	cipherSuites := utils.ConvertCipherSuites(tlsProfile.Ciphers)
+	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion, "cipherCount", len(cipherSuites))
 
 	// Configure webhook server with dynamic TLS settings from OpenShift
 	mgrOptions.WebhookServer = webhook.NewServer(webhook.Options{
 		Port: 9443,
 		TLSOpts: []func(*tls.Config){func(config *tls.Config) {
 			config.MinVersion = minTLSVersion
+			// Only set CipherSuites for TLS ≤ 1.2
+			// TLS 1.3 cipher suites are managed automatically by Go
+			if minTLSVersion < tls.VersionTLS13 && len(cipherSuites) > 0 {
+				config.CipherSuites = cipherSuites
+			}
 		}},
 	})
 

--- a/main.go
+++ b/main.go
@@ -229,7 +229,7 @@ func main() {
 		setupLog.Error(err, "unable to detect if cluster is openShift")
 		os.Exit(1)
 	}
-	ctx := ctrl.SetupSignalHandler()
+	ctx = ctrl.SetupSignalHandler()
 	upgradeableCondition := &utils.OperatorCondition{}
 
 	if utils.DeployOnOCP() {

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -262,7 +262,7 @@ func RenderCRDs(crdDir string, backplaneConfig *v1.MultiClusterEngine, skipDirs 
 			}
 		}
 
-		bytesFile, e := os.ReadFile(filepath.Clean(filePath)) // #nosec G304 -- filePath from filepath.Walk
+		bytesFile, e := os.ReadFile(filepath.Clean(filePath)) // #nosec G304,G122 -- filePath from filepath.Walk within operator's own template directory
 		if e != nil {
 			errs = append(errs, fmt.Errorf("%s - error reading file: %v", info.Name(), err.Error()))
 		}

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -35,13 +35,6 @@ const (
 	AlwaysChartsDir = "pkg/templates/charts/always"
 )
 
-// namespacesRequiringTLSProfile is a lookup table for namespaces that need the TLS profile ConfigMap.
-// The ConfigMap is required in namespaces where cluster-manager components are deployed.
-var namespacesRequiringTLSProfile = map[string]bool{
-	"open-cluster-management-hub":   true, // ClusterManager Default mode namespace
-	"open-cluster-management-agent": true, // Klusterlet agent namespace (for local-cluster)
-}
-
 type Values struct {
 	Global    Global    `json:"global" structs:"global"`
 	HubConfig HubConfig `json:"hubconfig" structs:"hubconfig"`
@@ -492,61 +485,60 @@ func injectValuesOverrides(values *Values, backplaneConfig *v1.MultiClusterEngin
 	}
 }
 
-// EnsureTLSProfileConfigMap creates or updates the TLS profile ConfigMap in the specified namespace.
+// EnsureTLSProfileConfigMaps creates or updates the TLS profile ConfigMap in the specified namespaces.
 // It reads the TLS security profile from the OpenShift APIServer resource and populates the ConfigMap
-// with minTLSVersion and cipherSuites.
-func EnsureTLSProfileConfigMap(
+// with minTLSVersion and cipherSuites in each namespace.
+func EnsureTLSProfileConfigMaps(
 	ctx context.Context,
 	cl client.Client,
 	mce *v1.MultiClusterEngine,
-	namespace string,
+	namespaces []string,
 	scheme *runtime.Scheme,
 ) error {
-	log := log.FromContext(ctx).WithValues("ConfigMap", "ocm-tls-profile", "Namespace", namespace)
-
-	// Get the TLS profile from the APIServer resource
+	// Get the TLS profile from the APIServer resource once
 	tlsProfile, err := utils.GetAPIServerTLSProfile(ctx, cl)
 	if err != nil {
 		return fmt.Errorf("failed to get APIServer TLS profile: %w", err)
 	}
 
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ocm-tls-profile",
-			Namespace: namespace,
-		},
-	}
-
-	// Convert ciphers from OpenSSL format to IANA format before CreateOrUpdate
+	// Convert ciphers from OpenSSL format to IANA format once
 	ianaCiphers, err := utils.ConvertCipherSuitesToIANA(tlsProfile.Ciphers)
 	if err != nil {
 		return fmt.Errorf("failed to convert cipher suites to IANA format: %w", err)
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, cl, configMap, func() error {
-		// Set the data
-		configMap.Data = map[string]string{
-			"minTLSVersion": string(tlsProfile.MinTLSVersion),
-			"cipherSuites":  strings.Join(ianaCiphers, ","),
+	// Create or update ConfigMap in each namespace
+	for _, namespace := range namespaces {
+		log := log.FromContext(ctx).WithValues("ConfigMap", "ocm-tls-profile", "Namespace", namespace)
+
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ocm-tls-profile",
+				Namespace: namespace,
+			},
 		}
 
-		// Set controller reference
-		if err := ctrl.SetControllerReference(mce, configMap, scheme); err != nil {
-			return fmt.Errorf("failed to set controller reference: %w", err)
+		_, err = controllerutil.CreateOrUpdate(ctx, cl, configMap, func() error {
+			// Set the data
+			configMap.Data = map[string]string{
+				"minTLSVersion": string(tlsProfile.MinTLSVersion),
+				"cipherSuites":  strings.Join(ianaCiphers, ","),
+			}
+
+			// Set controller reference
+			if err := ctrl.SetControllerReference(mce, configMap, scheme); err != nil {
+				return fmt.Errorf("failed to set controller reference: %w", err)
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return fmt.Errorf("failed to create or update TLS profile ConfigMap in namespace %s: %w", namespace, err)
 		}
 
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to create or update TLS profile ConfigMap: %w", err)
+		log.Info("Ensured TLS profile ConfigMap")
 	}
 
-	log.Info("Ensured TLS profile ConfigMap")
 	return nil
-}
-
-// NamespaceRequiresTLSProfile checks if a namespace needs the TLS profile ConfigMap.
-func NamespaceRequiresTLSProfile(namespace string) bool {
-	return namespacesRequiringTLSProfile[namespace]
 }

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -3,6 +3,7 @@
 package renderer
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 
 	loader "helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -19,7 +21,12 @@ import (
 	"github.com/stolostron/backplane-operator/pkg/utils"
 	"helm.sh/helm/v3/pkg/engine"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
@@ -27,6 +34,13 @@ import (
 const (
 	AlwaysChartsDir = "pkg/templates/charts/always"
 )
+
+// namespacesRequiringTLSProfile is a lookup table for namespaces that need the TLS profile ConfigMap.
+// The ConfigMap is required in namespaces where cluster-manager components are deployed.
+var namespacesRequiringTLSProfile = map[string]bool{
+	"open-cluster-management-hub":   true, // ClusterManager Default mode namespace
+	"open-cluster-management-agent": true, // Klusterlet agent namespace (for local-cluster)
+}
 
 type Values struct {
 	Global    Global    `json:"global" structs:"global"`
@@ -476,4 +490,63 @@ func injectValuesOverrides(values *Values, backplaneConfig *v1.MultiClusterEngin
 		proxyVar["NO_PROXY"] = os.Getenv("NO_PROXY")
 		values.HubConfig.ProxyConfigs = proxyVar
 	}
+}
+
+// EnsureTLSProfileConfigMap creates or updates the TLS profile ConfigMap in the specified namespace.
+// It reads the TLS security profile from the OpenShift APIServer resource and populates the ConfigMap
+// with minTLSVersion and cipherSuites.
+func EnsureTLSProfileConfigMap(
+	ctx context.Context,
+	cl client.Client,
+	mce *v1.MultiClusterEngine,
+	namespace string,
+	scheme *runtime.Scheme,
+) error {
+	log := log.FromContext(ctx).WithValues("ConfigMap", "ocm-tls-profile", "Namespace", namespace)
+
+	// Get the TLS profile from the APIServer resource
+	tlsProfile, err := utils.GetAPIServerTLSProfile(ctx, cl)
+	if err != nil {
+		return fmt.Errorf("failed to get APIServer TLS profile: %w", err)
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocm-tls-profile",
+			Namespace: namespace,
+		},
+	}
+
+	// Convert ciphers from OpenSSL format to IANA format before CreateOrUpdate
+	ianaCiphers, err := utils.ConvertCipherSuitesToIANA(tlsProfile.Ciphers)
+	if err != nil {
+		return fmt.Errorf("failed to convert cipher suites to IANA format: %w", err)
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, cl, configMap, func() error {
+		// Set the data
+		configMap.Data = map[string]string{
+			"minTLSVersion": string(tlsProfile.MinTLSVersion),
+			"cipherSuites":  strings.Join(ianaCiphers, ","),
+		}
+
+		// Set controller reference
+		if err := ctrl.SetControllerReference(mce, configMap, scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to create or update TLS profile ConfigMap: %w", err)
+	}
+
+	log.Info("Ensured TLS profile ConfigMap")
+	return nil
+}
+
+// NamespaceRequiresTLSProfile checks if a namespace needs the TLS profile ConfigMap.
+func NamespaceRequiresTLSProfile(namespace string) bool {
+	return namespacesRequiringTLSProfile[namespace]
 }

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -664,6 +664,7 @@ func TestRenderCRDsSkipDirectories(t *testing.T) {
 		})
 	}
 }
+
 func TestParseProbeConfigFromAnnotations(t *testing.T) {
 	t.Run("No annotations returns nil", func(t *testing.T) {
 		mce := &backplane.MultiClusterEngine{
@@ -804,5 +805,71 @@ func TestParseProbeConfigFromAnnotations(t *testing.T) {
 		if result.TimeoutSeconds == nil || *result.TimeoutSeconds != 20 {
 			t.Errorf("Expected TimeoutSeconds=20, got %v", result.TimeoutSeconds)
 		}
+	})
+}
+
+func TestNamespaceRequiresTLSProfile(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		want      bool
+	}{
+		{
+			name:      "open-cluster-management-hub requires TLS profile",
+			namespace: "open-cluster-management-hub",
+			want:      true,
+		},
+		{
+			name:      "open-cluster-management-agent requires TLS profile",
+			namespace: "open-cluster-management-agent",
+			want:      true,
+		},
+		{
+			name:      "multicluster-engine does not require TLS profile",
+			namespace: "multicluster-engine",
+			want:      false,
+		},
+		{
+			name:      "default namespace does not require TLS profile",
+			namespace: "default",
+			want:      false,
+		},
+		{
+			name:      "empty namespace does not require TLS profile",
+			namespace: "",
+			want:      false,
+		},
+		{
+			name:      "random namespace does not require TLS profile",
+			namespace: "random-namespace",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NamespaceRequiresTLSProfile(tt.namespace)
+			if got != tt.want {
+				t.Errorf("NamespaceRequiresTLSProfile(%q) = %v, want %v", tt.namespace, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureTLSProfileConfigMap(t *testing.T) {
+	// Note: This is a basic test that verifies the function doesn't panic
+	// and handles unit test mode correctly. Full integration testing would
+	// require a real Kubernetes client and APIServer resource.
+
+	os.Setenv("UNIT_TEST", "true")
+	defer os.Unsetenv("UNIT_TEST")
+
+	// This test verifies that the function can be called in unit test mode
+	// without panicking. The actual ConfigMap creation would need a proper
+	// fake client setup which is better suited for integration tests.
+	t.Run("unit test mode doesn't panic", func(t *testing.T) {
+		// In a real test environment, you would set up a fake client here
+		// For now, we just verify the function exists and compiles
+		_ = EnsureTLSProfileConfigMap
 	})
 }

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -814,54 +814,6 @@ func TestParseProbeConfigFromAnnotations(t *testing.T) {
 	})
 }
 
-func TestNamespaceRequiresTLSProfile(t *testing.T) {
-	tests := []struct {
-		name      string
-		namespace string
-		want      bool
-	}{
-		{
-			name:      "open-cluster-management-hub requires TLS profile",
-			namespace: "open-cluster-management-hub",
-			want:      true,
-		},
-		{
-			name:      "open-cluster-management-agent requires TLS profile",
-			namespace: "open-cluster-management-agent",
-			want:      true,
-		},
-		{
-			name:      "multicluster-engine does not require TLS profile",
-			namespace: "multicluster-engine",
-			want:      false,
-		},
-		{
-			name:      "default namespace does not require TLS profile",
-			namespace: "default",
-			want:      false,
-		},
-		{
-			name:      "empty namespace does not require TLS profile",
-			namespace: "",
-			want:      false,
-		},
-		{
-			name:      "random namespace does not require TLS profile",
-			namespace: "random-namespace",
-			want:      false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := NamespaceRequiresTLSProfile(tt.namespace)
-			if got != tt.want {
-				t.Errorf("NamespaceRequiresTLSProfile(%q) = %v, want %v", tt.namespace, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestEnsureTLSProfileConfigMaps(t *testing.T) {
 	os.Setenv("UNIT_TEST", "true")
 	defer os.Unsetenv("UNIT_TEST")

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -856,7 +856,7 @@ func TestNamespaceRequiresTLSProfile(t *testing.T) {
 	}
 }
 
-func TestEnsureTLSProfileConfigMap(t *testing.T) {
+func TestEnsureTLSProfileConfigMaps(t *testing.T) {
 	// Note: This is a basic test that verifies the function doesn't panic
 	// and handles unit test mode correctly. Full integration testing would
 	// require a real Kubernetes client and APIServer resource.
@@ -870,6 +870,6 @@ func TestEnsureTLSProfileConfigMap(t *testing.T) {
 	t.Run("unit test mode doesn't panic", func(t *testing.T) {
 		// In a real test environment, you would set up a fake client here
 		// For now, we just verify the function exists and compiles
-		_ = EnsureTLSProfileConfigMap
+		_ = EnsureTLSProfileConfigMaps
 	})
 }

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -4,9 +4,11 @@
 package renderer
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	backplane "github.com/stolostron/backplane-operator/api/v1"
@@ -16,7 +18,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -857,19 +863,140 @@ func TestNamespaceRequiresTLSProfile(t *testing.T) {
 }
 
 func TestEnsureTLSProfileConfigMaps(t *testing.T) {
-	// Note: This is a basic test that verifies the function doesn't panic
-	// and handles unit test mode correctly. Full integration testing would
-	// require a real Kubernetes client and APIServer resource.
-
 	os.Setenv("UNIT_TEST", "true")
 	defer os.Unsetenv("UNIT_TEST")
 
-	// This test verifies that the function can be called in unit test mode
-	// without panicking. The actual ConfigMap creation would need a proper
-	// fake client setup which is better suited for integration tests.
-	t.Run("unit test mode doesn't panic", func(t *testing.T) {
-		// In a real test environment, you would set up a fake client here
-		// For now, we just verify the function exists and compiles
-		_ = EnsureTLSProfileConfigMaps
-	})
+	tests := []struct {
+		name       string
+		namespaces []string
+		wantErr    bool
+	}{
+		{
+			name:       "single namespace",
+			namespaces: []string{"test-namespace"},
+			wantErr:    false,
+		},
+		{
+			name:       "multiple namespaces",
+			namespaces: []string{"namespace1", "namespace2", "namespace3"},
+			wantErr:    false,
+		},
+		{
+			name:       "empty namespace list",
+			namespaces: []string{},
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up scheme
+			s := runtime.NewScheme()
+			_ = scheme.AddToScheme(s)
+			_ = backplane.AddToScheme(s)
+
+			// Create test MCE object
+			mce := &backplane.MultiClusterEngine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-mce",
+					UID:  "test-uid-12345",
+				},
+				Spec: backplane.MultiClusterEngineSpec{
+					TargetNamespace: "multicluster-engine",
+				},
+			}
+
+			// Create namespaces
+			var initObjs []client.Object
+			initObjs = append(initObjs, mce)
+			for _, ns := range tt.namespaces {
+				initObjs = append(initObjs, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ns,
+					},
+				})
+			}
+
+			// Create fake client
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(initObjs...).
+				Build()
+
+			ctx := context.Background()
+
+			// Call function under test
+			err := EnsureTLSProfileConfigMaps(ctx, fakeClient, mce, tt.namespaces, s)
+
+			// Check error
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EnsureTLSProfileConfigMaps() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				return
+			}
+
+			// Verify ConfigMaps were created in each namespace
+			for _, ns := range tt.namespaces {
+				cm := &corev1.ConfigMap{}
+				err := fakeClient.Get(ctx, types.NamespacedName{
+					Name:      "ocm-tls-profile",
+					Namespace: ns,
+				}, cm)
+
+				if err != nil {
+					t.Errorf("Failed to get ConfigMap in namespace %s: %v", ns, err)
+					continue
+				}
+
+				// Verify ConfigMap data
+				if cm.Data == nil {
+					t.Errorf("ConfigMap in namespace %s has nil data", ns)
+					continue
+				}
+
+				minVersion, ok := cm.Data["minTLSVersion"]
+				if !ok {
+					t.Errorf("ConfigMap in namespace %s missing minTLSVersion key", ns)
+				}
+				if minVersion == "" {
+					t.Errorf("ConfigMap in namespace %s has empty minTLSVersion", ns)
+				}
+
+				ciphers, ok := cm.Data["cipherSuites"]
+				if !ok {
+					t.Errorf("ConfigMap in namespace %s missing cipherSuites key", ns)
+				}
+				// In unit test mode, we use Intermediate profile which has ciphers
+				if ciphers == "" {
+					t.Errorf("ConfigMap in namespace %s has empty cipherSuites", ns)
+				}
+
+				// Verify cipherSuites is comma-separated
+				cipherList := strings.Split(ciphers, ",")
+				if len(cipherList) == 0 {
+					t.Errorf("ConfigMap in namespace %s has no cipher suites", ns)
+				}
+
+				// Verify owner reference is set
+				if len(cm.OwnerReferences) == 0 {
+					t.Errorf("ConfigMap in namespace %s has no owner references", ns)
+					continue
+				}
+
+				ownerRef := cm.OwnerReferences[0]
+				if ownerRef.Kind != "MultiClusterEngine" {
+					t.Errorf("ConfigMap in namespace %s owner reference kind = %s, want MultiClusterEngine", ns, ownerRef.Kind)
+				}
+				if ownerRef.Name != mce.Name {
+					t.Errorf("ConfigMap in namespace %s owner reference name = %s, want %s", ns, ownerRef.Name, mce.Name)
+				}
+				if !*ownerRef.Controller {
+					t.Errorf("ConfigMap in namespace %s owner reference controller = false, want true", ns)
+				}
+			}
+		})
+	}
 }

--- a/pkg/templates/charts/toggle/discovery-operator/templates/discovery-operator-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/discovery-operator/templates/discovery-operator-clusterrole.yaml
@@ -90,6 +90,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - discovery.open-cluster-management.io
   resources:
   - discoveredclusters

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -397,6 +397,7 @@ package main
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;authentications,verbs=list;get;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;proxies,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusterversions;dnses;infrastructures;proxies,verbs=get;list;watch

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -510,7 +510,6 @@ func ComponentCRDDirectories(component string) []string {
 	}
 }
 
-<<<<<<< HEAD
 // opensslToIANACipherMap maps OpenSSL cipher names to IANA cipher names.
 // TLS 1.3 ciphers are already in IANA format.
 var opensslToIANACipherMap = map[string]string{
@@ -616,4 +615,52 @@ func ConvertTLSVersion(version configv1.TLSProtocolVersion) uint16 {
 		// Default to TLS 1.2 for safety
 		return tls.VersionTLS12
 	}
+}
+
+// ConvertCipherSuites converts OpenShift cipher suite names (OpenSSL format) to crypto/tls uint16 constants.
+// TLS 1.3 cipher suites are managed automatically by Go and cannot be configured, so they are filtered out.
+// Only returns cipher suites applicable to TLS ≤ 1.2.
+func ConvertCipherSuites(cipherNames []string) []uint16 {
+	// Mapping from OpenSSL cipher names to crypto/tls constants
+	// Only includes cipher suites that exist in Go's crypto/tls package
+	cipherMap := map[string]uint16{
+		// TLS 1.2 ECDHE ciphers (GCM and ChaCha20)
+		"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+
+		// TLS 1.2 ECDHE ciphers (CBC)
+		"ECDHE-RSA-AES128-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-RSA-AES128-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-ECDSA-AES128-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-ECDSA-AES128-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-RSA-AES256-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-ECDSA-AES256-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+
+		// RSA ciphers
+		"AES128-GCM-SHA256": tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"AES256-GCM-SHA384": tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"AES128-SHA256":     tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"AES128-SHA":        tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"AES256-SHA":        tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"DES-CBC3-SHA":      tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+
+	var result []uint16
+	for _, name := range cipherNames {
+		// Skip TLS 1.3 cipher suites (they start with TLS_ prefix and are auto-managed)
+		if len(name) > 4 && name[:4] == "TLS_" {
+			continue
+		}
+
+		if cipher, ok := cipherMap[name]; ok {
+			result = append(result, cipher)
+		}
+		// Silently skip unsupported cipher suites - Go may not support all OpenSSL ciphers
+	}
+
+	return result
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -550,9 +550,16 @@ var opensslToIANACipherMap = map[string]string{
 // GetAPIServerTLSProfile retrieves the TLS security profile from the OpenShift APIServer resource.
 // Returns the TLSProfileSpec containing minTLSVersion and ciphers.
 // If no profile is set, returns the default Intermediate profile.
+// On non-OpenShift clusters, returns the default Intermediate profile.
 func GetAPIServerTLSProfile(ctx context.Context, cl client.Client) (*configv1.TLSProfileSpec, error) {
 	// If running in unit test mode, return default Intermediate profile
 	if val, ok := os.LookupEnv(UnitTestEnvVar); ok && val == "true" {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+	}
+
+	// On non-OpenShift clusters, APIServer resource doesn't exist
+	// Return default Intermediate profile
+	if !DeployOnOCP() {
 		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ package utils
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -12,18 +13,17 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
-
 	"os"
 
 	configv1 "github.com/openshift/api/config/v1"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -510,6 +510,7 @@ func ComponentCRDDirectories(component string) []string {
 	}
 }
 
+<<<<<<< HEAD
 // opensslToIANACipherMap maps OpenSSL cipher names to IANA cipher names.
 // TLS 1.3 ciphers are already in IANA format.
 var opensslToIANACipherMap = map[string]string{
@@ -548,10 +549,10 @@ var opensslToIANACipherMap = map[string]string{
 }
 
 // GetAPIServerTLSProfile retrieves the TLS security profile from the OpenShift APIServer resource.
-// Returns the TLSProfileSpec containing ciphers and minTLSVersion.
+// Returns the TLSProfileSpec containing minTLSVersion and ciphers.
 // If no profile is set, returns the default Intermediate profile.
 func GetAPIServerTLSProfile(ctx context.Context, cl client.Client) (*configv1.TLSProfileSpec, error) {
-	// If Unit test
+	// If running in unit test mode, return default Intermediate profile
 	if val, ok := os.LookupEnv(UnitTestEnvVar); ok && val == "true" {
 		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
 	}
@@ -597,4 +598,22 @@ func ConvertCipherSuitesToIANA(ciphers []string) ([]string, error) {
 	}
 
 	return ianaCiphers, nil
+}
+
+// ConvertTLSVersion converts OpenShift TLSProtocolVersion string to crypto/tls uint16 constant.
+// Returns tls.VersionTLS12 as default if the version string is not recognized.
+func ConvertTLSVersion(version configv1.TLSProtocolVersion) uint16 {
+	switch version {
+	case configv1.VersionTLS10:
+		return tls.VersionTLS10
+	case configv1.VersionTLS11:
+		return tls.VersionTLS11
+	case configv1.VersionTLS12:
+		return tls.VersionTLS12
+	case configv1.VersionTLS13:
+		return tls.VersionTLS13
+	default:
+		// Default to TLS 1.2 for safety
+		return tls.VersionTLS12
+	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,6 +19,7 @@ import (
 
 	"os"
 
+	configv1 "github.com/openshift/api/config/v1"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -507,4 +508,93 @@ func ComponentCRDDirectories(component string) []string {
 	default:
 		return []string{}
 	}
+}
+
+// opensslToIANACipherMap maps OpenSSL cipher names to IANA cipher names.
+// TLS 1.3 ciphers are already in IANA format.
+var opensslToIANACipherMap = map[string]string{
+	// TLS 1.3 ciphers (already IANA format)
+	"TLS_AES_128_GCM_SHA256":       "TLS_AES_128_GCM_SHA256",
+	"TLS_AES_256_GCM_SHA384":       "TLS_AES_256_GCM_SHA384",
+	"TLS_CHACHA20_POLY1305_SHA256": "TLS_CHACHA20_POLY1305_SHA256",
+
+	// TLS 1.2 and below ciphers (OpenSSL -> IANA)
+	"ECDHE-ECDSA-AES128-GCM-SHA256": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+	"ECDHE-RSA-AES128-GCM-SHA256":   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+	"ECDHE-ECDSA-AES256-GCM-SHA384": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+	"ECDHE-RSA-AES256-GCM-SHA384":   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+	"ECDHE-ECDSA-CHACHA20-POLY1305": "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+	"ECDHE-RSA-CHACHA20-POLY1305":   "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+	"DHE-RSA-AES128-GCM-SHA256":     "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+	"DHE-RSA-AES256-GCM-SHA384":     "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+	"DHE-RSA-CHACHA20-POLY1305":     "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+	"ECDHE-ECDSA-AES128-SHA256":     "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+	"ECDHE-RSA-AES128-SHA256":       "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+	"ECDHE-ECDSA-AES128-SHA":        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+	"ECDHE-RSA-AES128-SHA":          "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+	"ECDHE-ECDSA-AES256-SHA384":     "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+	"ECDHE-RSA-AES256-SHA384":       "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+	"ECDHE-ECDSA-AES256-SHA":        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+	"ECDHE-RSA-AES256-SHA":          "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+	"DHE-RSA-AES128-SHA256":         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+	"DHE-RSA-AES256-SHA256":         "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+	"AES128-GCM-SHA256":             "TLS_RSA_WITH_AES_128_GCM_SHA256",
+	"AES256-GCM-SHA384":             "TLS_RSA_WITH_AES_256_GCM_SHA384",
+	"AES128-SHA256":                 "TLS_RSA_WITH_AES_128_CBC_SHA256",
+	"AES256-SHA256":                 "TLS_RSA_WITH_AES_256_CBC_SHA256",
+	"AES128-SHA":                    "TLS_RSA_WITH_AES_128_CBC_SHA",
+	"AES256-SHA":                    "TLS_RSA_WITH_AES_256_CBC_SHA",
+	"DES-CBC3-SHA":                  "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+}
+
+// GetAPIServerTLSProfile retrieves the TLS security profile from the OpenShift APIServer resource.
+// Returns the TLSProfileSpec containing ciphers and minTLSVersion.
+// If no profile is set, returns the default Intermediate profile.
+func GetAPIServerTLSProfile(ctx context.Context, cl client.Client) (*configv1.TLSProfileSpec, error) {
+	// If Unit test
+	if val, ok := os.LookupEnv(UnitTestEnvVar); ok && val == "true" {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+	}
+
+	apiServer := &configv1.APIServer{}
+	err := cl.Get(ctx, types.NamespacedName{Name: "cluster"}, apiServer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get APIServer resource: %w", err)
+	}
+
+	// If no TLS profile is set, use the default (Intermediate)
+	if apiServer.Spec.TLSSecurityProfile == nil {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+	}
+
+	profile := apiServer.Spec.TLSSecurityProfile
+
+	// For predefined profiles (Old, Intermediate, Modern), use the map
+	if profileSpec, ok := configv1.TLSProfiles[profile.Type]; ok {
+		return profileSpec, nil
+	}
+
+	// For custom profile, return the inline spec
+	if profile.Type == configv1.TLSProfileCustomType && profile.Custom != nil {
+		return &profile.Custom.TLSProfileSpec, nil
+	}
+
+	// Fallback to Intermediate if something unexpected
+	return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+}
+
+// ConvertCipherSuitesToIANA converts cipher suite names from OpenSSL format to IANA format.
+// Returns an error if any cipher is not found in the lookup table.
+func ConvertCipherSuitesToIANA(ciphers []string) ([]string, error) {
+	ianaCiphers := make([]string, 0, len(ciphers))
+
+	for _, cipher := range ciphers {
+		ianaCipher, ok := opensslToIANACipherMap[cipher]
+		if !ok {
+			return nil, fmt.Errorf("unknown cipher suite: %s", cipher)
+		}
+		ianaCiphers = append(ianaCiphers, ianaCipher)
+	}
+
+	return ianaCiphers, nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1152,6 +1152,33 @@ func TestGetAPIServerTLSProfile_UnitTest(t *testing.T) {
 	}
 }
 
+func TestGetAPIServerTLSProfile_NonOCP(t *testing.T) {
+	// Save original platform setting
+	originalPlatform := DeployOnOCP()
+	defer SetDeployOnOCP(originalPlatform)
+
+	// Set to non-OCP
+	SetDeployOnOCP(false)
+
+	ctx := context.Background()
+	got, err := GetAPIServerTLSProfile(ctx, nil)
+	if err != nil {
+		t.Errorf("GetAPIServerTLSProfile() on non-OCP cluster returned error: %v", err)
+		return
+	}
+
+	// On non-OCP clusters, should return default Intermediate profile
+	if got.MinTLSVersion != "VersionTLS12" {
+		t.Errorf("GetAPIServerTLSProfile() MinTLSVersion = %v, want VersionTLS12", got.MinTLSVersion)
+	}
+
+	// Check it has the expected number of ciphers for Intermediate profile
+	expectedCipherCount := 11
+	if len(got.Ciphers) != expectedCipherCount {
+		t.Errorf("GetAPIServerTLSProfile() returned %d ciphers, want %d for Intermediate profile", len(got.Ciphers), expectedCipherCount)
+	}
+}
+
 func TestConvertTLSVersion(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -1009,5 +1010,142 @@ func TestGetServingCertCABundle_NilGlobalGetter(t *testing.T) {
 	expectedErr := "GlobalServingCertCABundleGetter is nil"
 	if err.Error() != expectedErr {
 		t.Errorf("GetServingCertCABundle() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestConvertCipherSuitesToIANA(t *testing.T) {
+	tests := []struct {
+		name        string
+		ciphers     []string
+		want        []string
+		expectError bool
+	}{
+		{
+			name: "TLS 1.3 ciphers (already IANA format)",
+			ciphers: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+			},
+			want: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+			},
+			expectError: false,
+		},
+		{
+			name: "TLS 1.2 OpenSSL ciphers",
+			ciphers: []string{
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"ECDHE-ECDSA-AES256-GCM-SHA384",
+				"DHE-RSA-AES128-GCM-SHA256",
+			},
+			want: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+				"TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+			},
+			expectError: false,
+		},
+		{
+			name: "Mixed TLS 1.3 and 1.2 ciphers (Intermediate profile)",
+			ciphers: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+				"ECDHE-ECDSA-AES128-GCM-SHA256",
+				"ECDHE-RSA-AES128-GCM-SHA256",
+			},
+			want: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			},
+			expectError: false,
+		},
+		{
+			name: "Old profile ciphers with DES",
+			ciphers: []string{
+				"AES128-SHA",
+				"AES256-SHA",
+				"DES-CBC3-SHA",
+			},
+			want: []string{
+				"TLS_RSA_WITH_AES_128_CBC_SHA",
+				"TLS_RSA_WITH_AES_256_CBC_SHA",
+				"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+			},
+			expectError: false,
+		},
+		{
+			name: "Unknown cipher should error",
+			ciphers: []string{
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"UNKNOWN-CIPHER-SUITE",
+			},
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "Empty cipher list",
+			ciphers:     []string{},
+			want:        []string{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertCipherSuitesToIANA(tt.ciphers)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("ConvertCipherSuitesToIANA() expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ConvertCipherSuitesToIANA() unexpected error: %v", err)
+				return
+			}
+
+			if len(got) != len(tt.want) {
+				t.Errorf("ConvertCipherSuitesToIANA() returned %d ciphers, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ConvertCipherSuitesToIANA()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetAPIServerTLSProfile_UnitTest(t *testing.T) {
+	// Set unit test mode
+	os.Setenv("UNIT_TEST", "true")
+	defer os.Unsetenv("UNIT_TEST")
+
+	ctx := context.Background()
+	got, err := GetAPIServerTLSProfile(ctx, nil)
+	if err != nil {
+		t.Errorf("GetAPIServerTLSProfile() in unit test mode returned error: %v", err)
+		return
+	}
+
+	// In unit test mode, should return Intermediate profile
+	if got.MinTLSVersion != "VersionTLS12" {
+		t.Errorf("GetAPIServerTLSProfile() MinTLSVersion = %v, want VersionTLS12", got.MinTLSVersion)
+	}
+
+	// Check it has the expected number of ciphers for Intermediate profile
+	expectedCipherCount := 11
+	if len(got.Ciphers) != expectedCipherCount {
+		t.Errorf("GetAPIServerTLSProfile() returned %d ciphers, want %d for Intermediate profile", len(got.Ciphers), expectedCipherCount)
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -4,10 +4,12 @@ package utils
 
 import (
 	"context"
+	"crypto/tls"
 	"os"
 	"strings"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1147,5 +1149,128 @@ func TestGetAPIServerTLSProfile_UnitTest(t *testing.T) {
 	expectedCipherCount := 11
 	if len(got.Ciphers) != expectedCipherCount {
 		t.Errorf("GetAPIServerTLSProfile() returned %d ciphers, want %d for Intermediate profile", len(got.Ciphers), expectedCipherCount)
+	}
+}
+
+func TestConvertTLSVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version configv1.TLSProtocolVersion
+		want    uint16
+	}{
+		{
+			name:    "TLS 1.0",
+			version: configv1.VersionTLS10,
+			want:    tls.VersionTLS10,
+		},
+		{
+			name:    "TLS 1.1",
+			version: configv1.VersionTLS11,
+			want:    tls.VersionTLS11,
+		},
+		{
+			name:    "TLS 1.2",
+			version: configv1.VersionTLS12,
+			want:    tls.VersionTLS12,
+		},
+		{
+			name:    "TLS 1.3",
+			version: configv1.VersionTLS13,
+			want:    tls.VersionTLS13,
+		},
+		{
+			name:    "Unknown version defaults to TLS 1.2",
+			version: configv1.TLSProtocolVersion("VersionTLS99"),
+			want:    tls.VersionTLS12,
+		},
+		{
+			name:    "Empty version defaults to TLS 1.2",
+			version: "",
+			want:    tls.VersionTLS12,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertTLSVersion(tt.version)
+			if got != tt.want {
+				t.Errorf("ConvertTLSVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertCipherSuites(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []string
+		want   []uint16
+		wantOk bool
+	}{
+		{
+			name:   "TLS 1.2 ECDHE-RSA ciphers",
+			input:  []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+			wantOk: true,
+		},
+		{
+			name:   "TLS 1.2 ECDHE-ECDSA ciphers",
+			input:  []string{"ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-CHACHA20-POLY1305"},
+			want:   []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256},
+			wantOk: true,
+		},
+		{
+			name:   "TLS 1.3 ciphers are filtered out",
+			input:  []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "ECDHE-RSA-AES128-GCM-SHA256"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantOk: true,
+		},
+		{
+			name:   "All TLS 1.3 ciphers filtered",
+			input:  []string{"TLS_AES_128_GCM_SHA256", "TLS_CHACHA20_POLY1305_SHA256"},
+			want:   []uint16{},
+			wantOk: true,
+		},
+		{
+			name:   "Unknown cipher ignored",
+			input:  []string{"UNKNOWN-CIPHER", "ECDHE-RSA-AES128-GCM-SHA256"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantOk: true,
+		},
+		{
+			name:   "Empty input",
+			input:  []string{},
+			want:   []uint16{},
+			wantOk: true,
+		},
+		{
+			name:   "CBC ciphers",
+			input:  []string{"ECDHE-RSA-AES128-SHA256", "AES128-SHA"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_AES_128_CBC_SHA},
+			wantOk: true,
+		},
+		{
+			name:   "DHE ciphers not supported (ignored)",
+			input:  []string{"DHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantOk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertCipherSuites(tt.input)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("ConvertCipherSuites() returned %d ciphers, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ConvertCipherSuites()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Removes hardcoded TLS 1.2 from webhook server. Fetches TLS profile dynamically from OpenShift APIServer resource. Defaults to Intermediate if not set.

Related: ACM-30181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook server now derives TLS settings from the cluster API server profile with a TLS 1.2+ fallback and conditional cipher application.
  * Operator ensures per-namespace TLS-profile ConfigMaps for workloads to consume resolved TLS settings.

* **Refactor**
  * RBAC expanded to grant read access to APIServer resources for TLS/profile discovery.

* **Tests**
  * Added unit tests for TLS profile resolution and cipher conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->