### PR TITLE
[backplane-2.17][ACM-33412] Add POD_NAMESPACE env var to cluster-proxy deployments

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
@@ -74,6 +74,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           {{- if .Values.hubconfig.proxyConfigs }}
           - name: HTTP_PROXY
             value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml
@@ -75,13 +75,17 @@ spec:
           - "--signer-secret-namespace={{ .Values.global.namespace }}"
           - "--agent-image={{ .Values.global.imageOverrides.cluster_proxy }}"
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         {{- if .Values.hubconfig.proxyConfigs }}
-          - name: HTTP_PROXY
-            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
-          - name: NO_PROXY
-            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -109,6 +113,10 @@ spec:
           - "--service-proxy-ca-cert=/proxy-ca/ca.crt" # service-proxy is also sign by the singer ca of cluster-proxy. So here we use the same CA cert.
           - "--agent-install-namespace=open-cluster-management-agent-addon"
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         {{- if .Values.hubconfig.proxyConfigs }}
         - name: HTTP_PROXY
           value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}


### PR DESCRIPTION
# Description

Cherry-pick of #3219 for backplane-2.17 branch, adding POD_NAMESPACE environment variable to cluster-proxy deployments. Config.yaml change excluded from original PR.

## Related Issue

- Jira: https://redhat.atlassian.net/browse/ACM-33412
- Original PR: #3219

## Changes Made

- **manager-deployment.yaml**: Add POD_NAMESPACE env var to manager container using downward API
- **user-deployment.yaml**: Add POD_NAMESPACE env var to controllers and user-server containers using downward API

## Screenshots (if applicable)

N/A

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This is a clean cherry-pick of the POD_NAMESPACE deployment changes only. The config.yaml change from the original PR was intentionally excluded as it's not needed for the backplane-2.17 branch.

## Reviewers

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the backplane-2.17 branch.