### PR TITLE
fix(bundle): Remove -rhel9 suffix from operator image placeholder

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -3523,7 +3523,7 @@ spec:
                   value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/ose-baremetal-cluster-api-controllers-rhel9:latest
                 - name: OPERAND_IMAGE_POSTGRESQL_13
                   value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/postgresql-13:latest
-                image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-operator-rhel9:latest
+                image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-operator:latest
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:


### PR DESCRIPTION
## Problem

Bundle generation fails with:
```
Error: No image key mapping for: image-registry.openshift-image-registry.svc:5000/open-cluster-management/backplane-rhel9-operator:latest
```

## Root Cause

CSV uses `backplane-rhel9-operator` as operator container image, but binding script expects `backplane-operator` to match existing mapping:
```bash
image_key_mappings+=("backplane-operator:backplane_operator")
```

## Solution

Change CSV operator image placeholder from:
```
backplane-rhel9-operator
```
to:
```
backplane-operator
```

Binding script will map this to final published name `backplane-rhel9-operator` via config:
```json
{
  "image-key": "backplane_operator",
  "publish-name": "backplane-rhel9-operator"
}
```

## Testing

After merge, snapshot PR workflow should succeed in stolostron/mce-operator-bundle.