### PR TITLE
ACM-31164: Test and validate network policies for Image Based components

### DIFF
--- a/pkg/templates/charts/toggle/image-based-install-operator/templates/image-based-install-operator-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/image-based-install-operator/templates/image-based-install-operator-networkpolicy.yaml
@@ -1,0 +1,66 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: image-based-install-operator-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: image-based-install-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - protocol: TCP
+      port: 8000
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+    ports:
+    - protocol: TCP
+      port: 8080
+  - ports:
+    - protocol: TCP
+      port: 9443
+  - ports:
+    - protocol: TCP
+      port: 8000
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: apiserver
+    ports:
+    - protocol: TCP
+      port: 6443
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 6443
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32
+    ports:
+    - protocol: TCP
+      port: 443

--- a/pkg/templates/charts/toggle/image-based-install-operator/templates/image-based-install-operator-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/image-based-install-operator/templates/image-based-install-operator-networkpolicy.yaml
@@ -1,66 +1,64 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: image-based-install-operator-network-policy
+  name: image-based-install-operator
+  labels:
+    app: image-based-install-operator
 spec:
   podSelector:
     matchLabels:
       app: image-based-install-operator
   policyTypes:
-  - Ingress
-  - Egress
+    - Ingress
+    - Egress
   ingress:
-  - from:
-    - podSelector: {}
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          network.openshift.io/policy-group: ingress
-    ports:
-    - protocol: TCP
-      port: 8000
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          network.openshift.io/policy-group: monitoring
-    ports:
-    - protocol: TCP
-      port: 8080
-  - ports:
-    - protocol: TCP
-      port: 9443
-  - ports:
-    - protocol: TCP
-      port: 8000
+    # Same-namespace traffic
+    - from:
+        - podSelector: {}
+    # Metrics scraping from openshift-monitoring
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Webhook calls from kube-apiserver
+    - ports:
+        - protocol: TCP
+          port: 9443
+    # Image server - Ironic/BMC downloads ISOs (source IPs vary)
+    - ports:
+        - protocol: TCP
+          port: 8000
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-dns
-    ports:
-    - protocol: UDP
-      port: 5353
-    - protocol: TCP
-      port: 5353
-  - to:
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: apiserver
-    ports:
-    - protocol: TCP
-      port: 6443
-  - to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    ports:
-    - protocol: TCP
-      port: 6443
-  - to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-        except:
-        - 169.254.169.254/32
-    ports:
-    - protocol: TCP
-      port: 443
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Kubernetes API and spoke cluster API servers (dynamic IPs)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 6443
+    # HTTPS egress (registries, external services)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
## Summary

- Adds a `NetworkPolicy` for the `image-based-install-operator` in the MCE namespace
- Follows the same pattern as the hypershift-addon-manager NetworkPolicy (PR #3463)
- Restricts ingress to known ports and egress to required destinations per the ACM 5.0 DDR

## NetworkPolicy Details

**Ingress:**
- Same-namespace traffic (podSelector: {})
- OpenShift router → port 8000 (image server)
- Monitoring → port 8080 (metrics)
- Any → port 9443 (webhook, called by kube-apiserver)
- Any → port 8000 (image server, called by Ironic/BMC)

**Egress:**
- DNS (openshift-dns, port 5353)
- Kubernetes API (port 6443)
- Spoke cluster API servers (0.0.0.0/0, port 6443)
- HTTPS (0.0.0.0/0, port 443, excluding AWS metadata)

## Related

- Jira: [ACM-31164](https://redhat.atlassian.net/browse/ACM-31164)
- Also resolves: [ACM-37746](https://redhat.atlassian.net/browse/ACM-37746), [ACM-36702](https://redhat.atlassian.net/browse/ACM-36702)
- Component repo PR: [openshift/image-based-install-operator#847](https://github.com/openshift/image-based-install-operator/pull/847)
- Reference: HyperShift NetworkPolicy PR #3463

[ACM-31164]: https://redhat.atlassian.net/browse/ACM-31164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-37746]: https://redhat.atlassian.net/browse/ACM-37746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36702]: https://redhat.atlassian.net/browse/ACM-36702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added network traffic controls for the image-based installation operator.
  * Permitted required access for monitoring, webhooks, image services, DNS, the Kubernetes API, and HTTPS connections.
  * Restricted unauthorized inbound and outbound traffic, including access to the instance metadata endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->