### PR TITLE
ACM-37876: Add NetworkPolicy for managed-serviceaccount addon-agent

### DIFF
--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -736,6 +736,87 @@ func TestNetworkPoliciesValueInjection(t *testing.T) {
 	})
 }
 
+func TestManagedServiceAccountNetworkPolicies(t *testing.T) {
+	os.Setenv("DIRECTORY_OVERRIDE", "../../")
+	defer os.Unsetenv("DIRECTORY_OVERRIDE")
+	os.Setenv("POD_NAMESPACE", "default")
+	defer os.Unsetenv("POD_NAMESPACE")
+	os.Setenv("ACM_HUB_OCP_VERSION", "4.12.0")
+	defer os.Unsetenv("ACM_HUB_OCP_VERSION")
+
+	testImages := map[string]string{}
+	for _, v := range utils.GetTestImages() {
+		testImages[v] = "quay.io/test/test:Test"
+	}
+
+	addonTemplateContainsAgentNP := func(templates []*unstructured.Unstructured) bool {
+		for _, tmpl := range templates {
+			if tmpl.GetKind() != "AddOnTemplate" {
+				continue
+			}
+			manifests, found, err := unstructured.NestedSlice(tmpl.Object, "spec", "agentSpec", "workload", "manifests")
+			if err != nil || !found {
+				continue
+			}
+			for _, m := range manifests {
+				manifest, ok := m.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if manifest["kind"] == "NetworkPolicy" {
+					meta, _ := manifest["metadata"].(map[string]interface{})
+					if meta != nil && meta["name"] == "managed-serviceaccount-addon-agent-network-policy" {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	t.Run("NetworkPolicies enabled embeds agent NP in AddOnTemplate", func(t *testing.T) {
+		mce := &backplane.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-mce"},
+			Spec: backplane.MultiClusterEngineSpec{
+				TargetNamespace: "default",
+				NetworkPolicies: &backplane.NetworkPoliciesConfig{Enabled: true},
+			},
+		}
+
+		templates, errs := RenderChart(chartsPath, mce, testImages, map[string]string{})
+		if len(errs) > 0 {
+			t.Fatalf("RenderChart failed: %v", errs)
+		}
+		if !addonTemplateContainsAgentNP(templates) {
+			t.Error("expected managed-serviceaccount-addon-agent-network-policy in AddOnTemplate when networkPolicies.enabled=true")
+		}
+		// Spoke NP is nested in AddOnTemplate; ensure it is not applied as a hub NetworkPolicy.
+		for _, tmpl := range templates {
+			if tmpl.GetKind() == "NetworkPolicy" {
+				t.Errorf("unexpected top-level NetworkPolicy %s (MSA has no hub manager Deployment)", tmpl.GetName())
+			}
+		}
+	})
+
+	t.Run("NetworkPolicies disabled omits agent NP from AddOnTemplate", func(t *testing.T) {
+		mce := &backplane.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-mce"},
+			Spec: backplane.MultiClusterEngineSpec{
+				TargetNamespace: "default",
+				NetworkPolicies: &backplane.NetworkPoliciesConfig{Enabled: false},
+			},
+		}
+
+		templates, errs := RenderChart(chartsPath, mce, testImages, map[string]string{})
+		if len(errs) > 0 {
+			t.Fatalf("RenderChart failed: %v", errs)
+		}
+		if addonTemplateContainsAgentNP(templates) {
+			t.Error("NetworkPolicy should not be embedded in AddOnTemplate when networkPolicies.enabled=false")
+		}
+	})
+}
+
 func TestRenderChartInvalidPath(t *testing.T) {
 	os.Setenv("DIRECTORY_OVERRIDE", "../../")
 	defer os.Unsetenv("DIRECTORY_OVERRIDE")

--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/managed-serviceaccount-addontemplate.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/managed-serviceaccount-addontemplate.yaml
@@ -102,6 +102,55 @@ spec:
             targetPort: metrics
           selector:
             addon-agent: managed-serviceaccount
+{{- if .Values.global.networkPolicies.enabled }}
+      # ACM override: upstream uses .Values.networkPolicies.enabled; backplane uses
+      # .Values.global.networkPolicies.enabled (from MCE spec.networkPolicies.enabled).
+      # Purpose: Default-deny for managed-serviceaccount-addon-agent on the managed
+      # cluster, then allow DNS + hub/spoke API egress. Health ingress (:8000) allows
+      # kubelet livenessProbe /healthz. Metrics ingress (:38080) is opened because the
+      # AddOnTemplate always exposes the metrics Service (no separate prometheus toggle
+      # in this chart). Peers are port-based for portability across Kubernetes vendors.
+      - apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: managed-serviceaccount-addon-agent-network-policy
+          namespace: open-cluster-management-agent-addon
+          labels:
+            addon-agent: managed-serviceaccount
+        spec:
+          podSelector:
+            matchLabels:
+              addon-agent: managed-serviceaccount
+          policyTypes:
+          - Ingress
+          - Egress
+          ingress:
+          # kubelet livenessProbe /healthz
+          - ports:
+            - protocol: TCP
+              port: 8000
+          # metrics Service (:38080)
+          - ports:
+            - protocol: TCP
+              port: 38080
+          egress:
+          # DNS (:53 common; :5353 used by some distributions)
+          - ports:
+            - protocol: UDP
+              port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
+          # Hub kubeconfig API and spoke kube-apiserver
+          - ports:
+            - protocol: TCP
+              port: 443
+            - protocol: TCP
+              port: 6443
+{{- end }}
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:


### PR DESCRIPTION
## Summary
- Embed opt-in NetworkPolicy for the managed-serviceaccount addon-agent in the MCE `managed-serviceaccount` AddOnTemplate ([ACM-37876](https://redhat.atlassian.net/browse/ACM-37876)).
- MCE deploys MSA via AddOnTemplate (no dedicated hub manager Deployment), so the spoke policy is nested in agent manifests rather than a top-level hub NetworkPolicy chart file (unlike cluster-proxy / cluster-permission hub controllers).
- Default-deny with health ingress `:8000`, metrics ingress `:38080`, and DNS/API egress; gated by `global.networkPolicies.enabled` (from `MCE spec.networkPolicies.enabled`). Follows the upstream community pattern from [open-cluster-management-io/managed-serviceaccount#334](https://github.com/open-cluster-management-io/managed-serviceaccount/pull/334).

## Test plan
- [x] `go test ./pkg/rendering/ -run TestManagedServiceAccountNetworkPolicies`
- [ ] Install/upgrade MCE with `spec.networkPolicies.enabled=true` and confirm AddOnTemplate includes `managed-serviceaccount-addon-agent-network-policy`
- [ ] On a managed cluster, confirm the agent NetworkPolicy is applied and the agent remains healthy (liveness `:8000`)
- [ ] Confirm agent can still reach hub/spoke API and DNS under the policy
- [ ] Disable networkPolicies and confirm the NP is removed from the AddOnTemplate / spoke manifests


Made with [Cursor](https://cursor.com)

[ACM-37876]: https://redhat.atlassian.net/browse/ACM-37876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ