### PR TITLE
ACM-31165: Test and validate network policies for Infrastructure Operator components

### DIFF
--- a/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/templates/infrastructure-operator-networkpolicy.yaml
@@ -1,0 +1,60 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: infrastructure-operator
+  labels:
+    control-plane: infrastructure-operator
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: infrastructure-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic
+    - from:
+        - podSelector: {}
+    # Monitoring
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Webhook calls from kube-apiserver
+    - ports:
+        - protocol: TCP
+          port: 9443
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Kubernetes API
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              component: apiserver
+      ports:
+        - protocol: TCP
+          port: 6443
+    # HTTPS egress (registries for image lookups)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
## Summary

Adds a NetworkPolicy template for the infrastructure-operator pod in the assisted-service chart.

The assisted-service and assisted-image-service NetworkPolicies are NOT included here — they are created dynamically by the infrastructure-operator itself via AgentServiceConfig reconciliation (see component repo PR).

## Related

- Jira: [ACM-31165](https://redhat.atlassian.net/browse/ACM-31165)
- Also resolves: [ACM-37747](https://redhat.atlassian.net/browse/ACM-37747)
- Component repo PR: [openshift/assisted-service#10670](https://github.com/openshift/assisted-service/pull/10670)

[ACM-31165]: https://redhat.atlassian.net/browse/ACM-31165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-37747]: https://redhat.atlassian.net/browse/ACM-37747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network traffic policies for the Infrastructure Operator.
  * Enabled required monitoring and webhook access.
  * Permitted DNS, Kubernetes API, and HTTPS connectivity while restricting other inbound and outbound traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->