### PR TITLE
Fix: BUG ACM-35494: cluster-proxy-addon nodeSelector indentation in managedproxyconfiguration template

### DIFF
--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -37,7 +37,7 @@ func TestRender(t *testing.T) {
 	defer os.Unsetenv("DIRECTORY_OVERRIDE")
 
 	availabilityList := []string{"clusterclaims-controller", "cluster-curator-controller", "managedcluster-import-controller-v2", "ocm-controller", "ocm-proxyserver", "ocm-webhook"}
-	backplaneNodeSelector := map[string]string{"select": "test"}
+	backplaneNodeSelector := map[string]string{"select": "test", "select2": "test2"}
 	backplaneImagePullSecret := "test"
 	backplaneNamespace := "default"
 	backplaneAvailability := backplane.HAHigh
@@ -287,7 +287,7 @@ func TestNonOCPRender(t *testing.T) {
 	defer os.Unsetenv("DIRECTORY_OVERRIDE")
 	utils.SetDeployOnOCP(false)
 	availabilityList := []string{"clusterclaims-controller", "cluster-curator-controller", "managedcluster-import-controller-v2", "ocm-controller", "ocm-proxyserver", "ocm-webhook"}
-	backplaneNodeSelector := map[string]string{"select": "test"}
+	backplaneNodeSelector := map[string]string{"select": "test", "select2": "test2"}
 	backplaneImagePullSecret := "test"
 	backplaneNamespace := "default"
 	backplaneAvailability := backplane.HAHigh

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/managedproxyconfiguration.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/managedproxyconfiguration.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       {{- with .Values.hubconfig.nodeSelector }}
       nodeSelector:
-  {{ toYaml . | indent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
   proxyAgent:
     image: '{{ .Values.global.imageOverrides.cluster_proxy }}'


### PR DESCRIPTION
## Summary
- Fix template indentation bug in `cluster-proxy-addon/templates/managedproxyconfiguration.yaml` that caused `ManagedProxyConfiguration` to fail rendering when `nodeSelector` with 2+ keys is configured on `MultiClusterEngine`
- The buggy pattern `  {{ toYaml . | indent 8 }}` (2-space prefix) caused the first nodeSelector key to get 10 spaces of indentation while subsequent keys got only 8 — producing invalid YAML
- Updated renderer tests to use 2+ nodeSelector keys to prevent regression

## Problem
When `nodeSelector` with multiple keys is set on the MCE CR, the MCE operator enters a continuous error loop:
```
error converting file cluster-proxy-addon/templates/managedproxyconfiguration.yaml to unstructured
```

This prevents `ManagedProxyConfiguration` from being created, blocking `cluster-proxy-addon` deployment. Affects fresh installs and any scenario where the resource needs re-creation.

**Reproduced on MCE 2.11.2** — confirmed the buggy template inside the running operator pod and triggered the error on a live OCP cluster.

## Root Cause
In `managedproxyconfiguration.yaml`, the nodeSelector section had:
```yaml
      nodeSelector:
  {{ toYaml . | indent 8 }}
```

The 2-space prefix before `{{ toYaml }}` only applies to the first line of output, producing:
```yaml
      nodeSelector:
          env: infra-acm            # 10 spaces (WRONG)
        node-role...: ""            # 8 spaces
```

## Fix
Changed to the `nindent` pattern (consistent with other templates):
```yaml
      nodeSelector:
      {{- toYaml . | nindent 8 }}
```

## Test plan
- [x] Updated `TestRender` and `TestNonOCPRender` to use 2+ nodeSelector keys (`{"select": "test", "select2": "test2"}`) — these tests would have failed with the old template
- [x] `go test ./pkg/rendering/ -run TestRender -v` passes
- [x] Verified fix locally with a Go template reproduction test confirming valid YAML output
- [x] Reproduced the original error on a live OCP cluster (MCE 2.11.2) and confirmed the buggy template pattern inside the running pod


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected YAML indentation for node selector configurations in deployment templates.

* **Tests**
  * Expanded test coverage to validate node selector propagation with multiple key/value pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->