### PR TITLE
adding templates needed for hcp proxy to work

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,7 +11,6 @@ rules:
   - events
   - namespaces
   - secrets
-  - serviceaccounts
   - services
   verbs:
   - '*'
@@ -32,6 +31,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - groups
+  - users
+  verbs:
+  - impersonate
 - apiGroups:
   - ""
   resources:
@@ -68,6 +74,12 @@ rules:
   - ""
   resources:
   - pods/portforward
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-apiservice.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-apiservice.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.hcp.ocm.io
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+spec:
+  group: hcp.ocm.io
+  groupPriorityMinimum: 2000
+  service:
+    name: hypershift-addon-hcp-proxy
+    namespace: {{ .Values.global.namespace }}
+    port: 443
+  version: v1alpha1
+  versionPriority: 10

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}:{{ .Chart.Name }}:hypershift-addon-hcp-proxy
+rules:
+  - apiGroups: ["clusterview.open-cluster-management.io"]
+    resources: ["userpermissions"]
+    verbs: ["get"]
+  - apiGroups: ["cluster.open-cluster-management.io"]
+    resources: ["managedclusters"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["config.openshift.io"]
+    resources: ["apiservers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["users", "groups", "serviceaccounts"]
+    verbs: ["impersonate"]

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.org }}:{{ .Chart.Name }}:hypershift-addon-hcp-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.org }}:{{ .Chart.Name }}:hypershift-addon-hcp-proxy
+subjects:
+  - kind: ServiceAccount
+    name: hypershift-addon-manager-sa
+    namespace: {{ .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-service.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: hypershift-addon-hcp-proxy
+  namespace: {{ .Values.global.namespace }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: hypershift-addon-hcp-proxy-tls
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app: hypershift-addon-manager

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-deployment.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-deployment.yaml
@@ -58,6 +58,10 @@ spec:
       - emptyDir:
           medium: Memory
         name: tmp-vol
+      - name: hcp-proxy-tls
+        secret:
+          secretName: hypershift-addon-hcp-proxy-tls
+          optional: true
       hostNetwork: false
       hostPID: false
       hostIPC: false
@@ -77,6 +81,13 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: tmp-vol
+          - mountPath: /etc/hcp-proxy/tls
+            name: hcp-proxy-tls
+            readOnly: true
+          ports:
+          - name: hcp-proxy
+            containerPort: 9443
+            protocol: TCP
           args:
             - ./hypershift-addon
             - manager

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -127,6 +127,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=services,verbs=list;watch
 //+kubebuilder:rbac:groups="",resources=services;events;serviceaccounts,verbs=*
 //+kubebuilder:rbac:groups="",resources=services;services/finalizers;events;configmaps;secrets;serviceaccounts;namespaces,verbs=list;create;update;get;watch;patch;delete
+//+kubebuilder:rbac:groups="",resources=users;groups;serviceaccounts,verbs=impersonate
 //+kubebuilder:rbac:groups="";coordination.k8s.io,resources=configmaps;leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="";coordination.k8s.io,resources=configmaps;leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="";events.k8s.io,resources=configmaps;namespaces;events;endpoints;secrets,verbs=get;list;watch;create;update;delete;deletecollection;patch
@@ -332,6 +333,7 @@ package main
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters/status,verbs=patch;update
@@ -388,6 +390,7 @@ package main
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=delete;get;list;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=delete;get;list;watch
 //+kubebuilder:rbac:groups=clusterview.open-cluster-management.io,resources=managedclusters;managedclustersets,verbs=list;get;watch
+//+kubebuilder:rbac:groups=clusterview.open-cluster-management.io,resources=userpermissions,verbs=get
 //+kubebuilder:rbac:groups=clusterview.open-cluster-management.io,resources=userpermissions,verbs=get;list
 //+kubebuilder:rbac:groups=compute.azure.com,resources=diskaccesses/finalizers;diskaccesses/status;diskencryptionsets/finalizers;diskencryptionsets/status;disks/finalizers;disks/status;images/finalizers;images/status;snapshots/finalizers;snapshots/status;virtualmachines/finalizers;virtualmachines/status;virtualmachinescalesets/finalizers;virtualmachinescalesets/status;virtualmachinescalesetsextensions/finalizers;virtualmachinescalesetsextensions/status;virtualmachinesextensions/finalizers;virtualmachinesextensions/status,verbs=get;patch;update
 //+kubebuilder:rbac:groups=compute.azure.com,resources=diskaccesses/finalizers;diskaccesses/status;diskencryptionsets/finalizers;diskencryptionsets/status;disks/finalizers;disks/status;images/finalizers;images/status;snapshots/finalizers;snapshots/status;virtualmachines/finalizers;virtualmachines/status;virtualmachinescalesets/finalizers;virtualmachinescalesets/status;virtualmachinescalesetsextensions/finalizers;virtualmachinescalesetsextensions/status;virtualmachinesextensions/finalizers;virtualmachinesextensions/status,verbs=get;patch;update
@@ -396,6 +399,7 @@ package main
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;get;list;patch;update
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=get;list;watch;create;update;delete;patch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch


### PR DESCRIPTION
# Description

Add hub-side HCP proxy infrastructure resources to backplane-operator so the hypershift-addon-manager can serve the `hcp.ocm.io/v1alpha1` aggregated API for creating/managing HostedClusters from the hub.

## Related Issue

ACM-37269

Companion PR: https://github.com/stolostron/hypershift-addon-operator/pull/760

## Changes Made

### New Templates (`pkg/templates/charts/toggle/hypershift/templates/`)

- **`hypershift-addon-hcp-proxy-service.yaml`** — Service (port 443 → targetPort 9443) with `service-ca` annotation for automatic TLS cert generation
- **`hypershift-addon-hcp-proxy-apiservice.yaml`** — Registers `v1alpha1.hcp.ocm.io` with kube-apiserver aggregation, routing requests to the HCP proxy Service
- **`hypershift-addon-hcp-proxy-clusterrole.yaml`** — Dedicated ClusterRole granting:
  - `clusterview.open-cluster-management.io/userpermissions` GET (probe auth API + check caller's admin bindings)
  - User/group/serviceaccount impersonation (forward caller identity for permission checks)
  - `authentication.k8s.io/userextras` impersonation
  - `operator.open-cluster-management.io/multiclusterhubs` read access
  - `cluster.open-cluster-management.io/managedclusters` read access (spoke health checks)
  - `config.openshift.io/apiservers` read access (TLS profile compliance)
- **`hypershift-addon-hcp-proxy-clusterrolebinding.yaml`** — Binds the above ClusterRole to the `hypershift-addon-manager-sa` ServiceAccount

### Modified Templates

- **`hypershift-addon-manager-deployment.yaml`** — Added:
  - `containerPort: 9443` (named `hcp-proxy`) for the proxy listener
  - Volume mount at `/etc/hcp-proxy/tls` (readOnly) for the service-ca-generated TLS cert
  - Volume definition referencing the `hypershift-addon-hcp-proxy-tls` Secret (optional: true for non-OpenShift fallback)

### Generated Files

- **`pkg/templates/rbac_gen.go`** — Regenerated via `go generate` to include HCP proxy RBAC markers
- **`config/rbac/role.yaml`** — Regenerated via `make manifests` (controller-gen v0.19.0) so the backplane-operator itself has permission to manage the new resources

## Screenshots (if applicable)

N/A — infrastructure/RBAC changes only.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- The HCP proxy code itself lives in the [hypershift-addon-operator](https://github.com/stolostron/hypershift-addon-operator) repo (`pkg/manager/hcp_proxy.go`), merged in PR #760. This PR provides the infrastructure (Service, APIService, RBAC, Deployment wiring) that backplane-operator is responsible for provisioning.
- The template pattern (service-ca annotation + inject-cabundle on APIService + port 443) follows existing ACM conventions used by `ocm-proxyserver` and `clusterview`.
- `controller-gen` was upgraded from stale v0.15.0 → v0.19.0 (matching what `CONTROLLER_TOOLS_VERSION` already specified in the Makefile) to fix incompatibility with k8s v0.35.x vendored dependencies.

## Reviewers

/cc @yiraeChristineKim

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Hypershift add-on proxy endpoint registration (v1alpha1) for `hcp.ocm.io`.
  * Introduced an HTTPS proxy Service and exposed the manager proxy port on `9443`.
  * Added TLS support for the proxy via a mounted TLS secret.
* **Bug Fixes**
  * Updated RBAC permissions to support required proxy impersonation and read-only cluster discovery (users/groups/serviceaccounts; managed clusters and API server access).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->