### PR TITLE
Acm 31163 - Adding missing rbac for networkpolicy

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2544,6 +2544,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - create
   - delete
@@ -2552,14 +2553,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-  - get
-  - update
 - apiGroups:
   - notificationhubs.azure.com
   resources:

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -176,6 +176,9 @@ var (
 // InternalEngineComponent
 // +kubebuilder:rbac:groups="multicluster.openshift.io",resources="internalenginecomponents",verbs=create;get;delete;patch;list;watch
 
+// NetworkPolicy
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch;update;watch
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (retRes ctrl.Result, retErr error) {

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -415,7 +415,7 @@ func renderTemplates(chartPath string, backplaneConfig *v1.MultiClusterEngine, i
 
 		// Add namespace to namespaced resources
 		switch kind {
-		case "Deployment", "ServiceAccount", "Role", "RoleBinding", "Service", "ConfigMap", "Route":
+		case "Deployment", "ServiceAccount", "Role", "RoleBinding", "Service", "ConfigMap", "Route", "NetworkPolicy":
 			unstructured.SetNamespace(backplaneConfig.Spec.TargetNamespace)
 		}
 

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hypershift-addon-manager-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: hypershift-addon-manager
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
@@ -7,6 +7,7 @@ spec:
     matchLabels:
       app: hypershift-addon-manager
   policyTypes:
+  - Ingress
   - Egress
   egress:
   - {}

--- a/pkg/templates/rbac.go
+++ b/pkg/templates/rbac.go
@@ -65,6 +65,7 @@ var resources = []string{
 	"ManagedProxyServiceResolver",
 	"MutatingWebhookConfiguration",
 	"Namespace",
+	"NetworkPolicy",
 	"PodDisruptionBudget",
 	"PrometheusRule",
 	"Role",


### PR DESCRIPTION
# Description

Adds missing RBAC verbs for `networkpolicies` in the backplane-operator's ClusterRole. PR #3463 introduced a NetworkPolicy for the hypershift-addon-manager but only granted `create`, `get`, `update` permissions. The operator needs `patch`, `delete`, `list`, and `watch` to manage the NetworkPolicy on subsequent reconciliations.

## Related Issue

ACM-31163

## Changes Made

- Added a `//+kubebuilder:rbac` marker in `controllers/backplaneconfig_controller.go` granting all necessary verbs (`create`, `delete`, `get`, `list`, `patch`, `update`, `watch`) on `networkpolicies` in the `networking.k8s.io` API group.
- Regenerated `config/rbac/role.yaml` via `make manifests` — `controller-gen` merged `networkpolicies` into the existing `networking.k8s.io` rule alongside `ingresses`.
- Updated `pkg/templates/rbac_gen.go` to reflect the full verb set.

## Screenshots (if applicable)

Before fix — MCE status shows `ComponentFailure`:

ComponentFailure: hypershift-addon-manager-network-policy (Kind:NetworkPolicy)
  failed to update resource: networkpolicies.networking.k8s.io "hypershift-addon-manager-network-policy" is forbidden:
  User "system:serviceaccount:multicluster-engine:multicluster-engine-operator" cannot patch resource "networkpolicies"
  in API group "networking.k8s.io" in the namespace "multicluster-engine"

After fix — MCE status healthy:

Progressing    All components deployed
Available      All components available
Phase: Available

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

PR #3463 added the NetworkPolicy manifest and the code-level allowlist entry but missed the RBAC update. The operator could create the NetworkPolicy on the first reconciliation (since `create` was already granted from a sub-component chart), but failed on subsequent reconciliations when it tried to `patch` the existing resource.

The fix adds a permanent `//+kubebuilder:rbac` marker in the controller source so the permission survives `make manifests` regeneration.

## Reviewers

@yiraeChristineKim @dislbenn 

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Kubernetes NetworkPolicy for the addon manager, tightening pod traffic controls.
* **Bug Fixes**
  * NetworkPolicy resources are now assigned to the correct target namespace when rendered.
  * Expanded permissions so NetworkPolicy objects can be managed consistently alongside related networking resources.
* **Chores**
  * Updated internal resource handling so NetworkPolicy is recognized during manifest generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->