### PR TITLE
Add cluster-proxy to charts-config.yaml

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -39,6 +39,7 @@ const (
 	ClusterManager                   = "cluster-manager"
 	ClusterPermission                = "cluster-permission"
 	ClusterProxyAddon                = "cluster-proxy-addon"
+	ClusterProxy                     = "cluster-proxy"
 	ConsoleMCE                       = "console-mce"
 	Discovery                        = "discovery"
 	Hive                             = "hive"
@@ -68,7 +69,8 @@ const (
 	ClusterLifecycleCRDDir           = "cluster-lifecycle"
 	ClusterManagerCRDDir             = "cluster-manager"
 	ClusterPermissionCRDDir          = "cluster-permission"
-	ClusterProxyAddonCRDDir          = "cluster-proxy-addon"
+	ClusterProxyAddonCRDDir          = "cluster-proxy-addon" // Deprecated: Moved to ClusterProxy in MCE 2.11
+	ClusterProxyCRDDir               = "cluster-proxy"
 	DiscoveryCRDDir                  = "discovery-operator"
 	HiveCRDDir                       = "hive-operator"
 	ImageBasedInstallOperatorCRDDir  = "image-based-install-operator"

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1285,26 +1285,29 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 		log.Info(messages.SkippingExternallyManaged, "component", backplanev1.ServerFoundation)
 	}
 
-	if !r.isComponentExternallyManaged(backplaneConfig, backplanev1.ClusterProxyAddon) {
-		if backplaneConfig.Enabled(backplanev1.ClusterProxyAddon) && foundation.CanInstallAddons(ctx, r.Client) {
-			result, err = r.ensureClusterProxyAddon(ctx, backplaneConfig)
+	// Handle ClusterProxyAddon (deprecated) and ClusterProxy - both use same chart
+	if !r.isComponentExternallyManaged(backplaneConfig, backplanev1.ClusterProxyAddon) ||
+		!r.isComponentExternallyManaged(backplaneConfig, backplanev1.ClusterProxy) {
+		if (backplaneConfig.Enabled(backplanev1.ClusterProxyAddon) || backplaneConfig.Enabled(backplanev1.ClusterProxy)) &&
+			foundation.CanInstallAddons(ctx, r.Client) {
+			result, err = r.ensureClusterProxy(ctx, backplaneConfig)
 			if result != (ctrl.Result{}) {
 				requeue = true
 			}
 			if err != nil {
-				errs[backplanev1.ClusterProxyAddon] = err
+				errs[backplanev1.ClusterProxy] = err
 			}
 		} else {
-			result, err = r.ensureNoClusterProxyAddon(ctx, backplaneConfig)
+			result, err = r.ensureNoClusterProxy(ctx, backplaneConfig)
 			if result != (ctrl.Result{}) {
 				requeue = true
 			}
 			if err != nil {
-				errs[backplanev1.ClusterProxyAddon] = err
+				errs[backplanev1.ClusterProxy] = err
 			}
 		}
 	} else {
-		log.Info(messages.SkippingExternallyManaged, "component", backplanev1.ClusterProxyAddon)
+		log.Info(messages.SkippingExternallyManaged, "component", backplanev1.ClusterProxy)
 	}
 
 	if !r.isComponentExternallyManaged(backplaneConfig, backplanev1.ClusterAPI) {

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -1003,6 +1003,7 @@ func (r *MultiClusterEngineReconciler) fetchChartOrCRDPath(component string) str
 		backplanev1.ClusterManager:                 toggle.ClusterManagerChartDir,
 		backplanev1.ClusterPermission:              toggle.ClusterPermissionChartDir,
 		backplanev1.ClusterProxyAddon:              toggle.ClusterProxyAddonDir,
+		backplanev1.ClusterProxy:                   toggle.ClusterProxyDir,
 		backplanev1.ConsoleMCE:                     toggle.ConsoleMCEChartsDir,
 		backplanev1.Discovery:                      toggle.DiscoveryChartDir,
 		backplanev1.Hive:                           toggle.HiveChartDir,

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -1686,7 +1686,7 @@ func (r *MultiClusterEngineReconciler) removeHypershiftLocalHosting(ctx context.
 	return ctrl.Result{}, nil
 }
 
-func (r *MultiClusterEngineReconciler) ensureClusterProxyAddon(ctx context.Context,
+func (r *MultiClusterEngineReconciler) ensureClusterProxy(ctx context.Context,
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 
 	namespacedName := types.NamespacedName{Name: "cluster-proxy-addon-manager", Namespace: mce.Spec.TargetNamespace}
@@ -1700,12 +1700,12 @@ func (r *MultiClusterEngineReconciler) ensureClusterProxyAddon(ctx context.Conte
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 
 	// Ensure that the InternalHubComponent CR instance is created for component in MCE.
-	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.ClusterProxyAddon); err != nil {
+	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.ClusterProxy); err != nil {
 		return result, err
 	}
 
 	// Renders all templates from charts
-	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterProxyAddon)
+	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterProxy)
 	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
 
 	if len(errs) > 0 {
@@ -1716,7 +1716,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterProxyAddon(ctx context.Conte
 	}
 
 	// Apply deployment config overrides
-	if result, err := r.applyComponentDeploymentOverrides(mce, templates, backplanev1.ClusterProxyAddon); err != nil {
+	if result, err := r.applyComponentDeploymentOverrides(mce, templates, backplanev1.ClusterProxy); err != nil {
 		return result, err
 	}
 
@@ -1741,7 +1741,7 @@ func (r *MultiClusterEngineReconciler) ensureClusterProxyAddon(ctx context.Conte
 	return ctrl.Result{}, nil
 }
 
-func (r *MultiClusterEngineReconciler) ensureNoClusterProxyAddon(ctx context.Context,
+func (r *MultiClusterEngineReconciler) ensureNoClusterProxy(ctx context.Context,
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 
 	namespacedName := types.NamespacedName{Name: "cluster-proxy-addon-manager", Namespace: mce.Spec.TargetNamespace}
@@ -1756,12 +1756,12 @@ func (r *MultiClusterEngineReconciler) ensureNoClusterProxyAddon(ctx context.Con
 
 	// Ensure that the InternalHubComponent CR instance is deleted for component in MCE.
 	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
-		backplanev1.ClusterProxyAddon); (result != ctrl.Result{}) || err != nil {
+		backplanev1.ClusterProxy); (result != ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
 	// Renders all templates from charts
-	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterProxyAddon)
+	chartPath := r.fetchChartOrCRDPath(backplanev1.ClusterProxy)
 	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
 
 	if len(errs) > 0 {

--- a/hack/bundle-automation/chart-values/cluster-proxy/overwriteValues.yaml
+++ b/hack/bundle-automation/chart-values/cluster-proxy/overwriteValues.yaml
@@ -1,0 +1,16 @@
+# Enable service proxy to generate user-deployment and user-service
+enableServiceProxy: true
+
+# Number of replicas
+replicas: 1
+
+# Image registry
+registry: quay.io/open-cluster-management
+image: cluster-proxy
+tag:
+
+# Enable kube-api-proxy
+enableKubeApiProxy: true
+
+# Enable impersonation
+enableImpersonation: true

--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -161,3 +161,17 @@ components:
           - "CLUSTER_NAME"
           - "HUB_KUBECONFIG"
           - "INSTALL_NAMESPACE"
+
+  - repo_name: "cluster-proxy"
+    github_ref: "https://github.com/stolostron/cluster-proxy.git"
+    branch: "backplane-5.0"
+    charts:
+      - name: "cluster-proxy"
+        chart-path: "charts/cluster-proxy"
+        always-or-toggle: "toggle"
+        imageMappings:
+          cluster-proxy: cluster_proxy
+        inclusions:
+          - "pullSecretOverride"
+        skipRBACOverrides: true
+        updateChartVersion: true # the chart version will be retrieved from trimmed branch name, e.g. backplane-2.6 -> 2.6

--- a/pkg/templates/charts/toggle/cluster-proxy/Chart.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.1.0
+description: A Helm chart for Cluster-Proxy OCM Addon
+name: cluster-proxy
+type: application
+version: '5.0'

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-addon-manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-addon-manager-deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: cluster-proxy-manager
+  name: cluster-proxy-addon-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: cluster-proxy-manager
+      open-cluster-management.io/addon: cluster-proxy
+  template:
+    metadata:
+      labels:
+        component: cluster-proxy-manager
+        ocm-antiaffinity-selector: cluster-proxy-addon-manager
+        open-cluster-management.io/addon: cluster-proxy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - cluster-proxy-addon-manager
+              topologyKey: topology.kubernetes.io/zone
+            weight: 70
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - cluster-proxy-addon-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 35
+      containers:
+      - args:
+        - --leader-elect=true
+        - --signer-secret-namespace={{ .Values.global.namespace }}
+        - --enable-kube-api-proxy=true
+        - --enable-service-proxy=false
+        - --image-pull-policy=IfNotPresent
+        - --feature-gates=ClusterProfile=false
+        command:
+        - /manager
+        env:
+{{- if .Values.global.pullSecret }}
+        - name: AGENT_IMAGE_PULL_SECRET
+          value: {{ .Values.global.pullSecret }}
+{{- end }}
+{{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+{{- end }}
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: '{{ .Values.global.imageOverrides.cluster_proxy }}'
+        imagePullPolicy: '{{ .Values.global.pullPolicy }}'
+        name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+{{- if .Values.global.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.global.pullSecret }}
+{{- end }}
+{{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      securityContext:
+        runAsNonRoot: true
+{{- if .Values.global.deployOnOCP }}
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
+{{- end }}
+      serviceAccount: cluster-proxy
+{{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+        {{- end }}
+{{- end }}

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-addon-user-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-addon-user-deployment.yaml
@@ -2,19 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    component: cluster-proxy-manager
-  name: cluster-proxy-addon-manager
+    component: cluster-proxy-addon-user
+  name: cluster-proxy-addon-user
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: cluster-proxy-manager
+      component: cluster-proxy-addon-user
       open-cluster-management.io/addon: cluster-proxy
   template:
     metadata:
       labels:
-        component: cluster-proxy-manager
-        ocm-antiaffinity-selector: cluster-proxy-addon-manager
+        component: cluster-proxy-addon-user
+        ocm-antiaffinity-selector: cluster-proxy-addon-user
         open-cluster-management.io/addon: cluster-proxy
     spec:
       affinity:
@@ -26,7 +26,7 @@ spec:
                 - key: ocm-antiaffinity-selector
                   operator: In
                   values:
-                  - cluster-proxy-addon-manager
+                  - cluster-proxy-addon-user
               topologyKey: topology.kubernetes.io/zone
             weight: 70
           - podAffinityTerm:
@@ -35,19 +35,55 @@ spec:
                 - key: ocm-antiaffinity-selector
                   operator: In
                   values:
-                  - cluster-proxy-addon-manager
+                  - cluster-proxy-addon-user
               topologyKey: kubernetes.io/hostname
             weight: 35
       containers:
       - args:
-        - --leader-elect=true
+        - controllers
+        - --certificates-namespace={{ .Values.global.namespace }}
         - --signer-secret-namespace={{ .Values.global.namespace }}
-        - --enable-kube-api-proxy=true
-        - --enable-service-proxy=true
-        - --image-pull-policy=IfNotPresent
-        - --feature-gates=ClusterProfile=false
+        - --agent-image=quay.io/open-cluster-management/cluster-proxy:v5.0
         command:
-        - /manager
+        - /cluster-proxy
+        env:
+{{- if .Values.global.pullSecret }}
+        - name: AGENT_IMAGE_PULL_SECRET
+          value: {{ .Values.global.pullSecret }}
+{{- end }}
+{{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+{{- end }}
+        image: '{{ .Values.global.imageOverrides.cluster_proxy }}'
+        imagePullPolicy: '{{ .Values.global.pullPolicy }}'
+        name: controllers
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+      - args:
+        - user-server
+        - --host=proxy-entrypoint.{{ .Values.global.namespace }}.svc
+        - --port=8090
+        - --proxy-ca-cert=/proxy-ca/ca.crt
+        - --proxy-cert=/proxy-client-tls/tls.crt
+        - --proxy-key=/proxy-client-tls/tls.key
+        - --server-port=9092
+        - --server-key=/user-tls/tls.key
+        - --server-cert=/user-tls/tls.crt
+        - --service-proxy-ca-cert=/proxy-ca/ca.crt
+        - --agent-install-namespace=open-cluster-management-agent-addon
+        command:
+        - /cluster-proxy
         env:
 {{- if .Values.global.pullSecret }}
         - name: AGENT_IMAGE_PULL_SECRET
@@ -67,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         image: '{{ .Values.global.imageOverrides.cluster_proxy }}'
         imagePullPolicy: '{{ .Values.global.pullPolicy }}'
-        name: manager
+        name: user-server
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -76,6 +112,16 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /user-tls
+          name: user-tls-vol
+          readOnly: true
+        - mountPath: /proxy-ca
+          name: proxy-server-ca
+          readOnly: true
+        - mountPath: /proxy-client-tls
+          name: proxy-client-cert
+          readOnly: true
       hostIPC: false
       hostNetwork: false
       hostPID: false
@@ -106,3 +152,13 @@ spec:
         {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
         {{- end }}
 {{- end }}
+      volumes:
+      - name: user-tls-vol
+        secret:
+          secretName: cluster-proxy-user-serving-cert
+      - name: proxy-server-ca
+        secret:
+          secretName: proxy-server-ca
+      - name: proxy-client-cert
+        secret:
+          secretName: proxy-client

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-addon-user-service.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-addon-user-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: cluster-proxy-addon-user
+  name: cluster-proxy-addon-user
+  namespace: '{{ .Values.global.namespace }}'
+spec:
+  ports:
+  - name: https
+    port: 9092
+    protocol: TCP
+    targetPort: 9092
+  selector:
+    component: cluster-proxy-addon-user
+    open-cluster-management.io/addon: cluster-proxy
+  type: ClusterIP

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-clustermanagementaddon.yaml
@@ -1,0 +1,22 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  annotations:
+    addon.open-cluster-management.io/lifecycle: addon-manager
+  name: cluster-proxy
+spec:
+  addOnMeta:
+    description: cluster-proxy
+    displayName: cluster-proxy
+  installStrategy:
+    placements:
+    - name: cluster-proxy-placement
+      namespace: '{{ .Values.global.namespace }}'
+    type: Placements
+  supportedConfigs:
+  - defaultConfig:
+      name: cluster-proxy
+    group: proxy.open-cluster-management.io
+    resource: managedproxyconfigurations
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-managedproxyconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-managedproxyconfiguration.yaml
@@ -1,0 +1,22 @@
+
+# Source: cluster-proxy/templates/managedproxyconfiguration.yaml
+apiVersion: proxy.open-cluster-management.io/v1alpha1
+kind: ManagedProxyConfiguration
+metadata:
+  name: cluster-proxy
+spec:
+  authentication:
+    dump:
+      secrets: {}
+    signer:
+      type: SelfSigned
+  proxyServer:
+    image: quay.io/open-cluster-management/cluster-proxy:v5.0
+    replicas: 1
+    namespace: PLACEHOLDER_NAMESPACE
+    entrypoint:
+      type: PortForward
+      port: 8091
+  proxyAgent:
+    image: quay.io/open-cluster-management/cluster-proxy:v5.0
+    replicas: 1

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-placement-placement.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-placement-placement.yaml
@@ -1,0 +1,8 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: cluster-proxy-placement
+  namespace: '{{ .Values.global.namespace }}'
+spec:
+  clusterSets:
+  - global

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-serviceaccount.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/cluster-proxy-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-proxy

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/global-managedclustersetbinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/global-managedclustersetbinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: '{{ .Values.global.namespace }}'
+spec:
+  clusterSet: global

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/open-cluster-management:cluster-proxy:addon-manager-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/open-cluster-management:cluster-proxy:addon-manager-clusterrole.yaml
@@ -1,0 +1,194 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:cluster-proxy:addon-manager
+rules:
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  - managedclustersets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - clustermanagementaddons
+  - managedclusteraddons
+  - clustermanagementaddons/status
+  - clustermanagementaddons/finalizers
+  - managedclusteraddons/status
+  verbs:
+  - '*'
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - addondeploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - proxy.open-cluster-management.io
+  resources:
+  - managedproxyconfigurations
+  - managedproxyconfigurations/status
+  - managedproxyconfigurations/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  - certificatesigningrequests/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - open-cluster-management.io/proxy-agent-signer
+  - kubernetes.io/kube-apiserver-client
+  resources:
+  - signers
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  - secrets
+  - pods
+  - pods/portforward
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - manifestworks
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - imageregistry.open-cluster-management.io
+  resources:
+  - managedclusterimageregistries
+  - managedclusterimageregistries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - clusterprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - clusterprofiles/status
+  verbs:
+  - update
+  - patch

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/open-cluster-management:cluster-proxy:addon-manager-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/open-cluster-management:cluster-proxy:addon-manager-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: open-cluster-management:cluster-proxy:addon-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:cluster-proxy:addon-manager
+subjects:
+- kind: ServiceAccount
+  name: cluster-proxy
+  namespace: '{{ .Values.global.namespace }}'

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/open-cluster-management:cluster-proxy:addon-manager-role.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/open-cluster-management:cluster-proxy:addon-manager-role.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: open-cluster-management:cluster-proxy:addon-manager
+  namespace: '{{ .Values.global.namespace }}'
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - events
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+  - patch

--- a/pkg/templates/charts/toggle/cluster-proxy/templates/open-cluster-management:cluster-proxy:addon-manager-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/templates/open-cluster-management:cluster-proxy:addon-manager-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: open-cluster-management:cluster-proxy:addon-manager
+  namespace: '{{ .Values.global.namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: open-cluster-management:cluster-proxy:addon-manager
+subjects:
+- kind: ServiceAccount
+  name: cluster-proxy
+  namespace: '{{ .Values.global.namespace }}'

--- a/pkg/templates/charts/toggle/cluster-proxy/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy/values.yaml
@@ -1,0 +1,15 @@
+global:
+  deployOnOCP: true
+  imageOverrides:
+    cluster_proxy: ''
+  namespace: default
+  pullSecret: null
+  templateOverrides: {}
+hubconfig:
+  nodeSelector: null
+  ocpVersion: 4.12.0
+  probeConfig: null
+  proxyConfigs: {}
+  replicaCount: 1
+  tolerations: []
+org: open-cluster-management

--- a/pkg/templates/crds/cluster-proxy/managedproxyconfigurations.yaml
+++ b/pkg/templates/crds/cluster-proxy/managedproxyconfigurations.yaml
@@ -1,0 +1,412 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: managedproxyconfigurations.proxy.open-cluster-management.io
+spec:
+  group: proxy.open-cluster-management.io
+  names:
+    kind: ManagedProxyConfiguration
+    listKind: ManagedProxyConfigurationList
+    plural: managedproxyconfigurations
+    singular: managedproxyconfiguration
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedProxyConfiguration is the Schema for the managedproxyconfigurations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedProxyConfigurationSpec is the prescription of ManagedProxyConfiguration
+            properties:
+              authentication:
+                description: |-
+                  `authentication` defines how the credentials for the authentication
+                  between proxy servers and proxy agents are signed and mounted.
+                properties:
+                  dump:
+                    description: '`dump` is where we store the signed certificates
+                      from signers.'
+                    properties:
+                      secrets:
+                        description: '`secrets` is the names of the secrets for saving
+                          the signed certificates.'
+                        properties:
+                          signingAgentServerSecretName:
+                            default: agent-server
+                            description: |-
+                              `signingAgentServerSecretName` is the secret name of the proxy servers to receive
+                              tunneling handshakes from proxy agents.
+                            type: string
+                          signingProxyClientSecretName:
+                            default: proxy-client
+                            description: |-
+                              `signingProxyClientSecretName` is the secret name for requesting/streaming over
+                              the proxy server.
+                            type: string
+                          signingProxyServerSecretName:
+                            default: proxy-server
+                            description: |-
+                              `signingProxyServerSecretName` the secret name of the proxy server's listening
+                              certificates for serving proxy requests.
+                            type: string
+                        type: object
+                    type: object
+                  signer:
+                    description: |-
+                      `signer` defines how we sign server and client certificates for the proxy servers
+                      and agents.
+                    properties:
+                      selfSigned:
+                        description: '`selfSigned` prescribes the detail of how we
+                          self-sign the certificates.'
+                        properties:
+                          additionalSANs:
+                            description: '`additionalSANs` adds a few custom hostnames
+                              or IPs to the signing certificates.'
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type:
+                        default: SelfSigned
+                        description: '`type` is the supported type of signer. Currently
+                          only "SelfSign" supported.'
+                        enum:
+                        - SelfSigned
+                        - Provided
+                        - CertManager
+                        type: string
+                    type: object
+                type: object
+              deploy:
+                description: |-
+                  `deploy` is where we override miscellaneous details for deploying either
+                  proxy servers or agents.
+                properties:
+                  ports:
+                    description: '`ports` is the ports for proxying and tunneling.'
+                    properties:
+                      adminServer:
+                        default: 8095
+                        description: '`adminServer` is the port for debugging and
+                          operating.'
+                        format: int32
+                        type: integer
+                      agentServer:
+                        default: 8091
+                        description: '`agentServer` is the listening port of proxy
+                          server for serving tunneling handshakes.'
+                        format: int32
+                        type: integer
+                      healthServer:
+                        default: 8092
+                        description: '`healthServer` is for probing the healthiness.'
+                        format: int32
+                        type: integer
+                      proxyServer:
+                        default: 8090
+                        description: '`proxyServer` is the listening port of proxy
+                          server for serving proxy requests.'
+                        format: int32
+                        type: integer
+                    type: object
+                required:
+                - ports
+                type: object
+              proxyAgent:
+                description: '`proxyServer` structurelized the arguments for running
+                  proxy agents.'
+                properties:
+                  additionalArgs:
+                    description: '`additionalArgs` defines args used in proxy-agent.'
+                    items:
+                      type: string
+                    type: array
+                  additionalServiceCAConfigMap:
+                    description: |-
+                      `additionalServiceCAConfigMap` is the name of a ConfigMap in the managed cluster
+                      that contains additional CA certificates for services.
+                      The ConfigMap should contain a key named "service-ca.crt".
+                    type: string
+                  image:
+                    description: '`image` is the container image of the proxy agent.'
+                    type: string
+                  imagePullSecrets:
+                    description: '`imagePullSecrets` defines the imagePullSecrets
+                      used by proxy-agent'
+                    items:
+                      type: string
+                    type: array
+                  replicas:
+                    default: 3
+                    description: '`replicas` is the replicas of the agents.'
+                    format: int32
+                    type: integer
+                required:
+                - image
+                type: object
+              proxyServer:
+                description: '`proxyServer` structurelized the arguments for running
+                  proxy servers.'
+                properties:
+                  additionalArgs:
+                    description: '`additionalArgs` adds arbitrary additional command
+                      line args to the proxy-server.'
+                    items:
+                      type: string
+                    type: array
+                  entrypoint:
+                    description: '`entrypoint` defines how will the proxy agents connecting
+                      the servers.'
+                    properties:
+                      hostname:
+                        description: '`hostname` points to a fixed hostname for serving
+                          agents'' handshakes.'
+                        properties:
+                          value:
+                            type: string
+                        required:
+                        - value
+                        type: object
+                      loadBalancerService:
+                        description: '`loadBalancerService` points to a load-balancer
+                          typed service in the hub cluster.'
+                        properties:
+                          annotations:
+                            description: |-
+                              Annotations is the annoations of the load-balancer service.
+                              This is for allowing customizing service using vendor-specific extended annotations such as:
+                              - service.beta.kubernetes.io/alibaba-cloud-loadbalancer-address-type: "intranet"
+                              - service.beta.kubernetes.io/azure-load-balancer-internal: true
+                            items:
+                              description: AnnotationVar list of annotation variables
+                                to set in the LB Service.
+                              properties:
+                                key:
+                                  description: Key is the key of annotation
+                                  type: string
+                                value:
+                                  description: Value is the value of annotation
+                                  type: string
+                              required:
+                              - key
+                              type: object
+                            type: array
+                          name:
+                            default: proxy-agent-entrypoint
+                            description: |-
+                              `name` is the name of the load-balancer service. And the namespace will align
+                              to where the proxy-servers are deployed.
+                            type: string
+                        type: object
+                      port:
+                        default: 8091
+                        description: '`port` is the target port to access proxy servers'
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      type:
+                        description: |-
+                          `type` is the type of the entrypoint of the proxy servers.
+                          Currently supports "Hostname", "LoadBalancerService"
+                        enum:
+                        - Hostname
+                        - LoadBalancerService
+                        - PortForward
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  image:
+                    description: '`image` is the container image of the proxy servers.'
+                    type: string
+                  inClusterServiceName:
+                    default: proxy-entrypoint
+                    description: |-
+                      `inClusterServiceName` is the name of the in-cluster service for proxying
+                      requests inside the hub cluster to the proxy servers.
+                    type: string
+                  namespace:
+                    default: open-cluster-management-cluster-proxy
+                    description: |-
+                      `namespace` is the namespace where we will deploy the proxy servers and related
+                      resources.
+                    type: string
+                  nodePlacement:
+                    description: NodePlacement defines which Nodes the proxy server
+                      are scheduled on. The default is an empty list.
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector defines which Nodes the Pods are
+                          scheduled on. The default is an empty list.
+                        type: object
+                      tolerations:
+                        description: |-
+                          Tolerations is attached by pods to tolerate any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                          The default is an empty list.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  replicas:
+                    default: 3
+                    description: |-
+                      `replicas` is the expected replicas of the proxy servers.
+                      Note that the replicas will also be reflected in the flag `--server-count`
+                      so that agents can discover all the server instances.
+                    format: int32
+                    type: integer
+                required:
+                - image
+                type: object
+              userServer:
+                description: |-
+                  `userServer` configures certificate rotation for the user server.
+                  When configured, certificates will be automatically generated and rotated.
+                properties:
+                  additionalSANs:
+                    description: |-
+                      `additionalSANs` adds additional hostnames or IPs to the user server certificate.
+                      Use this to add external hostnames when the user server is exposed outside the cluster.
+                      The certificate always includes internal service DNS names automatically:
+                      - cluster-proxy-addon-user
+                      - cluster-proxy-addon-user.{namespace}
+                      - cluster-proxy-addon-user.{namespace}.svc
+                      - cluster-proxy-addon-user.{namespace}.svc.cluster.local
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - authentication
+            - proxyAgent
+            - proxyServer
+            type: object
+          status:
+            description: ManagedProxyConfigurationStatus defines the observed state
+              of ManagedProxyConfiguration
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastObservedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -31,7 +31,8 @@ const (
 	ClusterLifecycleChartDir           = "pkg/templates/charts/toggle/cluster-lifecycle"
 	ClusterManagerChartDir             = "pkg/templates/charts/toggle/cluster-manager"
 	ClusterPermissionChartDir          = "pkg/templates/charts/toggle/cluster-permission"
-	ClusterProxyAddonDir               = "pkg/templates/charts/toggle/cluster-proxy-addon"
+	ClusterProxyAddonDir               = "pkg/templates/charts/toggle/cluster-proxy-addon" // Deprecated: Moved to ClusterProxyDir in MCE 2.11
+	ClusterProxyDir                    = "pkg/templates/charts/toggle/cluster-proxy"
 	ConsoleMCEChartsDir                = "pkg/templates/charts/toggle/console-mce"
 	DiscoveryChartDir                  = "pkg/templates/charts/toggle/discovery-operator"
 	HiveChartDir                       = "pkg/templates/charts/toggle/hive-operator"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -495,6 +495,8 @@ func ComponentCRDDirectories(component string) []string {
 		return []string{backplanev1.ClusterPermissionCRDDir}
 	case backplanev1.ClusterProxyAddon:
 		return []string{backplanev1.ClusterProxyAddonCRDDir}
+	case backplanev1.ClusterProxy:
+		return []string{backplanev1.ClusterProxyCRDDir}
 	case backplanev1.Discovery:
 		return []string{backplanev1.DiscoveryCRDDir}
 	case backplanev1.Hive:


### PR DESCRIPTION
## Summary
- Add cluster-proxy component to charts-config.yaml for bundle automation
- Configure chart automation to pull from stolostron/cluster-proxy repo
- Set branch to backplane-5.0
- Configure image mapping for cluster-proxy

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Verify bundle automation workflow processes cluster-proxy chart
- [ ] Verify image mappings resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced cluster-proxy component as the new standard proxy solution in MCE 2.11, replacing cluster-proxy-addon with improved configuration and deployment capabilities
  * Added comprehensive Helm chart and Kubernetes resource templates for cluster-proxy installation and lifecycle management

* **Refactor**
  * Deprecated cluster-proxy-addon component; users should migrate to the new cluster-proxy component for continued support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->