### PR TITLE
ci: add backplane-2.17 to GitHub Actions workflow matrices

### DIFF
--- a/.github/workflows/regenerate-charts.yml
+++ b/.github/workflows/regenerate-charts.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false # If one jobs fail, we still want the other jobs to run.
       matrix:
         python-version: [3.9]
-        branch: ['main', 'backplane-2.6', 'backplane-2.7', 'backplane-2.8', 'backplane-2.9', 'backplane-2.10', 'backplane-2.11']
+        branch: ['main', 'backplane-2.6', 'backplane-2.7', 'backplane-2.8', 'backplane-2.9', 'backplane-2.10', 'backplane-2.11', 'backplane-2.17']
         include:
           - branch: backplane-2.6
             go-version: "1.24"
@@ -45,6 +45,8 @@ jobs:
           - branch: backplane-2.10
             go-version: "1.25"
           - branch: backplane-2.11
+            go-version: "1.25"
+          - branch: backplane-2.17
             go-version: "1.25"
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/regenerate-operator-bundles.yml
+++ b/.github/workflows/regenerate-operator-bundles.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false # If one jobs fail, we still want the other jobs to run.
       matrix:
         python-version: [3.9]
-        branch: ['main', 'backplane-2.6', 'backplane-2.7', 'backplane-2.8', 'backplane-2.9', 'backplane-2.10', 'backplane-2.11']
+        branch: ['main', 'backplane-2.6', 'backplane-2.7', 'backplane-2.8', 'backplane-2.9', 'backplane-2.10', 'backplane-2.11', 'backplane-2.17']
         include:
           - branch: backplane-2.6
             go-version: "1.24"
@@ -45,6 +45,8 @@ jobs:
           - branch: backplane-2.10
             go-version: "1.25"
           - branch: backplane-2.11
+            go-version: "1.25"
+          - branch: backplane-2.17
             go-version: "1.25"
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/resync-owner-file.yml
+++ b/.github/workflows/resync-owner-file.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         branch: [
+            'backplane-2.17',
             'backplane-2.11',
             'backplane-2.10',
             'backplane-2.9',


### PR DESCRIPTION
# Description

Add backplane-2.17 branch support to GitHub Actions workflows for automated chart and operator bundle regeneration, and OWNERS file syncing.

## Related Issue

N/A

## Changes Made

Updated three GitHub Actions workflow files to include backplane-2.17 in their branch matrices with Go 1.25:
- `.github/workflows/regenerate-operator-bundles.yml`
- `.github/workflows/regenerate-charts.yml`
- `.github/workflows/resync-owner-file.yml`

This ensures automated workflows run for the new backplane-2.17 branch alongside existing supported versions (2.6-2.11).

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This is a workflow configuration change only. No code changes required. The backplane-2.17 branch uses Go 1.25, consistent with versions 2.7-2.11.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.