### PR TITLE
ACM-31163 adding network policy in addon manager

### DIFF
--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -415,7 +415,7 @@ func renderTemplates(chartPath string, backplaneConfig *v1.MultiClusterEngine, i
 
 		// Add namespace to namespaced resources
 		switch kind {
-		case "Deployment", "ServiceAccount", "Role", "RoleBinding", "Service", "ConfigMap", "Route":
+		case "Deployment", "ServiceAccount", "Role", "RoleBinding", "Service", "ConfigMap", "Route", "NetworkPolicy":
 			unstructured.SetNamespace(backplaneConfig.Spec.TargetNamespace)
 		}
 

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hypershift-addon-manager-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: hypershift-addon-manager
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
@@ -7,6 +7,7 @@ spec:
     matchLabels:
       app: hypershift-addon-manager
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - {}

--- a/pkg/templates/rbac.go
+++ b/pkg/templates/rbac.go
@@ -65,6 +65,7 @@ var resources = []string{
 	"ManagedProxyServiceResolver",
 	"MutatingWebhookConfiguration",
 	"Namespace",
+	"NetworkPolicy",
 	"PodDisruptionBudget",
 	"PrometheusRule",
 	"Role",


### PR DESCRIPTION
# Description

Adds an egress-only NetworkPolicy for the `hypershift-addon-manager` deployment in the MCE namespace. This prepares the hypershift-addon-manager for environments where namespace-level default-deny network policies are applied, while allowing required outbound traffic to the Kubernetes API server, Open Cluster Management APIs, and DNS.

## Related Issue

[ACM-31163](https://redhat.atlassian.net/browse/ACM-31163) — Test and validate network policies for HyperShift components

Parent: [ACM-31152](https://redhat.atlassian.net/browse/ACM-31152) — Test and validate network policies for all component namespaces

## Changes Made

- Added `hypershift-addon-manager-networkpolicy.yaml` to the hypershift chart with an egress-only allow policy for pods labeled `app: hypershift-addon-manager`
- Updated `pkg/rendering/renderer.go` to assign the target namespace (`multicluster-engine`) to rendered `NetworkPolicy` resources

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

**Test environment:** ACM dev cluster (`multicluster-engine` namespace)

**Test method:** Built a custom `backplane-operator` image with this change, updated the CSV/deployment image, and verified the operator reconciled the NetworkPolicy.

**Test results:**
- `hypershift-addon-manager-network-policy` created successfully in `multicluster-engine`
- `hypershift-addon-manager` deployment remained `1/1` Ready
- `hypershift-addon` ManagedClusterAddOn remained `Available: True`
- `hypershift/operator` deployment remained `2/2` Ready
- MCE status remained `Available: True`

**Design notes:**
- This policy is **egress-only** — the hypershift-addon-manager does not expose ingress ports (no Service, metrics sidecar, or probes), so ingress rules are not required
- Without a namespace default-deny policy, this rule is effectively a no-op but does not break existing functionality
- Agent pod network policies (ingress on `8443`/`8000`) belong in **hypershift-addon-operator**, not this repo

## Reviewers

/cc @reviewer1 @reviewer2

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

[ACM-31163]: https://redhat.atlassian.net/browse/ACM-31163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-31152]: https://redhat.atlassian.net/browse/ACM-31152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a NetworkPolicy template (`hypershift-addon-manager-network-policy`) to define traffic rules for the hypershift add-on manager.
* **Improvements**
  * NetworkPolicy manifests are now handled consistently during rendering, including proper namespace assignment.
* **Bug Fixes**
  * Updated RBAC generation to recognize NetworkPolicy resources, preventing errors when such templates are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->