### PR TITLE
chore: sync cluster-proxy NetworkPolicies with upstream stolostron/cluster-proxy

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-addon-manager-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-addon-manager-networkpolicy.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.global.networkPolicies.enabled }}
-# Purpose: Layered-product default-deny for cluster-proxy-addon-manager, then allow
-# DNS and API egress. Manager has no Service/Route ingress.
-# Gaps: API egress is allow-all ({}) because kube-apiserver is often host-networked
-# and not selectable by NetworkPolicy (OpenShift NP guideline). DNS targets
-# openshift-dns only (OCP); non-OCP kube-dns is not covered.
+# ACM override: upstream uses .Values.networkPolicies.enabled; backplane uses .Values.global.networkPolicies.enabled.
+# Purpose: Default-deny for cluster-proxy addon-manager, then allow DNS and
+# Kubernetes API egress. Manager has no Service/ingress.
+# Peers are port-based (empty "to") for portability across Kubernetes vendors.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -11,19 +10,28 @@ metadata:
 spec:
   podSelector:
     matchLabels:
+      # ACM override: upstream uses component: cluster-proxy-manager.
+      # ACM uses cluster-proxy-addon-manager to match the backplane pod template labels
+      # (historically diverged; matchLabels are immutable so this cannot be changed).
       component: cluster-proxy-addon-manager
   policyTypes:
   - Ingress
   - Egress
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-dns
-    ports:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
     - protocol: TCP
-      port: 5353
+      port: 53
     - protocol: UDP
       port: 5353
-  - {}
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
 {{- end }}

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-addon-user-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-addon-user-networkpolicy.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.global.networkPolicies.enabled .Values.enableServiceProxy }}
-# Purpose: Layered-product default-deny for cluster-proxy-addon-user (user-server),
-# then allow Route/router and ocm-proxyserver ingress on 9092, plus DNS, API, and
-# ANP client egress to proxy-server on 8090.
-# Gaps: API egress is allow-all ({}). Router namespaceSelector may also match
-# hostNetwork traffic. Probe port 8000 is omitted (kubelet probes are not blocked
-# by NetworkPolicy). DNS is openshift-dns only.
+# ACM override: upstream uses .Values.networkPolicies.enabled; backplane uses .Values.global.networkPolicies.enabled.
+# Purpose: Default-deny for cluster-proxy-addon-user (user-server), then allow
+# ingress on serving port 9092 (empty "from" for ingress controllers / in-cluster
+# clients), plus DNS, API, and ANP client egress to proxy-server on 8090.
+# Probe port 8000 is omitted (kubelet probes are not blocked by NetworkPolicy).
+# Peers are port-based where destinations are not selectable across vendors.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,30 +17,28 @@ spec:
   - Ingress
   - Egress
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          policy-group.network.openshift.io/ingress: ""
-    ports:
-    - protocol: TCP
-      port: 9092
-  - from:
-    - podSelector:
-        matchLabels:
-          control-plane: ocm-proxyserver
-    ports:
+  # Empty from: port-based allow (ingress controllers / in-cluster clients).
+  - ports:
     - protocol: TCP
       port: 9092
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-dns
-    ports:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
     - protocol: TCP
-      port: 5353
+      port: 53
     - protocol: UDP
       port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # ANP client → same-namespace proxy-server
   - to:
     - podSelector:
         matchLabels:
@@ -48,5 +46,4 @@ spec:
     ports:
     - protocol: TCP
       port: 8090
-  - {}
 {{- end }}

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-proxy-server-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/cluster-proxy-proxy-server-networkpolicy.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.global.networkPolicies.enabled }}
-# Purpose: Layered-product default-deny for ANP proxy-server pods created via
-# ManagedProxyConfiguration, then allow OpenShift router ingress on 8090/8091
-# (proxy-entrypoint / cluster-proxy-addon-anp), same-namespace user-server
-# ingress on 8090 (ANP client), and DNS + API egress.
-# Gaps: API egress is allow-all ({}). Router namespaceSelector may also match
-# hostNetwork traffic. DNS is openshift-dns only.
+# ACM override: upstream uses .Values.networkPolicies.enabled; backplane uses .Values.global.networkPolicies.enabled.
+# Purpose: Default-deny for ANP proxy-server pods created via
+# ManagedProxyConfiguration, then allow ingress on 8090/8091 (empty "from" for
+# ingress controllers / tunnel clients), same-namespace user-server on 8090,
+# and DNS + API egress.
+# Peers are port-based where destinations are not selectable across vendors.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,11 +17,8 @@ spec:
   - Ingress
   - Egress
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          policy-group.network.openshift.io/ingress: ""
-    ports:
+  # Empty from: port-based allow (ingress controllers / ANP agents).
+  - ports:
     - protocol: TCP
       port: 8090
     - protocol: TCP
@@ -35,14 +32,20 @@ spec:
     - protocol: TCP
       port: 8090
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-dns
-    ports:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
     - protocol: TCP
-      port: 5353
+      port: 53
     - protocol: UDP
       port: 5353
-  - {}
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
 {{- end }}

--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/manager-deployment.yaml
@@ -108,6 +108,11 @@ spec:
             - --enable-kube-api-proxy={{ .Values.enableKubeApiProxy }}
             # ACM override: upstream default false. ACM sets true via EnableServiceProxy in renderer.go (commit efb29e7b, Nov 2025).
             - --enable-service-proxy={{ .Values.enableServiceProxy }}
+            # ACM override: upstream uses .Values.networkPolicies.enabled.
+            # Backplane uses .Values.global.networkPolicies.enabled (same value, different path).
+            # Controls whether the addon-manager deploys a NetworkPolicy on the managed cluster
+            # spoke-side (proxy-agent pod). Set from MCE spec.networkPolicies.enabled via renderer.go.
+            - --enable-network-policies={{ .Values.global.networkPolicies.enabled }}
             # ACM: upstream --image-pull-policy= <proxyServer.imagePullPolicy>  arg removed. Not needed in ACM.
             # ACM: upstream --feature-gates=ClusterProfile=... conditional removed.
             # ClusterProfile not enabled in ACM. Re-add when needed


### PR DESCRIPTION
## Summary

Syncs the three cluster-proxy-addon NetworkPolicy templates and the `--enable-network-policies` manager flag from upstream `stolostron/cluster-proxy` main (upstream PR #334: _Add opt-in NetworkPolicies for hub and managed workloads_).

## Changes

### `manager-deployment.yaml`
- Add `--enable-network-policies={{ .Values.global.networkPolicies.enabled }}` arg to the addon-manager container. This flag tells the addon-manager to deploy a NetworkPolicy on the managed-cluster spoke-side (proxy-agent pod). Uses the backplane path `.Values.global.networkPolicies.enabled` (mapped from `MCE spec.networkPolicies.enabled` via `renderer.go`); upstream uses `.Values.networkPolicies.enabled`.

### NetworkPolicy templates (all three)
Replaces the OpenShift-specific implementations (namespace selectors for `openshift-dns`, router ingress labels, allow-all egress) with the upstream **port-based peer** policies for vendor portability:

| Template | Key ACM override |
|---|---|
| `cluster-proxy-addon-manager-networkpolicy.yaml` | Toggle uses `.Values.global.networkPolicies.enabled`; podSelector uses `component: cluster-proxy-addon-manager` (historical label divergence -- upstream uses `cluster-proxy-manager`, but backplane pod template labels use `cluster-proxy-addon-manager` and matchLabels are immutable) |
| `cluster-proxy-addon-user-networkpolicy.yaml` | Toggle uses `.Values.global.networkPolicies.enabled` |
| `cluster-proxy-proxy-server-networkpolicy.yaml` | Toggle uses `.Values.global.networkPolicies.enabled` |

## Validation
- `go generate ./...` ✅
- `make manifests` ✅  
- `go test ./pkg/rendering/...` ✅ (all tests pass)
- `go build ./...` ✅

## Upstream reference
- stolostron/cluster-proxy PR #334: https://github.com/stolostron/cluster-proxy/pull/334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global setting to enable or disable network policy deployment for the cluster proxy addon.
  * Added explicit network policies for DNS, Kubernetes API, proxy communication, and required service ports.

* **Bug Fixes**
  * Replaced broad egress permissions with restricted, port-based access rules.
  * Updated ingress permissions to support required traffic while removing outdated namespace-based restrictions.
  * Improved consistency between network policy behavior and the addon’s default-deny security model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->