### PR TITLE
fix: skip hypershift-local-hosting in ensureNetworkPolicies

### DIFF
--- a/controllers/networkpolicy.go
+++ b/controllers/networkpolicy.go
@@ -65,6 +65,11 @@ func (r *MultiClusterEngineReconciler) ensureNetworkPolicies(
 			continue
 		}
 
+		// Skip components without chart directories (e.g. hypershift-local-hosting uses RenderHypershiftAddon)
+		if component == backplanev1.HypershiftLocalHosting {
+			continue
+		}
+
 		// Skip externally managed components
 		if r.isComponentExternallyManaged(mce, component) {
 			log.V(2).Info("Skipping externally managed component", "component", component)


### PR DESCRIPTION
# Description

Skip `hypershift-local-hosting` in `ensureNetworkPolicies` to eliminate false "Chart directory not found" INFO log messages during reconciliation.

## Related Issue

Introduced by #3550 (Add NetworkPolicy support to MCE operator).

## Changes Made

- Added explicit skip for `HypershiftLocalHosting` component in `ensureNetworkPolicies` (`controllers/networkpolicy.go`)
- `hypershift-local-hosting` has no chart directory — it uses `RenderHypershiftAddon()` directly, so there are no NetworkPolicy templates to render from a chart

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Before this fix, every reconcile loop logged:
```
INFO reconcile Chart directory not found for component detected {"Component": "hypershift-local-hosting"}
```
This was because `ensureNetworkPolicies` iterates all `MCEComponents` and calls `fetchChartOrCRDPath`, which returns a fallback path for unmapped components. `hypershift-local-hosting` is a chartless component that uses `renderer.RenderHypershiftAddon()` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)