### PR TITLE
fix: bump Go to 1.25.11 to fix CVE-2026-39820 [mce-2.11]

### DIFF
--- a/.github/workflows/rbac-gen.yml
+++ b/.github/workflows/rbac-gen.yml
@@ -12,10 +12,6 @@ defaults:
 jobs:
   rbac-check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go:
-          - '1.25.7'
     name: Generate role permissions
     steps:
     - name: Checkout backplane
@@ -23,11 +19,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Go - ${{ matrix.go }}
+    - name: Set up Go
       uses: actions/setup-go@v6
       id: go
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: go.mod
 
     - name: Verify modules
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/backplane-operator
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
## Summary
- Bumps Go toolchain from 1.25.7 to **1.25.11** to resolve **CVE-2026-39820** (`net/mail` DoS via crafted email inputs; fixed in ≥1.25.10)
- Aligns `rbac-gen.yml` to derive CI Go version from `go.mod` (`go-version-file`), matching the approach in #3616

## Jira
Related: [ACM-37481](https://redhat.atlassian.net/browse/ACM-37481)

## Test plan
- [x] `go mod verify`
- [x] `go build ./...`
- [ ] `make test` — blocked locally (envtest GCS 401 / missing etcd assets); rely on CI
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)

[ACM-37481]: https://redhat.atlassian.net/browse/ACM-37481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ