### PR TITLE
ACM-36254 Implement the fleet-navigation component

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -37,6 +37,7 @@ const (
 	ClusterProxyAddon                = "cluster-proxy-addon"
 	ConsoleMCE                       = "console-mce"
 	Discovery                        = "discovery"
+	FleetNavigation                  = "fleet-navigation"
 	Hive                             = "hive"
 	HyperShift                       = "hypershift"
 	HypershiftLocalHosting           = "hypershift-local-hosting"
@@ -91,6 +92,7 @@ var AllComponents = []string{
 	ClusterProxyAddon,
 	ConsoleMCE,
 	Discovery,
+	FleetNavigation,
 	Hive,
 	HyperShift,
 	HypershiftLocalHosting,
@@ -120,6 +122,7 @@ var MCEComponents = []string{
 	ClusterProxyAddon,
 	ConsoleMCE,
 	Discovery,
+	FleetNavigation,
 	Hive,
 	HyperShift,
 	HypershiftLocalHosting,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -925,6 +925,7 @@ rules:
   - managedclusters/status
   - managedclustersets
   - placementdecisions
+  - placements
   verbs:
   - create
   - delete
@@ -941,7 +942,6 @@ rules:
   - managedclustersets/bind
   - managedclustersets/finalizers
   - managedclustersets/join
-  - placements
   - placements/finalizers
   verbs:
   - create
@@ -1091,6 +1091,7 @@ rules:
   - authentications
   - clusteroperators
   - clusterversions
+  - consoles
   - dnses
   - ingresses
   - proxies

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1149,6 +1149,7 @@ rules:
 - apiGroups:
   - console.openshift.io
   resources:
+  - consolenotifications
   - consoleplugins
   - consolequickstarts
   verbs:

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -2609,8 +2609,8 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		consoleURL, err := r.getConsoleURL(ctx)
 		if err != nil {
 			log.Info("Failed to detect console URL, fleet-navigation link may be empty", "error", err)
-		} else {
-			os.Setenv("ACM_HUB_CONSOLE_URL", consoleURL)
+		} else if err := os.Setenv("ACM_HUB_CONSOLE_URL", consoleURL); err != nil {
+			return ctrl.Result{}, pkgerrors.Wrapf(err, "failed to set ACM_HUB_CONSOLE_URL")
 		}
 
 		// If OCP 4.10+ then set then enable the MCE console. Else ensure it is disabled
@@ -2834,6 +2834,9 @@ func (r *MultiClusterEngineReconciler) getConsoleURL(ctx context.Context) (strin
 		return "", err
 	}
 
+	if console.Status.ConsoleURL == "" {
+		return "", fmt.Errorf("consoleURL not found or empty in Console config")
+	}
 	return console.Status.ConsoleURL, nil
 }
 

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -2225,6 +2225,7 @@ func (r *MultiClusterEngineReconciler) ensureNoAllInternalEngineComponents(ctx c
 		backplanev1.ClusterProxyAddon,
 		backplanev1.ConsoleMCE,
 		backplanev1.Discovery,
+		backplanev1.FleetNavigation,
 		backplanev1.Hive,
 		backplanev1.HyperShift,
 		backplanev1.ImageBasedInstallOperator,

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -120,7 +120,7 @@ var (
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs,verbs=get
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs,verbs=list
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs;discoveredclusters,verbs=create;get;list;watch;update;delete;deletecollection;patch;approve;escalate;bind
-// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions;consoles,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update;patch
 
@@ -151,6 +151,7 @@ var (
 // +kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons;clustermanagementaddons/finalizers;managedclusteraddons;managedclusteraddons/finalizers;managedclusteraddons/status,verbs=create;get;list;update;patch;watch;delete;deletecollection
 // +kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addontemplates,verbs=get;list;delete
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=addonplacementscores,verbs=create;get;list;update;patch;watch;delete;deletecollection
 // +kubebuilder:rbac:groups=proxy.open-cluster-management.io,resources=managedproxyconfigurations,verbs=create;get;list;update;patch;watch;delete;deletecollection
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersetbindings,verbs=create;get;list;update;patch;watch;delete;deletecollection
@@ -1015,6 +1016,7 @@ func (r *MultiClusterEngineReconciler) fetchChartOrCRDPath(component string) str
 		backplanev1.ClusterProxyAddon:              toggle.ClusterProxyAddonDir,
 		backplanev1.ConsoleMCE:                     toggle.ConsoleMCEChartsDir,
 		backplanev1.Discovery:                      toggle.DiscoveryChartDir,
+		backplanev1.FleetNavigation:                toggle.FleetNavigationChartDir,
 		backplanev1.Hive:                           toggle.HiveChartDir,
 		backplanev1.HyperShift:                     toggle.HyperShiftChartDir,
 		backplanev1.ImageBasedInstallOperator:      toggle.ImageBasedInstallOperatorChartDir,
@@ -1057,6 +1059,28 @@ func (r *MultiClusterEngineReconciler) ensureToggleableComponents(ctx context.Co
 		}
 	} else {
 		log.Info(messages.SkippingExternallyManaged, "component", backplanev1.ManagedServiceAccount)
+	}
+
+	if !r.isComponentExternallyManaged(backplaneConfig, backplanev1.FleetNavigation) {
+		if backplaneConfig.Enabled(backplanev1.FleetNavigation) && foundation.CanInstallAddons(ctx, r.Client) {
+			result, err := r.ensureFleetNavigation(ctx, backplaneConfig)
+			if result != (ctrl.Result{}) {
+				requeue = true
+			}
+			if err != nil {
+				errs[backplanev1.FleetNavigation] = err
+			}
+		} else {
+			result, err := r.ensureNoFleetNavigation(ctx, backplaneConfig)
+			if result != (ctrl.Result{}) {
+				requeue = true
+			}
+			if err != nil {
+				errs[backplanev1.FleetNavigation] = err
+			}
+		}
+	} else {
+		log.Info(messages.SkippingExternallyManaged, "component", backplanev1.FleetNavigation)
 	}
 
 	if !r.isComponentExternallyManaged(backplaneConfig, backplanev1.ImageBasedInstallOperator) {
@@ -2582,6 +2606,13 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		// Set OCP version as env var, so that charts can render this value
 		os.Setenv("ACM_CLUSTER_INGRESS_DOMAIN", clusterIngressDomain)
 
+		consoleURL, err := r.getConsoleURL(ctx)
+		if err != nil {
+			log.Info("Failed to detect console URL, fleet-navigation link may be empty", "error", err)
+		} else {
+			os.Setenv("ACM_HUB_CONSOLE_URL", consoleURL)
+		}
+
 		// If OCP 4.10+ then set then enable the MCE console. Else ensure it is disabled
 		currentClusterVersion, err := r.getClusterVersion(ctx)
 		if err != nil {
@@ -2790,6 +2821,21 @@ func (r *MultiClusterEngineReconciler) getClusterVersion(ctx context.Context) (s
 }
 
 // +kubebuilder:rbac:groups="config.openshift.io",resources="ingresses",verbs=get;list;watch
+
+func (r *MultiClusterEngineReconciler) getConsoleURL(ctx context.Context) (string, error) {
+	if val, ok := os.LookupEnv("UNIT_TEST"); ok && val == "true" {
+		return "https://console-openshift-console.apps.installer-test-cluster.dev00.red-chesterfield.com", nil
+	}
+
+	console := &configv1.Console{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: "cluster"}, console)
+	if err != nil {
+		r.Log.Error(err, "Failed to get console config")
+		return "", err
+	}
+
+	return console.Status.ConsoleURL, nil
+}
 
 func (r *MultiClusterEngineReconciler) getClusterIngressDomain(ctx context.Context, mce *backplanev1.MultiClusterEngine) (string, error) {
 	// If Unit test

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
@@ -2545,6 +2546,78 @@ func Test_ensureToggleableComponents_withExternallyManagedComponents(t *testing.
 			_, err := recon.ensureToggleableComponents(context.TODO(), tt.mce)
 			if err != tt.want {
 				t.Errorf("ensureToggleableComponents() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getConsoleURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		unitTest  string
+		console   *configv1.Console
+		wantURL   string
+		wantError bool
+	}{
+		{
+			name:     "returns test URL when UNIT_TEST is set",
+			unitTest: "true",
+			wantURL:  "https://console-openshift-console.apps.installer-test-cluster.dev00.red-chesterfield.com",
+		},
+		{
+			name: "returns console URL from cluster resource",
+			console: &configv1.Console{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     configv1.ConsoleStatus{ConsoleURL: "https://console.example.com"},
+			},
+			wantURL: "https://console.example.com",
+		},
+		{
+			name: "returns error when console URL is empty",
+			console: &configv1.Console{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			},
+			wantError: true,
+		},
+		{
+			name:      "returns error when console resource does not exist",
+			wantError: true,
+		},
+	}
+
+	registerScheme()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unitTest != "" {
+				os.Setenv("UNIT_TEST", tt.unitTest)
+				defer os.Unsetenv("UNIT_TEST")
+			} else {
+				os.Unsetenv("UNIT_TEST")
+			}
+
+			objs := []client.Object{}
+			if tt.console != nil {
+				objs = append(objs, tt.console)
+			}
+			cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).WithStatusSubresource(objs...).Build()
+			r := &MultiClusterEngineReconciler{
+				Client: cl,
+				Scheme: scheme.Scheme,
+				Log:    logr.Discard(),
+			}
+
+			url, err := r.getConsoleURL(context.TODO())
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if url != tt.wantURL {
+				t.Errorf("got URL %q, want %q", url, tt.wantURL)
 			}
 		})
 	}

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -2469,7 +2469,7 @@ func Test_ensureToggleableComponents_withExternallyManagedComponents(t *testing.
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-mce",
 					Annotations: map[string]string{
-						utils.AnnotationExternallyManaged: `["managedserviceaccount","image-based-install-operator","hypershift","console-mce","discovery","hive","assisted-service","cluster-lifecycle","cluster-manager","cluster-permission","server-foundation","cluster-proxy-addon","cluster-api","cluster-api-provider-aws","cluster-api-provider-azure-preview","cluster-api-provider-metal3-preview","cluster-api-provider-openshift-assisted","local-cluster"]`,
+						utils.AnnotationExternallyManaged: `["managedserviceaccount","image-based-install-operator","hypershift","console-mce","discovery","fleet-navigation","hive","assisted-service","cluster-lifecycle","cluster-manager","cluster-permission","server-foundation","cluster-proxy-addon","cluster-api","cluster-api-provider-aws","cluster-api-provider-azure-preview","cluster-api-provider-metal3-preview","cluster-api-provider-openshift-assisted","local-cluster"]`,
 					},
 				},
 				Spec: backplanev1.MultiClusterEngineSpec{
@@ -2482,6 +2482,7 @@ func Test_ensureToggleableComponents_withExternallyManagedComponents(t *testing.
 							{Name: backplanev1.HyperShift, Enabled: true},
 							{Name: backplanev1.ConsoleMCE, Enabled: true},
 							{Name: backplanev1.Discovery, Enabled: true},
+							{Name: backplanev1.FleetNavigation, Enabled: true},
 							{Name: backplanev1.Hive, Enabled: true},
 							{Name: backplanev1.AssistedService, Enabled: true},
 							{Name: backplanev1.ClusterLifecycle, Enabled: true},

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -449,6 +449,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: true,
 								},
 								{
+									Name:    backplanev1.FleetNavigation,
+									Enabled: true,
+								},
+								{
 									Name:    backplanev1.Hive,
 									Enabled: true,
 								},
@@ -641,6 +645,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 								},
 								{
 									Name:    backplanev1.Discovery,
+									Enabled: false,
+								},
+								{
+									Name:    backplanev1.FleetNavigation,
 									Enabled: false,
 								},
 								{
@@ -943,6 +951,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 									Enabled: true,
 								},
 								{
+									Name:    backplanev1.FleetNavigation,
+									Enabled: true,
+								},
+								{
 									Name:    backplanev1.Hive,
 									Enabled: true,
 								},
@@ -1068,6 +1080,10 @@ var _ = Describe("BackplaneConfig controller", func() {
 								},
 								{
 									Name:    backplanev1.Discovery,
+									Enabled: false,
+								},
+								{
+									Name:    backplanev1.FleetNavigation,
 									Enabled: false,
 								},
 								{

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -2470,7 +2470,15 @@ func Test_ensureToggleableComponents_withExternallyManagedComponents(t *testing.
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-mce",
 					Annotations: map[string]string{
-						utils.AnnotationExternallyManaged: `["managedserviceaccount","image-based-install-operator","hypershift","console-mce","discovery","fleet-navigation","hive","assisted-service","cluster-lifecycle","cluster-manager","cluster-permission","server-foundation","cluster-proxy-addon","cluster-api","cluster-api-provider-aws","cluster-api-provider-azure-preview","cluster-api-provider-metal3-preview","cluster-api-provider-openshift-assisted","local-cluster"]`,
+						utils.AnnotationExternallyManaged: `[` +
+							`"managedserviceaccount","image-based-install-operator",` +
+							`"hypershift","console-mce","discovery","fleet-navigation",` +
+							`"hive","assisted-service","cluster-lifecycle","cluster-manager",` +
+							`"cluster-permission","server-foundation","cluster-proxy-addon",` +
+							`"cluster-api","cluster-api-provider-aws",` +
+							`"cluster-api-provider-azure-preview",` +
+							`"cluster-api-provider-metal3-preview",` +
+							`"cluster-api-provider-openshift-assisted","local-cluster"]`,
 					},
 				},
 				Spec: backplanev1.MultiClusterEngineSpec{
@@ -2589,9 +2597,9 @@ func Test_getConsoleURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.unitTest != "" {
-				os.Setenv("UNIT_TEST", tt.unitTest)
-				defer os.Unsetenv("UNIT_TEST")
-			} else {
+				t.Setenv("UNIT_TEST", tt.unitTest)
+			} else if _, ok := os.LookupEnv("UNIT_TEST"); ok {
+				t.Setenv("UNIT_TEST", "")
 				os.Unsetenv("UNIT_TEST")
 			}
 

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -241,6 +241,84 @@ func (r *MultiClusterEngineReconciler) ensureNoManagedServiceAccount(ctx context
 	return ctrl.Result{}, nil
 }
 
+func (r *MultiClusterEngineReconciler) ensureFleetNavigation(ctx context.Context,
+	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
+
+	r.StatusManager.RemoveComponent(toggle.DisabledStatus(types.NamespacedName{Name: "fleet-navigation",
+		Namespace: mce.Spec.TargetNamespace}, []*unstructured.Unstructured{}))
+
+	r.StatusManager.AddComponent(status.NewPresentStatus(types.NamespacedName{Name: "fleet-navigation"},
+		clusterManagementAddOnGVK))
+
+	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.FleetNavigation); err != nil {
+		return result, err
+	}
+
+	chartPath := r.fetchChartOrCRDPath(backplanev1.FleetNavigation)
+	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
+
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Info(err.Error())
+		}
+		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
+	}
+
+	missingCRDErrorOccured := false
+	for _, template := range templates {
+		applyReleaseVersionAnnotation(template)
+		result, err := r.applyTemplate(ctx, mce, template)
+		if err != nil {
+			if apimeta.IsNoMatchError(errors.Unwrap(err)) || apierrors.IsNotFound(err) {
+				log.Info("Couldn't apply template for fleet-navigation due to missing CRD", "error is", err.Error())
+				missingCRDErrorOccured = true
+				r.StatusManager.AddComponent(clusterManagementAddOnNotFoundStatus("fleet-navigation",
+					mce.Spec.TargetNamespace))
+			} else {
+				return result, err
+			}
+		}
+	}
+
+	if missingCRDErrorOccured {
+		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterEngineReconciler) ensureNoFleetNavigation(ctx context.Context,
+	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
+
+	if result, err := r.ensureNoInternalEngineComponent(ctx, mce,
+		backplanev1.FleetNavigation); (result != ctrl.Result{}) || err != nil {
+		return result, err
+	}
+
+	chartPath := r.fetchChartOrCRDPath(backplanev1.FleetNavigation)
+	templates, errs := renderer.RenderChart(chartPath, mce, r.CacheSpec.ImageOverrides, r.CacheSpec.TemplateOverrides)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Info(err.Error())
+		}
+		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
+	}
+
+	r.StatusManager.AddComponent(toggle.DisabledStatus(types.NamespacedName{Name: "fleet-navigation",
+		Namespace: mce.Spec.TargetNamespace}, []*unstructured.Unstructured{}))
+
+	for _, template := range templates {
+		if template.GetKind() == foundation.ClusterManagementAddonKind && !foundation.CanInstallAddons(ctx, r.Client) {
+			continue
+		}
+		result, err := r.deleteTemplate(ctx, mce, template)
+		if err != nil {
+			log.Error(err, "Failed to delete fleet-navigation template")
+			return result, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
 // addPluginToConsoleResource ...
 func (r *MultiClusterEngineReconciler) addPluginToConsoleResource(ctx context.Context) (ctrl.Result, error) {
 	console := &operatorv1.Console{}

--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -244,10 +244,10 @@ func (r *MultiClusterEngineReconciler) ensureNoManagedServiceAccount(ctx context
 func (r *MultiClusterEngineReconciler) ensureFleetNavigation(ctx context.Context,
 	mce *backplanev1.MultiClusterEngine) (ctrl.Result, error) {
 
-	r.StatusManager.RemoveComponent(toggle.DisabledStatus(types.NamespacedName{Name: "fleet-navigation",
+	r.StatusManager.RemoveComponent(toggle.DisabledStatus(types.NamespacedName{Name: backplanev1.FleetNavigation,
 		Namespace: mce.Spec.TargetNamespace}, []*unstructured.Unstructured{}))
 
-	r.StatusManager.AddComponent(status.NewPresentStatus(types.NamespacedName{Name: "fleet-navigation"},
+	r.StatusManager.AddComponent(status.NewPresentStatus(types.NamespacedName{Name: backplanev1.FleetNavigation},
 		clusterManagementAddOnGVK))
 
 	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.FleetNavigation); err != nil {
@@ -272,7 +272,7 @@ func (r *MultiClusterEngineReconciler) ensureFleetNavigation(ctx context.Context
 			if apimeta.IsNoMatchError(errors.Unwrap(err)) || apierrors.IsNotFound(err) {
 				log.Info("Couldn't apply template for fleet-navigation due to missing CRD", "error is", err.Error())
 				missingCRDErrorOccured = true
-				r.StatusManager.AddComponent(clusterManagementAddOnNotFoundStatus("fleet-navigation",
+				r.StatusManager.AddComponent(clusterManagementAddOnNotFoundStatus(backplanev1.FleetNavigation,
 					mce.Spec.TargetNamespace))
 			} else {
 				return result, err
@@ -303,7 +303,7 @@ func (r *MultiClusterEngineReconciler) ensureNoFleetNavigation(ctx context.Conte
 		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
 	}
 
-	r.StatusManager.AddComponent(toggle.DisabledStatus(types.NamespacedName{Name: "fleet-navigation",
+	r.StatusManager.AddComponent(toggle.DisabledStatus(types.NamespacedName{Name: backplanev1.FleetNavigation,
 		Namespace: mce.Spec.TargetNamespace}, []*unstructured.Unstructured{}))
 
 	for _, template := range templates {

--- a/controllers/toggle_components_test.go
+++ b/controllers/toggle_components_test.go
@@ -1472,54 +1472,91 @@ func Test_ensureFleetNavigation(t *testing.T) {
 	os.Setenv("DIRECTORY_OVERRIDE", "../")
 	defer os.Unsetenv("DIRECTORY_OVERRIDE")
 
-	ctx := context.TODO()
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
-	r := newFleetNavReconciler(ns)
-	mce := fleetNavMCE()
+	t.Run("creates InternalEngineComponent and renders templates", func(t *testing.T) {
+		ctx := context.TODO()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+		r := newFleetNavReconciler(ns)
+		mce := fleetNavMCE()
 
-	result, err := r.ensureFleetNavigation(ctx, mce)
-	if err != nil {
-		t.Fatalf("ensureFleetNavigation() returned error: %v", err)
-	}
-	if result != (ctrl.Result{}) {
-		t.Fatalf("ensureFleetNavigation() returned non-zero result: %v", result)
-	}
+		result, err := r.ensureFleetNavigation(ctx, mce)
+		if err != nil {
+			t.Fatalf("ensureFleetNavigation() returned error: %v", err)
+		}
+		if result != (ctrl.Result{}) {
+			t.Fatalf("ensureFleetNavigation() returned non-zero result: %v", result)
+		}
 
-	iec := &backplanev1.InternalEngineComponent{}
-	if err := r.Client.Get(ctx, types.NamespacedName{
-		Name: backplanev1.FleetNavigation, Namespace: "test-ns",
-	}, iec); err != nil {
-		t.Errorf("expected InternalEngineComponent to exist: %v", err)
-	}
+		iec := &backplanev1.InternalEngineComponent{}
+		if err := r.Client.Get(ctx, types.NamespacedName{
+			Name: backplanev1.FleetNavigation, Namespace: "test-ns",
+		}, iec); err != nil {
+			t.Errorf("expected InternalEngineComponent to exist: %v", err)
+		}
+	})
+
+	t.Run("is idempotent on second call", func(t *testing.T) {
+		ctx := context.TODO()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+		r := newFleetNavReconciler(ns)
+		mce := fleetNavMCE()
+
+		if _, err := r.ensureFleetNavigation(ctx, mce); err != nil {
+			t.Fatalf("first call failed: %v", err)
+		}
+		result, err := r.ensureFleetNavigation(ctx, mce)
+		if err != nil {
+			t.Fatalf("second call returned error: %v", err)
+		}
+		if result != (ctrl.Result{}) {
+			t.Fatalf("second call returned non-zero result: %v", result)
+		}
+	})
+
 }
 
 func Test_ensureNoFleetNavigation(t *testing.T) {
 	os.Setenv("DIRECTORY_OVERRIDE", "../")
 	defer os.Unsetenv("DIRECTORY_OVERRIDE")
 
-	ctx := context.TODO()
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
-	r := newFleetNavReconciler(ns)
-	mce := fleetNavMCE()
+	t.Run("deletes InternalEngineComponent and templates", func(t *testing.T) {
+		ctx := context.TODO()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+		r := newFleetNavReconciler(ns)
+		mce := fleetNavMCE()
 
-	// First ensure, so there is something to delete.
-	if _, err := r.ensureFleetNavigation(ctx, mce); err != nil {
-		t.Fatalf("setup ensureFleetNavigation() failed: %v", err)
-	}
+		if _, err := r.ensureFleetNavigation(ctx, mce); err != nil {
+			t.Fatalf("setup ensureFleetNavigation() failed: %v", err)
+		}
 
-	result, err := r.ensureNoFleetNavigation(ctx, mce)
-	if err != nil {
-		t.Fatalf("ensureNoFleetNavigation() returned error: %v", err)
-	}
-	if result != (ctrl.Result{}) {
-		t.Fatalf("ensureNoFleetNavigation() returned non-zero result: %v", result)
-	}
+		result, err := r.ensureNoFleetNavigation(ctx, mce)
+		if err != nil {
+			t.Fatalf("ensureNoFleetNavigation() returned error: %v", err)
+		}
+		if result != (ctrl.Result{}) {
+			t.Fatalf("ensureNoFleetNavigation() returned non-zero result: %v", result)
+		}
 
-	iec := &backplanev1.InternalEngineComponent{}
-	err = r.Client.Get(ctx, types.NamespacedName{
-		Name: backplanev1.FleetNavigation, Namespace: "test-ns",
-	}, iec)
-	if !apierrors.IsNotFound(err) {
-		t.Errorf("expected InternalEngineComponent to be deleted, got: %v", err)
-	}
+		iec := &backplanev1.InternalEngineComponent{}
+		err = r.Client.Get(ctx, types.NamespacedName{
+			Name: backplanev1.FleetNavigation, Namespace: "test-ns",
+		}, iec)
+		if !apierrors.IsNotFound(err) {
+			t.Errorf("expected InternalEngineComponent to be deleted, got: %v", err)
+		}
+	})
+
+	t.Run("succeeds when nothing to delete", func(t *testing.T) {
+		ctx := context.TODO()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+		r := newFleetNavReconciler(ns)
+		mce := fleetNavMCE()
+
+		result, err := r.ensureNoFleetNavigation(ctx, mce)
+		if err != nil {
+			t.Fatalf("ensureNoFleetNavigation() returned error: %v", err)
+		}
+		if result != (ctrl.Result{}) {
+			t.Fatalf("ensureNoFleetNavigation() returned non-zero result: %v", result)
+		}
+	})
 }

--- a/controllers/toggle_components_test.go
+++ b/controllers/toggle_components_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"os"
 	"reflect"
 	"testing"
 
@@ -17,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -1430,5 +1432,94 @@ func Test_driversMatch(t *testing.T) {
 				t.Errorf("driversMatch() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func newFleetNavReconciler(objs ...runtime.Object) *MultiClusterEngineReconciler {
+	s := runtime.NewScheme()
+	corev1.AddToScheme(s)
+	backplanev1.AddToScheme(s)
+	addonv1alpha1.AddToScheme(s)
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+	return &MultiClusterEngineReconciler{
+		Client:        cl,
+		Scheme:        s,
+		StatusManager: &status.StatusTracker{Client: cl},
+		CacheSpec: CacheSpec{
+			ImageOverrides:    map[string]string{},
+			TemplateOverrides: map[string]string{},
+		},
+	}
+}
+
+func fleetNavMCE() *backplanev1.MultiClusterEngine {
+	return &backplanev1.MultiClusterEngine{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mce"},
+		Spec: backplanev1.MultiClusterEngineSpec{
+			TargetNamespace:  "test-ns",
+			LocalClusterName: "local-cluster",
+			Overrides: &backplanev1.Overrides{
+				Components: []backplanev1.ComponentConfig{
+					{Name: backplanev1.FleetNavigation, Enabled: true},
+				},
+			},
+		},
+	}
+}
+
+func Test_ensureFleetNavigation(t *testing.T) {
+	os.Setenv("DIRECTORY_OVERRIDE", "../")
+	defer os.Unsetenv("DIRECTORY_OVERRIDE")
+
+	ctx := context.TODO()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+	r := newFleetNavReconciler(ns)
+	mce := fleetNavMCE()
+
+	result, err := r.ensureFleetNavigation(ctx, mce)
+	if err != nil {
+		t.Fatalf("ensureFleetNavigation() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("ensureFleetNavigation() returned non-zero result: %v", result)
+	}
+
+	iec := &backplanev1.InternalEngineComponent{}
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Name: backplanev1.FleetNavigation, Namespace: "test-ns",
+	}, iec); err != nil {
+		t.Errorf("expected InternalEngineComponent to exist: %v", err)
+	}
+}
+
+func Test_ensureNoFleetNavigation(t *testing.T) {
+	os.Setenv("DIRECTORY_OVERRIDE", "../")
+	defer os.Unsetenv("DIRECTORY_OVERRIDE")
+
+	ctx := context.TODO()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+	r := newFleetNavReconciler(ns)
+	mce := fleetNavMCE()
+
+	// First ensure, so there is something to delete.
+	if _, err := r.ensureFleetNavigation(ctx, mce); err != nil {
+		t.Fatalf("setup ensureFleetNavigation() failed: %v", err)
+	}
+
+	result, err := r.ensureNoFleetNavigation(ctx, mce)
+	if err != nil {
+		t.Fatalf("ensureNoFleetNavigation() returned error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("ensureNoFleetNavigation() returned non-zero result: %v", result)
+	}
+
+	iec := &backplanev1.InternalEngineComponent{}
+	err = r.Client.Get(ctx, types.NamespacedName{
+		Name: backplanev1.FleetNavigation, Namespace: "test-ns",
+	}, iec)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected InternalEngineComponent to be deleted, got: %v", err)
 	}
 }

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -77,6 +77,8 @@ type HubConfig struct {
 	ClusterIngressDomain string            `json:"clusterIngressDomain" structs:"clusterIngressDomain"`
 	HubType              string            `json:"hubType" structs:"hubType"`
 	EnableFlightCtl      bool              `json:"enableFlightCtl" structs:"enableFlightCtl"`
+	ConsoleURL           string            `json:"consoleURL" structs:"consoleURL"`
+	LocalClusterName     string            `json:"localClusterName" structs:"localClusterName"`
 }
 
 type ProbeConfig struct {
@@ -477,6 +479,10 @@ func injectValuesOverrides(values *Values, backplaneConfig *v1.MultiClusterEngin
 	values.HubConfig.OCPVersion = os.Getenv("ACM_HUB_OCP_VERSION")
 
 	values.HubConfig.ClusterIngressDomain = os.Getenv("ACM_CLUSTER_INGRESS_DOMAIN")
+
+	values.HubConfig.ConsoleURL = os.Getenv("ACM_HUB_CONSOLE_URL")
+
+	values.HubConfig.LocalClusterName = backplaneConfig.Spec.LocalClusterName
 
 	values.HubConfig.HubType = utils.GetHubType(backplaneConfig)
 

--- a/pkg/templates/charts/toggle/fleet-navigation/Chart.yaml
+++ b/pkg/templates/charts/toggle/fleet-navigation/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.0.0
+description: A Helm chart for Fleet Navigation Addon
+name: fleet-navigation
+type: application
+version: '1.0'

--- a/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-addondeploymentconfig.yaml
+++ b/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-addondeploymentconfig.yaml
@@ -24,10 +24,15 @@ spec:
   - name: LINK_TEXT
     value: Go to the hub cluster console
   nodePlacement:
+    {{- if .Values.hubconfig.nodeSelector }}
     nodeSelector:
       {{- range $key, $val := .Values.hubconfig.nodeSelector }}
       {{ $key }}: {{ $val | quote }}
       {{- end }}
+    {{- else }}
+    nodeSelector: {}
+    {{- end }}
+    {{- if .Values.hubconfig.tolerations }}
     tolerations:
       {{- range .Values.hubconfig.tolerations }}
       - {{ if .Key }}key: {{ .Key }}{{- end }}
@@ -36,3 +41,6 @@ spec:
         {{ if .Effect }}effect: {{ .Effect }}{{- end }}
         {{ if .TolerationSeconds }}tolerationSeconds: {{ .TolerationSeconds }}{{- end }}
       {{- end }}
+    {{- else }}
+    tolerations: []
+    {{- end }}

--- a/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-addondeploymentconfig.yaml
+++ b/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-addondeploymentconfig.yaml
@@ -1,0 +1,38 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: fleet-navigation
+  namespace: {{ .Values.global.namespace }}
+spec:
+  customizedVariables:
+  - name: TEXT_PREFIX
+    value: 'Cluster '
+  - name: TEXT_POSTFIX
+{{- if .Values.hubconfig.localClusterName }}
+    value: ' is managed by {{ .Values.hubconfig.localClusterName }}.'
+{{- else }}
+    value: ' is managed by a hub cluster.'
+{{- end }}
+  - name: LOCATION
+    value: BannerTop
+  - name: COLOR
+    value: 'var(--pf-v6-c-banner--Color, var(--pf-v5-global--Color--light-100))'
+  - name: BACKGROUND_COLOR
+    value: 'var(--pf-v6-c-banner--BackgroundColor, var(--pf-v5-global--BackgroundColor--dark-400))'
+  - name: LINK_HREF
+    value: '{{ .Values.hubconfig.consoleURL }}'
+  - name: LINK_TEXT
+    value: Go to the hub cluster console
+  nodePlacement:
+    nodeSelector:
+      {{- range $key, $val := .Values.hubconfig.nodeSelector }}
+      {{ $key }}: {{ $val | quote }}
+      {{- end }}
+    tolerations:
+      {{- range .Values.hubconfig.tolerations }}
+      - {{ if .Key }}key: {{ .Key }}{{- end }}
+        {{ if .Operator }}operator: {{ .Operator }}{{- end }}
+        {{ if .Value }}value: {{ .Value }}{{- end }}
+        {{ if .Effect }}effect: {{ .Effect }}{{- end }}
+        {{ if .TolerationSeconds }}tolerationSeconds: {{ .TolerationSeconds }}{{- end }}
+      {{- end }}

--- a/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-addontemplate.yaml
+++ b/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-addontemplate.yaml
@@ -1,0 +1,40 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: fleet-navigation
+spec:
+  addonName: fleet-navigation
+  agentSpec:
+    workload:
+      manifests:
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          labels:
+            open-cluster-management.io/aggregate-to-work: 'true'
+          name: open-cluster-management:fleet-navigation:agent
+        rules:
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consolenotifications
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+      - apiVersion: console.openshift.io/v1
+        kind: ConsoleNotification
+        metadata:
+          name: fleet-navigation-{{ `{{CLUSTER_NAME}}` }}
+        spec:
+          backgroundColor: '{{ `{{BACKGROUND_COLOR}}` }}'
+          color: '{{ `{{COLOR}}` }}'
+          link:
+            href: '{{ `{{LINK_HREF}}` }}'
+            text: '{{ `{{LINK_TEXT}}` }}'
+          location: '{{ `{{LOCATION}}` }}'
+          text: '{{ `{{TEXT_PREFIX}}` }}{{ `{{CLUSTER_NAME}}` }}{{ `{{TEXT_POSTFIX}}` }}'

--- a/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-clustermanagementaddon.yaml
@@ -1,0 +1,27 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  annotations:
+    addon.open-cluster-management.io/lifecycle: addon-manager
+  name: fleet-navigation
+spec:
+  addOnMeta:
+    description: fleet-navigation
+    displayName: fleet-navigation
+  installStrategy:
+    placements:
+    - name: fleet-navigation
+      namespace: open-cluster-management-global-set
+      rolloutStrategy:
+        type: All
+    type: Placements
+  supportedConfigs:
+  - defaultConfig:
+      name: fleet-navigation
+      namespace: {{ .Values.global.namespace }}
+    group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+  - defaultConfig:
+      name: fleet-navigation
+    group: addon.open-cluster-management.io
+    resource: addontemplates

--- a/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-placement.yaml
+++ b/pkg/templates/charts/toggle/fleet-navigation/templates/fleet-navigation-placement.yaml
@@ -1,0 +1,28 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: fleet-navigation
+  namespace: open-cluster-management-global-set
+spec:
+  clusterSets:
+  - global
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: vendor
+          operator: In
+          values:
+          - OpenShift
+        - key: fleet-navigation
+          operator: NotIn
+          values:
+          - disabled
+        - key: name
+          operator: NotIn
+          values:
+{{- if .Values.hubconfig.localClusterName }}
+          - {{ .Values.hubconfig.localClusterName }}
+{{- else }}
+          - local-cluster
+{{- end }}

--- a/pkg/templates/charts/toggle/fleet-navigation/values.yaml
+++ b/pkg/templates/charts/toggle/fleet-navigation/values.yaml
@@ -1,0 +1,10 @@
+global:
+  deployOnOCP: true
+  namespace: default
+  pullSecret: null
+  templateOverrides: {}
+hubconfig:
+  clusterIngressDomain: ''
+  consoleURL: ''
+  localClusterName: ''
+org: open-cluster-management

--- a/pkg/templates/rbac.go
+++ b/pkg/templates/rbac.go
@@ -40,7 +40,8 @@ const (
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons,verbs=create;get;list;update;patch;watch;delete
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=create;get;list;update;patch;watch;delete
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addontemplates,verbs=create;get;list;update;patch;watch;delete
-//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=console.openshift.io,resources=consolenotifications;consoleplugins;consolequickstarts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;update;list;watch;delete;patch
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;create;update;list;watch;delete;patch
 //+kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;create;update;list;watch;delete;patch
@@ -57,6 +58,7 @@ var resources = []string{
 	"ClusterRole",
 	"ClusterRoleBinding",
 	"ConfigMap",
+	"ConsoleNotification",
 	"ConsolePlugin",
 	"ConsoleQuickStart",
 	"CustomResourceDefinition",
@@ -66,6 +68,7 @@ var resources = []string{
 	"MutatingWebhookConfiguration",
 	"Namespace",
 	"NetworkPolicy",
+	"Placement",
 	"PodDisruptionBudget",
 	"PrometheusRule",
 	"Role",

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -38,6 +38,7 @@ const (
 	ClusterProxyAddonDir               = "pkg/templates/charts/toggle/cluster-proxy-addon"
 	ConsoleMCEChartsDir                = "pkg/templates/charts/toggle/console-mce"
 	DiscoveryChartDir                  = "pkg/templates/charts/toggle/discovery-operator"
+	FleetNavigationChartDir            = "pkg/templates/charts/toggle/fleet-navigation"
 	HiveChartDir                       = "pkg/templates/charts/toggle/hive-operator"
 	HostedImportChartDir               = "pkg/templates/charts/hosted/server-foundation"
 	HostingImportChartDir              = "pkg/templates/charts/hosting/server-foundation"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -54,6 +54,7 @@ var onComponents = []string{
 	backplanev1.ClusterManager,
 	backplanev1.ClusterPermission,
 	backplanev1.Discovery,
+	backplanev1.FleetNavigation,
 	backplanev1.Hive,
 	backplanev1.ServerFoundation,
 	backplanev1.ClusterProxyAddon,


### PR DESCRIPTION
# Description

Implement the fleet-navigation component, which deploys an add-on that installs a banner on managed clusters with a link back to the hub

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.
https://redhat.atlassian.net/browse/ACM-36254

## Changes Made

ACM-36254 adds a ConsoleNotification banner to managed OpenShift clusters that tells users which hub manages them and links back to the hub console. This is implemented as an OCM addon (fleet-navigation) using the AddOnTemplate API, deployed entirely through backplane-operator chart rendering — no new repositories needed.

The addon deploys two resources to each qualifying managed cluster: an aggregating ClusterRole (granting the work agent permission to manage consolenotifications) and a ConsoleNotification CR (the banner itself). Selection is handled by a Placement resource that targets OpenShift clusters, excludes local-cluster, and respects per-cluster opt-out via a fleet-navigation=disabled label.

## Screenshots (if applicable)

<img width="1729" height="995" alt="image" src="https://github.com/user-attachments/assets/71ac1c43-4cf3-4847-91e2-35213a65aa10" />

<img width="1729" height="995" alt="image" src="https://github.com/user-attachments/assets/3732e7c7-19d3-48f1-8355-c549c5aa2b5d" />


## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added **Fleet Navigation** as a supported, default-enabled component, including new Helm charts/templates for deployment, placement, console notifications, and add-on configuration.

* **Improvements**
  * Enhanced template rendering with **hub console URL** and **local cluster name** for banner/link personalization.
  * Reconciliation now creates/updates Fleet Navigation when enabled and removes it when disabled (skipping when externally managed).

* **Permissions**
  * Expanded operator and generated RBAC to support additional console access and **placements**, plus console notification resources.

* **Tests**
  * Added unit coverage for Fleet Navigation reconciliation and console URL detection, including error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->