### PR TITLE
Update bundle manifests with RBAC and CRD changes

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-07-20T13:37:13Z"
+    createdAt: "2026-07-24T14:28:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: multicluster-engine.v0.0.1
@@ -1010,6 +1010,7 @@ spec:
           - managedclusters/status
           - managedclustersets
           - placementdecisions
+          - placements
           verbs:
           - create
           - delete
@@ -1026,7 +1027,6 @@ spec:
           - managedclustersets/bind
           - managedclustersets/finalizers
           - managedclustersets/join
-          - placements
           - placements/finalizers
           verbs:
           - create
@@ -1234,6 +1234,7 @@ spec:
         - apiGroups:
           - console.openshift.io
           resources:
+          - consolenotifications
           - consoleplugins
           - consolequickstarts
           verbs:
@@ -1906,6 +1907,7 @@ spec:
           - metal3remediations
           - rosamachinepools
           - rosanetworks
+          - rosaocmroleconfigs
           - rosaroleconfigs
           verbs:
           - create
@@ -1925,6 +1927,7 @@ spec:
           - azureasomanagedmachinepools/finalizers
           - rosamachinepools/finalizers
           - rosanetworks/finalizers
+          - rosaocmroleconfigs/finalizers
           - rosaroleconfigs/finalizers
           verbs:
           - update
@@ -1954,6 +1957,7 @@ spec:
           - metal3remediations/status
           - rosaclusters/status
           - rosanetworks/status
+          - rosaocmroleconfigs/status
           - rosaroleconfigs/status
           verbs:
           - get
@@ -2808,14 +2812,6 @@ spec:
           resources:
           - managedproxyconfigurations/finalizers
           - managedproxyconfigurations/status
-          - managedproxyserviceresolvers/finalizers
-          - managedproxyserviceresolvers/status
-          verbs:
-          - '*'
-        - apiGroups:
-          - proxy.open-cluster-management.io
-          resources:
-          - managedproxyserviceresolvers
           verbs:
           - '*'
         - apiGroups:

--- a/bundle/manifests/multicluster.openshift.io_multiclusterengines.yaml
+++ b/bundle/manifests/multicluster.openshift.io_multiclusterengines.yaml
@@ -226,8 +226,6 @@ spec:
                       type: string
                   type: object
                 type: array
-            required:
-            - networkPolicies
             type: object
           status:
             description: MultiClusterEngineStatus defines the observed state of MultiClusterEngine


### PR DESCRIPTION
# Description

Update bundle manifests to reflect RBAC permission changes and CRD schema updates for the multicluster-engine operator.

## Related Issue

N/A

## Changes Made

- **RBAC**: Moved `placements` resource from `managedclustersets` verb group to `managedclusters` verb group
- **RBAC**: Added `consolenotifications` to `console.openshift.io` API group resources
- **RBAC**: Added `rosaocmroleconfigs`, `rosaocmroleconfigs/finalizers`, and `rosaocmroleconfigs/status` resources
- **RBAC**: Removed `managedproxyserviceresolvers` and related finalizer/status resources
- **CRD**: Made `networkPolicies` field optional in MultiClusterEngine spec (removed from `required` list)

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Generated manifest changes from operator-sdk / controller-gen tooling updates.

## Reviewers

/cc

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.