### PR TITLE
ACM-37875: Add NetworkPolicies for cluster-proxy hub components

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-addon-manager-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-addon-manager-networkpolicy.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Purpose: Layered-product default-deny for cluster-proxy-addon-manager, then allow
+# DNS and API egress. Manager has no Service/Route ingress.
+# Gaps: API egress is allow-all ({}) because kube-apiserver is often host-networked
+# and not selectable by NetworkPolicy (OpenShift NP guideline). DNS targets
+# openshift-dns only (OCP); non-OCP kube-dns is not covered.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-proxy-addon-manager-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      component: cluster-proxy-addon-manager
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: TCP
+      port: 5353
+    - protocol: UDP
+      port: 5353
+  - {}
+{{- end }}

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-addon-user-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-addon-user-networkpolicy.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.global.networkPolicies.enabled .Values.enableServiceProxy }}
+# Purpose: Layered-product default-deny for cluster-proxy-addon-user (user-server),
+# then allow Route/router and ocm-proxyserver ingress on 9092, plus DNS, API, and
+# ANP client egress to proxy-server on 8090.
+# Gaps: API egress is allow-all ({}). Router namespaceSelector may also match
+# hostNetwork traffic. Probe port 8000 is omitted (kubelet probes are not blocked
+# by NetworkPolicy). DNS is openshift-dns only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-proxy-addon-user-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      component: cluster-proxy-addon-user
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+    ports:
+    - protocol: TCP
+      port: 9092
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: ocm-proxyserver
+    ports:
+    - protocol: TCP
+      port: 9092
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: TCP
+      port: 5353
+    - protocol: UDP
+      port: 5353
+  - to:
+    - podSelector:
+        matchLabels:
+          proxy.open-cluster-management.io/component-name: proxy-server
+    ports:
+    - protocol: TCP
+      port: 8090
+  - {}
+{{- end }}

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-proxy-server-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-proxy-server-networkpolicy.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Purpose: Layered-product default-deny for ANP proxy-server pods created via
+# ManagedProxyConfiguration, then allow OpenShift router ingress on 8090/8091
+# (proxy-entrypoint / cluster-proxy-addon-anp), same-namespace user-server
+# ingress on 8090 (ANP client), and DNS + API egress.
+# Gaps: API egress is allow-all ({}). Router namespaceSelector may also match
+# hostNetwork traffic. DNS is openshift-dns only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-proxy-proxy-server-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      proxy.open-cluster-management.io/component-name: proxy-server
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+    ports:
+    - protocol: TCP
+      port: 8090
+    - protocol: TCP
+      port: 8091
+  # Reciprocal allow for cluster-proxy-addon-user ANP client → proxy-server :8090
+  - from:
+    - podSelector:
+        matchLabels:
+          component: cluster-proxy-addon-user
+    ports:
+    - protocol: TCP
+      port: 8090
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: TCP
+      port: 5353
+    - protocol: UDP
+      port: 5353
+  - {}
+{{- end }}


### PR DESCRIPTION
## Summary
- Adds three layered-product NetworkPolicies in the `cluster-proxy-addon` toggle chart for hub workloads: addon-manager, addon-user, and ANP proxy-server.
- Policies are gated by `global.networkPolicies.enabled` (user NP also by `enableServiceProxy`) and follow deny-by-default with explicit DNS, router, peer, and API egress allows.
- Extends renderer tests to assert all three NPs render when enabled and none when disabled.

Jira: https://redhat.atlassian.net/browse/ACM-37875

## Test plan
- [x] `go test ./pkg/rendering/ -run TestClusterProxyAddonNetworkPolicies`
- [ ] Enable `spec.networkPolicies.enabled` on an MCE and confirm the three NPs are created once in the target namespace
- [ ] Verify cluster-proxy Routes still work (ANP 8091 / user 9092 via OpenShift router)
- [ ] Verify ocm-proxyserver can still reach `cluster-proxy-addon-user:9092`
- [ ] Disable networkPolicies and confirm MCE deletes installer-owned NPs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable network policies for the cluster proxy add-on components.
  * When enabled, policies control inbound access to proxy services and permit required DNS and service communication.
  * Policies can be applied conditionally when the service proxy feature is enabled.
  * Added default-deny ingress behavior for selected components while preserving required connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->