### PR TITLE
fix: bump Go to 1.25.11 to fix CVE-2026-27145 [mce-2.8]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/backplane-operator
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Bumps Go from `1.25.7` to `1.25.11` to address CVE-2026-27145 (crypto/x509: Denial of Service via excessive processing of DNS SAN entries).

Same fix as PR #3616 on main.

Related: ACM-37679