### PR TITLE
ACM-35920 Make console deployment probes configurable

### DIFF
--- a/pkg/templates/charts/toggle/console-mce/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-deployment.yaml
@@ -135,7 +135,6 @@ spec:
         ports:
         - containerPort: 3000
           protocol: TCP
-        {{- if not (eq (index .Values.global.templateOverrides "console_mce_deployment_container_readiness_probe_disabled" | default "false") "true") }}
         readinessProbe:
           httpGet:
             path: /readinessProbe
@@ -158,8 +157,6 @@ spec:
           {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_readiness_probe_failure_threshold" }}
           failureThreshold: {{ .Values.global.templateOverrides.console_mce_deployment_container_readiness_probe_failure_threshold }}
           {{- end }}
-        {{- end }}
-        {{- if not (eq (index .Values.global.templateOverrides "console_mce_deployment_container_liveness_probe_disabled" | default "false") "true") }}
         livenessProbe:
           httpGet:
             path: /livenessProbe
@@ -184,7 +181,6 @@ spec:
           {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_liveness_probe_failure_threshold" }}
           failureThreshold: {{ .Values.global.templateOverrides.console_mce_deployment_container_liveness_probe_failure_threshold }}
           {{- end }}
-        {{- end }}
       {{- if .Values.global.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.pullSecret }}

--- a/pkg/templates/charts/toggle/console-mce/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-deployment.yaml
@@ -135,19 +135,56 @@ spec:
         ports:
         - containerPort: 3000
           protocol: TCP
+        {{- if not (eq (index .Values.global.templateOverrides "console_mce_deployment_container_readiness_probe_disabled" | default "false") "true") }}
         readinessProbe:
           httpGet:
             path: /readinessProbe
             port: 3000
             scheme: HTTPS
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_readiness_probe_timeout_seconds" }}
+          timeoutSeconds: {{ .Values.global.templateOverrides.console_mce_deployment_container_readiness_probe_timeout_seconds }}
+          {{- else }}
           timeoutSeconds: 10
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_readiness_probe_initial_delay_seconds" }}
+          initialDelaySeconds: {{ .Values.global.templateOverrides.console_mce_deployment_container_readiness_probe_initial_delay_seconds }}
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_readiness_probe_period_seconds" }}
+          periodSeconds: {{ .Values.global.templateOverrides.console_mce_deployment_container_readiness_probe_period_seconds }}
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_readiness_probe_success_threshold" }}
+          successThreshold: {{ .Values.global.templateOverrides.console_mce_deployment_container_readiness_probe_success_threshold }}
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_readiness_probe_failure_threshold" }}
+          failureThreshold: {{ .Values.global.templateOverrides.console_mce_deployment_container_readiness_probe_failure_threshold }}
+          {{- end }}
+        {{- end }}
+        {{- if not (eq (index .Values.global.templateOverrides "console_mce_deployment_container_liveness_probe_disabled" | default "false") "true") }}
         livenessProbe:
           httpGet:
             path: /livenessProbe
             port: 3000
             scheme: HTTPS
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_liveness_probe_timeout_seconds" }}
+          timeoutSeconds: {{ .Values.global.templateOverrides.console_mce_deployment_container_liveness_probe_timeout_seconds }}
+          {{- else }}
           timeoutSeconds: 10
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_liveness_probe_initial_delay_seconds" }}
+          initialDelaySeconds: {{ .Values.global.templateOverrides.console_mce_deployment_container_liveness_probe_initial_delay_seconds }}
+          {{- else }}
           initialDelaySeconds: 10
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_liveness_probe_period_seconds" }}
+          periodSeconds: {{ .Values.global.templateOverrides.console_mce_deployment_container_liveness_probe_period_seconds }}
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_liveness_probe_success_threshold" }}
+          successThreshold: {{ .Values.global.templateOverrides.console_mce_deployment_container_liveness_probe_success_threshold }}
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_mce_deployment_container_liveness_probe_failure_threshold" }}
+          failureThreshold: {{ .Values.global.templateOverrides.console_mce_deployment_container_liveness_probe_failure_threshold }}
+          {{- end }}
+        {{- end }}
       {{- if .Values.global.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.pullSecret }}

--- a/pkg/templates/charts/toggle/console-mce/values.yaml
+++ b/pkg/templates/charts/toggle/console-mce/values.yaml
@@ -13,6 +13,22 @@ global:
   # console_mce_deployment_container_memory_limit: <memory-value>
   # console_mce_deployment_container_cpu_request: <cpu-value>
   # console_mce_deployment_container_cpu_limit: <cpu-value>
+  #
+  # Readiness probe overrides:
+  # console_mce_deployment_container_readiness_probe_disabled: "true"  (omits the entire readiness probe)
+  # console_mce_deployment_container_readiness_probe_timeout_seconds: <seconds>
+  # console_mce_deployment_container_readiness_probe_initial_delay_seconds: <seconds>
+  # console_mce_deployment_container_readiness_probe_period_seconds: <seconds>
+  # console_mce_deployment_container_readiness_probe_success_threshold: <count>
+  # console_mce_deployment_container_readiness_probe_failure_threshold: <count>
+  #
+  # Liveness probe overrides:
+  # console_mce_deployment_container_liveness_probe_disabled: "true"  (omits the entire liveness probe)
+  # console_mce_deployment_container_liveness_probe_timeout_seconds: <seconds>
+  # console_mce_deployment_container_liveness_probe_initial_delay_seconds: <seconds>
+  # console_mce_deployment_container_liveness_probe_period_seconds: <seconds>
+  # console_mce_deployment_container_liveness_probe_success_threshold: <count>
+  # console_mce_deployment_container_liveness_probe_failure_threshold: <count>
   pullPolicy: Always
   namespace: default
   pullSecret: null

--- a/pkg/templates/charts/toggle/console-mce/values.yaml
+++ b/pkg/templates/charts/toggle/console-mce/values.yaml
@@ -15,7 +15,6 @@ global:
   # console_mce_deployment_container_cpu_limit: <cpu-value>
   #
   # Readiness probe overrides:
-  # console_mce_deployment_container_readiness_probe_disabled: "true"  (omits the entire readiness probe)
   # console_mce_deployment_container_readiness_probe_timeout_seconds: <seconds>
   # console_mce_deployment_container_readiness_probe_initial_delay_seconds: <seconds>
   # console_mce_deployment_container_readiness_probe_period_seconds: <seconds>
@@ -23,7 +22,6 @@ global:
   # console_mce_deployment_container_readiness_probe_failure_threshold: <count>
   #
   # Liveness probe overrides:
-  # console_mce_deployment_container_liveness_probe_disabled: "true"  (omits the entire liveness probe)
   # console_mce_deployment_container_liveness_probe_timeout_seconds: <seconds>
   # console_mce_deployment_container_liveness_probe_initial_delay_seconds: <seconds>
   # console_mce_deployment_container_liveness_probe_period_seconds: <seconds>


### PR DESCRIPTION
# Description

Added support for customizable readiness and liveness probes in the console deployment configuration. Users can now override probe settings such as timeout, initial delay, period, success, and failure thresholds through template overrides in the values.yaml file. This improves flexibility and allows for better tuning of application health checks.

## Related Issue

https://redhat.atlassian.net/browse/ACM-35920

## Changes Made

Modified the console-deployment template to refer to new values from the global template overrides.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Kubernetes readiness and liveness probe templating to support overrideable timing parameters.
  * `timeoutSeconds` now defaults to `10`, and additional probe settings (initial delay, period, success threshold, failure threshold) are applied when corresponding overrides are provided.
* **Documentation**
  * Added comment-only documentation describing the probe override parameters available in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->