### PR TITLE
[ACM-33645] Update PostgreSQL references to version 16 for MCE

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -33,7 +33,7 @@ components:
         assisted-installer-agent: assisted_installer_agent
         assisted-installer-controller: assisted_installer_controller
         assisted-service: assisted_service_9
-        postgresql-15-c9s: postgresql_15
+        postgresql-16-c9s: postgresql_16
       name: assisted-service
     repo_name: assisted-service
 

--- a/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml
@@ -55,7 +55,7 @@ spec:
         - name: IMAGE_SERVICE_IMAGE
           value: '{{ .Values.global.imageOverrides.assisted_image_service }}'
         - name: DATABASE_IMAGE
-          value: '{{ .Values.global.imageOverrides.postgresql_15 }}'
+          value: '{{ .Values.global.imageOverrides.postgresql_16 }}'
         - name: AGENT_IMAGE
           value: '{{ .Values.global.imageOverrides.assisted_installer_agent }}'
         - name: CONTROLLER_IMAGE

--- a/pkg/templates/charts/toggle/assisted-service/values.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/values.yaml
@@ -6,7 +6,7 @@ global:
     assisted_installer_agent: ''
     assisted_installer_controller: ''
     assisted_service_9: ''
-    postgresql_15: ''
+    postgresql_16: ''
   namespace: default
   pullSecret: null
   templateOverrides: {}

--- a/pkg/templates/charts/toggle/maestro/templates/maestro.db.statefulset.yaml
+++ b/pkg/templates/charts/toggle/maestro/templates/maestro.db.statefulset.yaml
@@ -29,7 +29,7 @@ spec:
 {{- end }}
       containers:
       - name: postgresql
-        image: {{ .Values.global.imageOverrides.postgresql_15 }}
+        image: {{ .Values.global.imageOverrides.postgresql_16 }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         ports:
         - containerPort: 5432

--- a/pkg/templates/charts/toggle/maestro/values.yaml
+++ b/pkg/templates/charts/toggle/maestro/values.yaml
@@ -5,7 +5,7 @@
 global:
   imageOverrides:
     maestro: ""
-    postgresql_15: ""
+    postgresql_16: ""
   # Available template overrides:
   # maestro_database_storage: <storage-value>
   templateOverrides: {}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -207,7 +207,7 @@ func GetTestImages() []string {
 		"HYPERSHIFT_ADDON_OPERATOR", "HYPERSHIFT_OPERATOR", "IMAGE_BASED_INSTALL_OPERATOR", "KUBE_RBAC_PROXY_MCE",
 		"MANAGEDCLUSTER_IMPORT_CONTROLLER", "MANAGED_SERVICEACCOUNT", "MCE_CAPI_WEBHOOK_CONFIG_RHEL9",
 		"MULTICLOUD_MANAGER", "OPENSHIFT_HIVE", "OSE_AWS_CLUSTER_API_CONTROLLERS_RHEL9", "OSE_CLUSTER_API_RHEL9",
-		"POSTGRESQL_15", "PROVIDER_CREDENTIAL_CONTROLLER", "REGISTRATION", "REGISTRATION_OPERATOR", "WORK",
+		"POSTGRESQL_16", "PROVIDER_CREDENTIAL_CONTROLLER", "REGISTRATION", "REGISTRATION_OPERATOR", "WORK",
 		"apiserver_network_proxy", "assisted_image_service", "assisted_installer", "assisted_installer_agent",
 		"assisted_installer_controller", "assisted_service_9", "aws_encryption_provider", "azure_service_operator_rhel9",
 		"cluster_api", "cluster_api_bootstrap_provider_openshift_assisted",
@@ -220,7 +220,7 @@ func GetTestImages() []string {
 		"hypershift_operator", "image_based_install_operator", "ip_address_manager", "kube_rbac_proxy_mce",
 		"maestro", "managed_serviceaccount", "managedcluster_import_controller", "mce_capi_webhook_config_rhel9",
 		"multicloud_manager", "openshift_hive", "ose_aws_cluster_api_controllers_rhel9",
-		"ose_baremetal_cluster_api_controllers_rhel9", "ose_cluster_api_rhel9", "postgresql_15",
+		"ose_baremetal_cluster_api_controllers_rhel9", "ose_cluster_api_rhel9", "postgresql_16",
 		"provider_credential_controller", "registration", "registration_operator", "work",
 	}
 }


### PR DESCRIPTION
# Description

Updates PostgreSQL image references from postgresql-15 to postgresql-16 for ACM 5.0 / MCE 5.0.

## Related Issue

https://redhat.atlassian.net/browse/ACM-33645

## Changes Made

Updated PostgreSQL 15 → 16 in 6 files:

1. **hack/bundle-automation/config.yaml**
   - Changed `postgresql-15-c9s: postgresql_15` → `postgresql-16-c9s: postgresql_16`

2. **pkg/templates/charts/toggle/assisted-service/values.yaml**
   - Changed `postgresql_15: ''` → `postgresql_16: ''`

3. **pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator.yaml**
   - Changed `DATABASE_IMAGE` reference from `postgresql_15` → `postgresql_16`

4. **pkg/templates/charts/toggle/maestro/values.yaml**
   - Changed `postgresql_15: ""` → `postgresql_16: ""`

5. **pkg/templates/charts/toggle/maestro/templates/maestro.db.statefulset.yaml**
   - Changed image reference from `postgresql_15` → `postgresql_16`

6. **pkg/utils/utils.go**
   - Updated `POSTGRESQL_15` → `POSTGRESQL_16` in image lists (2 occurrences)

## Additional Notes

Following the same upgrade pattern as PG13→PG15 (PR #3102).

**Dependency:** This PR requires mce-operator-bundle PR #3586 to merge first, as it adds the `postgresql_16` image key to the manifest config.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have rebased my branch on top of the latest backplane-5.0 branch.