### PR TITLE
ACM-37877 Add NetworkPolicy for cluster-permission hub controller

### DIFF
--- a/pkg/templates/charts/toggle/cluster-permission/templates/cluster-permission-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-permission/templates/cluster-permission-networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# ACM override: upstream uses .Values.networkPolicies.enabled; backplane uses
+# .Values.global.networkPolicies.enabled (set from MCE spec.networkPolicies.enabled).
+# Purpose: Default-deny for cluster-permission controller, then allow DNS and
+# Kubernetes API egress. Metrics ingress (:8286) is allowed when NetworkPolicies
+# are enabled. Peers are port-based (empty "to"/"from") for portability across
+# Kubernetes vendors. Health probes use exec (ls), so no health ingress port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-permission-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      name: cluster-permission
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8286
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}


### PR DESCRIPTION
## Summary
- Add hub NetworkPolicy for the `cluster-permission` controller in the backplane toggle chart ([ACM-37877](https://redhat.atlassian.net/browse/ACM-37877)).
- Policy is default-deny with port-based peers (DNS `:53`/`:5353`, API `:443`/`:6443`) and metrics ingress (`:8286`), gated by `global.networkPolicies.enabled` (from `MCE spec.networkPolicies.enabled`).
- Ports the upstream community chart pattern from [open-cluster-management-io/cluster-permission#93](https://github.com/open-cluster-management-io/cluster-permission/pull/93). Health probes use `exec: ls`, so no health ingress port is required.

## Test plan
- [x] `helm template` with chart defaults — NetworkPolicy rendered (values default `enabled: true`)
- [x] `helm template --set global.networkPolicies.enabled=false` — no NetworkPolicy
- [x] `go test ./pkg/rendering/`
- [ ] Install/upgrade MCE with `spec.networkPolicies.enabled=true` and confirm `cluster-permission-network-policy` exists
- [ ] Confirm cluster-permission can still reach hub API and DNS under the policy


Made with [Cursor](https://cursor.com)

[ACM-37877]: https://redhat.atlassian.net/browse/ACM-37877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional network policy support for cluster-permission workloads.
  * When enabled, network traffic is restricted to required application, DNS, and Kubernetes API ports.
  * Policies are disabled by default unless explicitly enabled through the global network policy setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->