### PR TITLE
ACM-33066 Bridge OCM CA bundle into console pod for PlacementDebugServer

### DIFF
--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -79,6 +79,10 @@ func (r *MultiClusterEngineReconciler) ensureConsoleMCE(ctx context.Context, mce
 		}
 	}
 
+	if err := r.ensurePlacementDebugCABundle(ctx, mce); err != nil {
+		log.Error(err, "Failed to sync placement debug CA bundle")
+	}
+
 	// Check console-mce deployment health before adding plugin
 	consoleDeployment := &appsv1.Deployment{}
 	err := r.Client.Get(ctx, namespacedName, consoleDeployment)
@@ -145,6 +149,56 @@ func (r *MultiClusterEngineReconciler) ensureNoConsoleMCE(ctx context.Context, m
 		}
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterEngineReconciler) ensurePlacementDebugCABundle(
+	ctx context.Context, mce *backplanev1.MultiClusterEngine,
+) error {
+	sourceNS := "open-cluster-management-hub"
+	sourceName := "ca-bundle-configmap"
+	source := &corev1.ConfigMap{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: sourceName, Namespace: sourceNS}, source)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to get OCM CA bundle ConfigMap")
+	}
+
+	caBundle, ok := source.Data["ca-bundle.crt"]
+	if !ok || caBundle == "" {
+		return nil
+	}
+
+	targetName := "placement-debug-ca-bundle"
+	target := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName,
+			Namespace: mce.Spec.TargetNamespace,
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": caBundle,
+		},
+	}
+
+	if err := ctrl.SetControllerReference(mce, target, r.Scheme); err != nil {
+		return errors.Wrapf(err, "failed to set controller reference on placement debug CA ConfigMap")
+	}
+
+	existing := &corev1.ConfigMap{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: targetName, Namespace: mce.Spec.TargetNamespace}, existing)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.Client.Create(ctx, target)
+		}
+		return errors.Wrapf(err, "failed to get placement debug CA ConfigMap")
+	}
+
+	if existing.Data["ca-bundle.crt"] != caBundle {
+		existing.Data = target.Data
+		return r.Client.Update(ctx, existing)
+	}
+	return nil
 }
 
 func (r *MultiClusterEngineReconciler) ensureManagedServiceAccount(ctx context.Context,

--- a/pkg/templates/charts/toggle/console-mce/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-deployment.yaml
@@ -82,6 +82,10 @@ spec:
       - name: console-mce-console-mce-config
         configMap:
           name: console-mce-config
+      - name: placement-debug-ca
+        configMap:
+          name: placement-debug-ca-bundle
+          optional: true
       containers:
       - name: console
         volumeMounts:
@@ -89,6 +93,9 @@ spec:
           name: console-mce-console-certs
         - mountPath: /app/config
           name: console-mce-console-mce-config
+        - mountPath: /var/run/secrets/placement-debug-ca
+          name: placement-debug-ca
+          readOnly: true
         image: {{ .Values.global.imageOverrides.console_mce }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         resources:
@@ -124,6 +131,8 @@ spec:
           value: "3000"
         - name: CLUSTER_API_URL
           value: https://kubernetes.default.svc:443
+        - name: PLACEMENT_CA_BUNDLE_PATH
+          value: /var/run/secrets/placement-debug-ca/ca-bundle.crt
         {{- if .Values.hubconfig.proxyConfigs }}
         - name: HTTP_PROXY
           value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}


### PR DESCRIPTION
## Summary

- Adds `ensurePlacementDebugCABundle()` to copy the OCM CA bundle ConfigMap from `open-cluster-management-hub` to the MCE namespace
- Adds volume, volumeMount, and `PLACEMENT_CA_BUNDLE_PATH` env var to the console-mce deployment Helm chart

## Context

The PlacementDebugServer uses TLS certificates signed by the OCM CertRotationController's signing CA (via [ocm#1494](https://github.com/open-cluster-management-io/ocm/pull/1494)) instead of the OCP service-CA. The ACM console needs to trust this CA to proxy placement debug requests.

This PR bridges the OCM CA bundle (`ca-bundle-configmap` in `open-cluster-management-hub`) into the MCE namespace as `placement-debug-ca-bundle`, then mounts it into the console pod at `/var/run/secrets/placement-debug-ca/ca-bundle.crt`.

The console code that reads this CA and creates a custom HTTPS agent is in [console#6090](https://github.com/stolostron/console/pull/6090).

## Test plan

- [x] E2E tested on live ACM cluster: console reads OCM CA from mounted path, creates custom HTTPS agent, successfully connects to PlacementDebugServer
- [ ] Unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic CA bundle synchronization for placement debugging and troubleshooting support.
  * Console application now has access to certificate authority information for enhanced diagnostics of placement operations.
  * Configured new environment variable to enable dynamic CA bundle path resolution.
  * Improved placement issue diagnostics through centralized certificate authority management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->