### PR TITLE
Add OLM v1 dual support for MCE operator

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -84,6 +84,7 @@ type MultiClusterEngineReconciler struct {
 	Log              logr.Logger
 	UpgradeableCond  utils.Condition
 	DeprecatedFields map[string]bool
+	OLMVersion       string
 }
 
 const (
@@ -581,8 +582,11 @@ func (r *MultiClusterEngineReconciler) setOperatorUpgradeableStatus(ctx context.
 	}
 	// This error should only occur if the operator condition does not exist for some reason
 	// We will return true so that we re-reconcile on the failed update of the operator condition
-	if err := r.UpgradeableCond.Set(ctx, status, reason, msg); err != nil {
-		return true, err
+	// Only set OperatorCondition for OLM v0
+	if r.OLMVersion == "v0" {
+		if err := r.UpgradeableCond.Set(ctx, status, reason, msg); err != nil {
+			return true, err
+		}
 	}
 
 	if !upgradeable {

--- a/main.go
+++ b/main.go
@@ -118,6 +118,36 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+func detectOLMVersion(ctx context.Context, cl client.Client) (string, error) {
+	// Check for OLM v0 via environment variable (fastest check)
+	// OLM v0 injects OPERATOR_CONDITION_NAME into operator pods at deployment time
+	if os.Getenv("OPERATOR_CONDITION_NAME") != "" {
+		return "v0", nil
+	}
+
+	// Check for OLM v1 by looking for ClusterExtension CRD
+	// If this CRD exists, the cluster is running OLM v1
+	crd := &apixv1.CustomResourceDefinition{}
+	err := cl.Get(ctx, types.NamespacedName{
+		Name: "clusterextensions.olm.operatorframework.io",
+	}, crd)
+
+	switch {
+	case err == nil:
+		// ClusterExtension CRD exists - OLM v1 present
+		return "v1", nil
+
+	case errors.IsNotFound(err):
+		// CRD not found - no OLM on cluster (legitimate case for bare Kubernetes)
+		return "", nil
+
+	default:
+		// API error (timeout, permission, etc) - fail fast and let Kubernetes retry
+		// Kubernetes will restart the pod with exponential backoff
+		return "", fmt.Errorf("failed to check for OLM v1 CRD: %w", err)
+	}
+}
+
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -254,8 +284,16 @@ func main() {
 	ctx = ctrl.SetupSignalHandler()
 	upgradeableCondition := &utils.OperatorCondition{}
 
-	if utils.DeployOnOCP() {
-		// Force OperatorCondition Upgradeable to False
+	// Detect OLM version to determine if OperatorCondition is needed
+	olmVersion, err := detectOLMVersion(ctx, uncachedClient)
+	if err != nil {
+		setupLog.Error(err, "Failed to detect OLM version")
+		os.Exit(1)
+	}
+	setupLog.Info("OLM version detected", "version", olmVersion)
+
+	if utils.DeployOnOCP() && olmVersion == "v0" {
+		// Force OperatorCondition Upgradeable to False (OLM v0 only)
 		//
 		// We have to at least default the condition to False or
 		// OLM will use the Readiness condition via our readiness probe instead:
@@ -275,6 +313,8 @@ func main() {
 			setupLog.Error(err, "unable to create set operator condition upgradable to false")
 			os.Exit(1)
 		}
+	} else if olmVersion == "v1" {
+		setupLog.Info("Skipping OperatorCondition (OLM v0 only)")
 	}
 
 	// Apply all component CRDs except cluster-api ones (which may be disabled)
@@ -314,6 +354,7 @@ func main() {
 		UncachedClient:  uncachedClient,
 		StatusManager:   &status.StatusTracker{Client: mgr.GetClient()},
 		UpgradeableCond: upgradeableCondition,
+		OLMVersion:      olmVersion,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MultiClusterEngine")
 		os.Exit(1)
@@ -386,7 +427,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(multiclusterengineList.Items) == 0 {
+	if len(multiclusterengineList.Items) == 0 && olmVersion == "v0" {
 		err = upgradeableCondition.Set(ctx, metav1.ConditionTrue, utils.UpgradeableAllowReason, utils.UpgradeableAllowMessage)
 		if err != nil {
 			setupLog.Error(err, "Could not set Operator Condition")


### PR DESCRIPTION
## Summary

Implements dual OLM v0/v1 support for backplane-operator (MCE), enabling operation on both OLM v0 (OpenShift 4.x) and OLM v1 (OpenShift 5.x) clusters.

## Changes

- **OLM version detection**: Added `detectOLMVersion()` function checking OPERATOR_CONDITION_NAME env var (v0) and ClusterExtension CRD (v1)
- **OperatorCondition guard**: Only create OperatorCondition for v0, skip for v1
- **OLMVersion field**: Added to MultiClusterEngineReconciler struct
- **setOperatorUpgradeableStatus() guard**: Only set UpgradeableCond for v0
- **Controller setup**: Pass OLMVersion during initialization

## Pattern

Implementation matches multiclusterhub-operator for consistency across ACM operators.

## Fixes

Resolves crash in OLM v1 environments:
```
ERROR setup Cannot create the Upgradeable Operator Condition {"error": "get operator condition name: could not determine operator condition name: environment variable OPERATOR_CONDITION_NAME not set"}
```

## Testing

- Code compiles successfully
- Pattern verified against MCH operator implementation
- Ready for integration testing on OpenShift 5.0 with OLM v1

## Related PRs

- multiclusterhub-operator: https://github.com/stolostron/multiclusterhub-operator/pull/4109

🤖 Generated with [Claude Code](https://claude.com/claude-code)