### PR TITLE
Add POD_NAMESPACE env var to cluster-proxy deployments and update assisted-service branch

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -23,7 +23,7 @@ components:
       - config/webhook/manifests.yaml
     repo_name: image-based-install-operator
 
-  - branch: release-ocm-5.0
+  - branch: backplane-5.0
     github_ref: https://github.com/openshift/assisted-service.git
     operators:
     - bundlePath: deploy/olm-catalog/manifests/

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
@@ -74,6 +74,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           {{- if .Values.hubconfig.proxyConfigs }}
           - name: HTTP_PROXY
             value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml
@@ -75,13 +75,17 @@ spec:
           - "--signer-secret-namespace={{ .Values.global.namespace }}"
           - "--agent-image={{ .Values.global.imageOverrides.cluster_proxy }}"
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         {{- if .Values.hubconfig.proxyConfigs }}
-          - name: HTTP_PROXY
-            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
-          - name: NO_PROXY
-            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -109,6 +113,10 @@ spec:
           - "--service-proxy-ca-cert=/proxy-ca/ca.crt" # service-proxy is also sign by the singer ca of cluster-proxy. So here we use the same CA cert.
           - "--agent-install-namespace=open-cluster-management-agent-addon"
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         {{- if .Values.hubconfig.proxyConfigs }}
         - name: HTTP_PROXY
           value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}


### PR DESCRIPTION
## Summary
- Add POD_NAMESPACE environment variable to cluster-proxy manager and user deployment containers using downward API
- Update assisted-service branch from release-ocm-5.0 to backplane-5.0 in bundle automation config

## Changes
- **manager-deployment.yaml**: Add POD_NAMESPACE env var to manager container
- **user-deployment.yaml**: Add POD_NAMESPACE env var to controllers and user-server containers
- **config.yaml**: Update assisted-service branch reference

## Test plan
- [ ] Verify deployments have POD_NAMESPACE env var populated correctly
- [ ] Verify bundle automation uses correct branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Configuration Updates**
  * Enhanced cluster-proxy-addon deployment templates to provide namespace information to containers for improved operational context.
  * Updated assisted-service component configuration source branch.
  * Improved deployment template formatting and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->