### PR TITLE
fix: update hive bundle generation to use bundle-gen.sh

### DIFF
--- a/hack/bundle-automation/gen-hive-bundle.sh
+++ b/hack/bundle-automation/gen-hive-bundle.sh
@@ -55,7 +55,7 @@ if [[ -z "$output_dir" ]]; then
 fi
 
 hive_repo="https://github.com/openshift/hive.git"
-gen_tool="hack/bundle-gen.py"  # Path within Hive's repo.
+gen_tool="hack/bundle-gen.sh"  # Path within Hive's repo.
 
 start_cwd="$PWD"
 rm -rf "$output_dir"
@@ -99,16 +99,9 @@ fi
 mkdir bundle
 cd bundle || exit 3
 
-# Copy the original version2.py from before Hive removed it (commit f1bc37a1b).
-# This is needed because bundle-gen.py still expects to import version2, but Hive
-# converted it to version2.sh. We maintain a local copy of the original Python version.
-echo "Copying version2.py compatibility layer..."
-cp "$start_cwd/hack/bundle-automation/version2.py" ../hive/hack/version2.py
-chmod u+x ../hive/hack/version2.py
-
 echo "Running Hive bundle-gen tool ($gen_tool)."
-python3 ../hive/$gen_tool --hive-repo "$hive_repo_spot" --commit "$commit_ish" --dummy-bundle "$branch" \
-   --image-repo dummy.io/disable-image-validation/hive --skip-release-config
+bash ../hive/$gen_tool --hive-repo "$hive_repo_spot" --commit "$commit_ish" --dummy-bundle \
+   --image-repo dummy.io/disable-image-validation/hive --skip-release-config --skip-image-validation
 
 # Note: We point the bundle-gen tool at the local repo we already checked out
 # since we know that it contains the Git SHA we are using for input.


### PR DESCRIPTION
# Description

Fixes `make regenerate-charts-from-bundles` which was failing because Hive upstream rewrote their bundle-gen tool from Python to shell script.

## Related Issue

N/A - Discovered during routine chart regeneration

## Changes Made

Updated `hack/bundle-automation/gen-hive-bundle.sh` to work with Hive's new bundle-gen.sh:
- Changed gen_tool path from `hack/bundle-gen.py` to `hack/bundle-gen.sh`
- Switched from `python3` to `bash` for execution
- Fixed `--dummy-bundle` flag (no longer takes argument in shell version)
- Added `--skip-image-validation` flag
- Removed obsolete version2.py compatibility layer

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Verified by running `make regenerate-charts-from-bundles` - hive bundle generation now completes successfully.

## Reviewers

N/A

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)