### PR TITLE
ACM-37740 Create NetworkPolicy resource for console-mce

### DIFF
--- a/pkg/templates/charts/toggle/console-mce/templates/console-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-networkpolicy.yaml
@@ -1,0 +1,44 @@
+# Copyright Contributors to the Open Cluster Management project
+#
+# NetworkPolicy for console-mce pods in the multicluster-engine namespace.
+#
+# Ingress:
+#   - OpenShift Console (openshift-console namespace) on port 3000
+#     The OCP console reverse-proxies plugin requests to this backend.
+#
+# Egress (allow-all):
+#   The backend proxies requests to the Kubernetes API server (port 443),
+#   search-api (port 4010), observability rbac-query-proxy (port 8443),
+#   Prometheus (port 9091), cluster-proxy-addon (port 9092),
+#   placement-debug (port 9443), and external HTTPS services
+#   (Red Hat SSO, OpenShift Cluster Manager API, Red Hat Insights).
+#   Because targets span many namespaces and include user-configured
+#   external URLs, egress is left unrestricted.
+{{- if .Values.global.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: console-mce-network-policy
+  labels:
+    app: console-mce
+spec:
+  podSelector:
+    matchLabels:
+      app: console-mce
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: console
+          podSelector:
+            matchLabels:
+              app: console
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - {}
+{{- end }}


### PR DESCRIPTION
# Description

Create a NetworkPolicy resource that would restrict network access to the console-mce pod in the MCE namespace.

## Related Issue

https://redhat.atlassian.net/browse/ACM-37740

## Changes Made

Create a NetworkPolicy resource that would restrict network access to the console-mce pod in the MCE namespace.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional network policy for the console MCE component.
  * When enabled, it restricts inbound traffic to authorized console pods on port 3000 while allowing outbound traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->