### PR TITLE
Add networkPolicies.enabled and olmVersion to chart values

### DIFF
--- a/hack/bundle-automation/chart-templates/values.yaml
+++ b/hack/bundle-automation/chart-templates/values.yaml
@@ -5,8 +5,11 @@ global:
   deployOnOCP: true
   imageOverrides: {}
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
+  networkPolicies:
+    enabled: true
 hubconfig:
   nodeSelector: null
   ocpVersion: 4.12.0

--- a/pkg/templates/charts/toggle/assisted-service/values.yaml
+++ b/pkg/templates/charts/toggle/assisted-service/values.yaml
@@ -8,6 +8,7 @@ global:
     assisted_service_9: ''
     postgresql_16: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api-k8s/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-k8s/values.yaml
@@ -3,6 +3,7 @@ global:
   imageOverrides:
     ose_cluster_api_rhel9: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api-provider-aws/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-aws/values.yaml
@@ -3,6 +3,7 @@ global:
   imageOverrides:
     cluster_api_provider_aws_rhel9: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api-provider-azure-k8s/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-azure-k8s/values.yaml
@@ -4,6 +4,7 @@ global:
     azure_service_operator_rhel9: ''
     cluster_api_provider_azure_rhel9: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api-provider-azure/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-azure/values.yaml
@@ -4,6 +4,7 @@ global:
     azure_service_operator_rhel9: ''
     cluster_api_provider_azure_rhel9: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api-provider-metal3-k8s/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-metal3-k8s/values.yaml
@@ -3,6 +3,7 @@ global:
   imageOverrides:
     ose_baremetal_cluster_api_controllers_rhel9: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api-provider-metal3/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-metal3/values.yaml
@@ -3,6 +3,7 @@ global:
   imageOverrides:
     ose_baremetal_cluster_api_controllers_rhel9: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted-k8s/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted-k8s/values.yaml
@@ -4,6 +4,7 @@ global:
     cluster_api_provider_openshift_assisted_bootstrap: ''
     cluster_api_provider_openshift_assisted_control_plane: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api-provider-openshift-assisted/values.yaml
@@ -4,6 +4,7 @@ global:
     cluster_api_provider_openshift_assisted_bootstrap: ''
     cluster_api_provider_openshift_assisted_control_plane: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-api/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-api/values.yaml
@@ -4,6 +4,7 @@ global:
     mce_capi_webhook_config_rhel9: ''
     ose_cluster_api_rhel9: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-lifecycle/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/values.yaml
@@ -10,6 +10,7 @@ global:
     enabled: true
   pullSecret: ""
   namespace: default
+  olmVersion: v0
   deployOnOCP: ""
 hubconfig:
   nodeSelector: {}

--- a/pkg/templates/charts/toggle/cluster-manager/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-manager/values.yaml
@@ -3,6 +3,7 @@ global:
   imageOverrides:
     registration_operator: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/cluster-permission/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-permission/values.yaml
@@ -6,6 +6,7 @@ global:
   imageOverrides:
     cluster_permission: ''
   namespace: open-cluster-management
+  olmVersion: v0
   pullSecret: null
 hubconfig:
   nodeSelector: null

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/values.yaml
@@ -1,6 +1,7 @@
 global:
   pullPolicy: Always
   namespace: default
+  olmVersion: v0
   pullSecret: null
   imageOverrides:
     cluster_proxy: ""

--- a/pkg/templates/charts/toggle/console-mce/values.yaml
+++ b/pkg/templates/charts/toggle/console-mce/values.yaml
@@ -31,6 +31,7 @@ global:
   # console_mce_deployment_container_liveness_probe_failure_threshold: <count>
   pullPolicy: Always
   namespace: default
+  olmVersion: v0
   pullSecret: null
 hubconfig:
   nodeSelector: null

--- a/pkg/templates/charts/toggle/discovery-operator/values.yaml
+++ b/pkg/templates/charts/toggle/discovery-operator/values.yaml
@@ -3,6 +3,7 @@ global:
   imageOverrides:
     discovery_operator: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/fleet-navigation/values.yaml
+++ b/pkg/templates/charts/toggle/fleet-navigation/values.yaml
@@ -1,8 +1,11 @@
 global:
   deployOnOCP: true
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
+  networkPolicies:
+    enabled: true
 hubconfig:
   clusterIngressDomain: ''
   consoleURL: ''

--- a/pkg/templates/charts/toggle/hive-operator/values.yaml
+++ b/pkg/templates/charts/toggle/hive-operator/values.yaml
@@ -3,6 +3,7 @@ global:
   imageOverrides:
     openshift_hive: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/hypershift/values.yaml
+++ b/pkg/templates/charts/toggle/hypershift/values.yaml
@@ -9,6 +9,7 @@ global:
   networkPolicies:
     enabled: true
   namespace: default
+  olmVersion: v0
   pullSecret: null
   deployOnOCP: ""
 hubconfig:

--- a/pkg/templates/charts/toggle/image-based-install-operator/values.yaml
+++ b/pkg/templates/charts/toggle/image-based-install-operator/values.yaml
@@ -3,6 +3,7 @@ global:
   imageOverrides:
     image_based_install_operator: ''
   namespace: default
+  olmVersion: v0
   pullSecret: null
   templateOverrides: {}
   networkPolicies:

--- a/pkg/templates/charts/toggle/maestro/values.yaml
+++ b/pkg/templates/charts/toggle/maestro/values.yaml
@@ -11,6 +11,7 @@ global:
   templateOverrides: {}
   networkPolicies:
     enabled: true
+  olmVersion: v0
   pullSecret: null
   pullPolicy: IfNotPresent
   deployOnOCP: true

--- a/pkg/templates/charts/toggle/managed-serviceaccount/values.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/values.yaml
@@ -3,10 +3,11 @@ global:
   imageOverrides:
     managed_serviceaccount: ''
   namespace: default
-  pullSecret: null
-  templateOverrides: {}
+  olmVersion: v0
   networkPolicies:
     enabled: true
+  pullSecret: null
+  templateOverrides: {}
 hubconfig:
   nodeSelector: null
   ocpVersion: 4.12.0

--- a/pkg/templates/charts/toggle/server-foundation/values.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/values.yaml
@@ -6,6 +6,7 @@ global:
     enabled: true
   pullSecret: ""
   namespace: default
+  olmVersion: v0
   deployOnOCP: ""
   servingCertCABundle: ""
   upgrading: false


### PR DESCRIPTION
## Summary
- Add `global.networkPolicies.enabled: true` to all toggle chart `values.yaml` files (was missing from `fleet-navigation`)
- Add `global.olmVersion: v0` to all toggle chart `values.yaml` files
- Add both fields to `hack/bundle-automation/chart-templates/values.yaml` so automated chart regeneration preserves them

## Test plan
- [ ] Run `make regenerate-charts` and verify generated `values.yaml` files retain both fields
- [ ] Verify NetworkPolicy templates render correctly with `networkPolicies.enabled: true`
- [ ] Verify no regressions in chart rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)