### PR TITLE
chore: disable backplane-2.7 automation workflows

### DIFF
--- a/.github/workflows/regenerate-charts.yml
+++ b/.github/workflows/regenerate-charts.yml
@@ -32,12 +32,10 @@ jobs:
       fail-fast: false # If one jobs fail, we still want the other jobs to run.
       matrix:
         python-version: [3.9]
-        branch: ['main', 'backplane-2.6', 'backplane-2.7', 'backplane-2.8', 'backplane-2.9', 'backplane-2.10', 'backplane-2.11', 'backplane-2.17']
+        branch: ['main', 'backplane-2.6', 'backplane-2.8', 'backplane-2.9', 'backplane-2.10', 'backplane-2.11', 'backplane-2.17']
         include:
           - branch: backplane-2.6
             go-version: "1.24"
-          - branch: backplane-2.7
-            go-version: "1.25"
           - branch: backplane-2.8
             go-version: "1.25"
           - branch: backplane-2.9

--- a/.github/workflows/regenerate-operator-bundles.yml
+++ b/.github/workflows/regenerate-operator-bundles.yml
@@ -36,7 +36,6 @@ jobs:
           [
             "main",
             "backplane-2.6",
-            "backplane-2.7",
             "backplane-2.8",
             "backplane-2.9",
             "backplane-2.10",
@@ -46,8 +45,6 @@ jobs:
         include:
           - branch: backplane-2.6
             go-version: "1.24"
-          - branch: backplane-2.7
-            go-version: "1.25"
           - branch: backplane-2.8
             go-version: "1.25"
           - branch: backplane-2.9

--- a/.github/workflows/resync-owner-file.yml
+++ b/.github/workflows/resync-owner-file.yml
@@ -25,7 +25,6 @@ jobs:
             'backplane-2.10',
             'backplane-2.9',
             'backplane-2.8',
-            'backplane-2.7',
             'backplane-2.6',
         ]
 


### PR DESCRIPTION
# Description

Removes backplane-2.7 from automated GitHub Actions workflows as the branch has reached end-of-life (EOL).

## Related Issue

N/A

## Changes Made

Removed `backplane-2.7` from matrix configurations in:
- `.github/workflows/regenerate-charts.yml`
- `.github/workflows/regenerate-operator-bundles.yml`
- `.github/workflows/resync-owner-file.yml`

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

backplane-2.7 has reached EOL. Automated workflows will no longer run for this branch.

## Reviewers

N/A

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)