### PR TITLE
ACM-31156: Test and validate network policies for CAPOA components

### DIFF
--- a/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/templates/capoa-bootstrap-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/templates/capoa-bootstrap-networkpolicy.yaml
@@ -51,6 +51,8 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
       ports:
         - protocol: TCP
           port: 8090
@@ -60,6 +62,8 @@ spec:
             cidr: 0.0.0.0/0
             except:
               - 169.254.169.254/32
+        - ipBlock:
+            cidr: ::/0
       ports:
         - protocol: TCP
           port: 443

--- a/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/templates/capoa-bootstrap-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/templates/capoa-bootstrap-networkpolicy.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capoa-bootstrap-controller-manager
+  labels:
+    control-plane: capoa-bootstrap-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: capoa-bootstrap-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic
+    - from:
+        - podSelector: {}
+    # Monitoring
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Webhook calls from kube-apiserver (validating + conversion)
+    - ports:
+        - protocol: TCP
+          port: 9443
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Kubernetes API
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              component: apiserver
+      ports:
+        - protocol: TCP
+          port: 6443
+    # assisted-service (ignition download, port varies by deployment)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 8090
+    # HTTPS egress (assisted-service external mode)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 443

--- a/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/templates/capoa-controlplane-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/templates/capoa-controlplane-networkpolicy.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capoa-controlplane-controller-manager
+  labels:
+    control-plane: capoa-controlplane-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: capoa-controlplane-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic
+    - from:
+        - podSelector: {}
+    # Monitoring
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Webhook calls from kube-apiserver (conversion)
+    - ports:
+        - protocol: TCP
+          port: 9443
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Kubernetes API
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              component: apiserver
+      ports:
+        - protocol: TCP
+          port: 6443
+    # Spoke/workload cluster API servers (dynamic IPs)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 6443
+    # HTTPS egress (container registries for release image manifests)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 443

--- a/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/templates/capoa-controlplane-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/templates/capoa-controlplane-networkpolicy.yaml
@@ -38,19 +38,12 @@ spec:
           port: 5353
         - protocol: TCP
           port: 5353
-    # Kubernetes API
-    - to:
-        - namespaceSelector: {}
-          podSelector:
-            matchLabels:
-              component: apiserver
-      ports:
-        - protocol: TCP
-          port: 6443
-    # Spoke/workload cluster API servers (dynamic IPs)
+    # Kubernetes API and spoke/workload cluster API servers (dynamic IPs)
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
       ports:
         - protocol: TCP
           port: 6443
@@ -60,6 +53,8 @@ spec:
             cidr: 0.0.0.0/0
             except:
               - 169.254.169.254/32
+        - ipBlock:
+            cidr: ::/0
       ports:
         - protocol: TCP
           port: 443


### PR DESCRIPTION
## Summary

Adds NetworkPolicy templates for both CAPOA providers in the chart:

- **capoa-bootstrap-controller-manager** — ingress on 8080 (metrics), 9443 (webhooks); egress to DNS, K8s API, assisted-service, HTTPS
- **capoa-controlplane-controller-manager** — ingress on 8080 (metrics), 9443 (webhooks); egress to DNS, K8s API, spoke clusters, registries

## Test results (kind + Calico)

```
=== SUMMARY: 12 passed, 0 failed ===
```

## Related

- Jira: [ACM-31156](https://redhat.atlassian.net/browse/ACM-31156)
- Also resolves: [ACM-37738](https://redhat.atlassian.net/browse/ACM-37738)
- Component repo PR: [openshift-assisted/cluster-api-provider-openshift-assisted#766](https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted/pull/766)

[ACM-31156]: https://redhat.atlassian.net/browse/ACM-31156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-37738]: https://redhat.atlassian.net/browse/ACM-37738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added network policies for bootstrap and control-plane components.
  * Restricted inbound traffic to approved same-namespace, monitoring, and Kubernetes API webhook connections.
  * Restricted outbound traffic to required DNS, Kubernetes API, assisted-service, and HTTPS endpoints.
  * Blocked access to the cloud metadata endpoint while preserving necessary application connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->