### PR TITLE
ACM-37777: bump Go to 1.25.11 to resolve stdlib CVEs

### DIFF
--- a/.github/workflows/rbac-gen.yml
+++ b/.github/workflows/rbac-gen.yml
@@ -12,10 +12,6 @@ defaults:
 jobs:
   rbac-check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go:
-          - '1.25.11'
     name: Generate role permissions
     steps:
     - name: Checkout backplane
@@ -23,11 +19,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Go - ${{ matrix.go }}
+    - name: Set up Go
       uses: actions/setup-go@v2
       id: go
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: go.mod
 
     - name: Verify modules
       run: |

--- a/.github/workflows/rbac-gen.yml
+++ b/.github/workflows/rbac-gen.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.25.7'
+          - '1.25.11'
     name: Generate role permissions
     steps:
     - name: Checkout backplane

--- a/.github/workflows/rbac-gen.yml
+++ b/.github/workflows/rbac-gen.yml
@@ -15,13 +15,10 @@ jobs:
     name: Generate role permissions
     steps:
     - name: Checkout backplane
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v2
-      id: go
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/backplane-operator
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
## Summary

Bumps the Go version from 1.25.7 to 1.25.11 to resolve 11 Go stdlib CVEs flagged against the backplane-rhel9-operator image.

## CVEs Resolved

| CVE | Severity | Component |
|-----|----------|-----------|
| CVE-2026-27145 | High | crypto/x509 — DoS via excessive DNS SAN entries |
| CVE-2026-39836 | High | net — DoS via NUL byte in Dial/LookupPort |
| CVE-2026-39823 | Medium | html/template — XSS via improper URL escaping |
| CVE-2026-33811 | High | net — DoS via long CNAME response |
| CVE-2026-39825 | Medium | net/http/httputil — ReverseProxy forwards hidden query params |
| CVE-2026-42507 | Medium | net/textproto — misleading error messages via injection |
| CVE-2026-33814 | High | HTTP/2 — DoS via malformed SETTINGS_MAX_FRAME_SIZE |
| CVE-2026-39826 | Medium | html/template — XSS via incorrect script tag escaping |
| CVE-2026-42499 | High | net/mail — DoS via pathological email address parsing |
| CVE-2026-39820 | High | net/mail — DoS via crafted email inputs |
| CVE-2026-42504 | High | MIME — DoS via maliciously-crafted MIME header |

Jira: https://redhat.atlassian.net/browse/ACM-37777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to 1.25.11 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->