### PR TITLE
[ACM-30442] Convert cacheDuration from var to const

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,12 +78,15 @@ import (
 const (
 	crdName = "multiclusterengines.multicluster.openshift.io"
 	crdsDir = "pkg/templates/crds"
+
+	// cacheDuration defines how long to cache client connections and metadata
+	// in the controller manager. Cached data is refreshed every 5 minutes.
+	cacheDuration = 5 * time.Minute
 )
 
 var (
-	cacheDuration time.Duration = time.Minute * 5
-	scheme                      = runtime.NewScheme()
-	setupLog                    = ctrl.Log.WithName("setup")
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
 )
 
 func init() {


### PR DESCRIPTION
# Description

Convert `cacheDuration` from `var` to `const` to prevent accidental modification and make intent clearer.

## Related Issue

https://redhat.atlassian.net/browse/ACM-30442

## Changes Made

**File: main.go**
- Moved `cacheDuration` from `var` block to `const` block
- Added documentation explaining the 5-minute cache duration
- Changed declaration from `var cacheDuration time.Duration = time.Minute * 5` to `const cacheDuration = 5 * time.Minute`

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This is a code quality improvement with no functional changes. The value was never modified at runtime, so converting to const better reflects actual usage.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code optimization: cache duration setting refactored to improve code quality.

*Note: This is an internal implementation change with no impact on end-user functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->