### PR TITLE
Fix probeConfig template checks to use hasKey

### DIFF
--- a/pkg/templates/charts/toggle/cluster-permission/templates/cluster-permission.yaml
+++ b/pkg/templates/charts/toggle/cluster-permission/templates/cluster-permission.yaml
@@ -57,16 +57,14 @@ spec:
             - ls
           initialDelaySeconds: 15
           periodSeconds: 15
-{{- if .Values.hubconfig.probeConfig }}
-{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}
+{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}
           timeoutSeconds: {{ .Values.hubconfig.probeConfig.timeoutSeconds }}
 {{- end }}
-{{- if .Values.hubconfig.probeConfig.failureThreshold }}
+{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "failureThreshold") }}
           failureThreshold: {{ .Values.hubconfig.probeConfig.failureThreshold }}
 {{- end }}
-{{- if .Values.hubconfig.probeConfig.successThreshold }}
+{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "successThreshold") }}
           successThreshold: {{ .Values.hubconfig.probeConfig.successThreshold }}
-{{- end }}
 {{- end }}
         name: cluster-permission
         readinessProbe:
@@ -75,16 +73,14 @@ spec:
             - ls
           initialDelaySeconds: 15
           periodSeconds: 15
-{{- if .Values.hubconfig.probeConfig }}
-{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}
+{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}
           timeoutSeconds: {{ .Values.hubconfig.probeConfig.timeoutSeconds }}
 {{- end }}
-{{- if .Values.hubconfig.probeConfig.failureThreshold }}
+{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "failureThreshold") }}
           failureThreshold: {{ .Values.hubconfig.probeConfig.failureThreshold }}
 {{- end }}
-{{- if .Values.hubconfig.probeConfig.successThreshold }}
+{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "successThreshold") }}
           successThreshold: {{ .Values.hubconfig.probeConfig.successThreshold }}
-{{- end }}
 {{- end }}
         resources:
           requests:


### PR DESCRIPTION
# Description

Fixes cluster-permission template to use hasKey checks for probeConfig fields, preventing "map has no entry for key" errors when probeConfig has partial fields set.

## Related Issue

Follows same pattern as multiclusterhub-operator and installer-dev-tools fixes (PRs #145, #146).

## Changes Made

**cluster-permission.yaml:**
- Replace nested if statements with single hasKey checks
- Remove redundant outer `{{- if .Values.hubconfig.probeConfig }}` wrappers
- Add hasKey checks for timeoutSeconds, failureThreshold, successThreshold
- Applies to both livenessProbe and readinessProbe sections

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This prevents template rendering failures when users set only one probeConfig field (e.g., timeoutSeconds) without setting the others.

Example failure scenario:
```yaml
hubconfig:
  probeConfig:
    timeoutSeconds: 30
```

Old template would fail evaluating `.Values.hubconfig.probeConfig.failureThreshold` because the key doesn't exist.

New template checks `hasKey` before accessing, preventing the error.

## Reviewers

/cc @cameronmwall @ngraham20 @dislbenn

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.