### PR TITLE
Fix must-gather name in image-references

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -11,10 +11,10 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/azure-service-operator-rhel9:latest
-  - name: backplane-must-gather-rhel9
+  - name: must-gather-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-must-gather-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/must-gather-rhel9:latest
   - name: capoa-bootstrap-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
## Summary

Rename `backplane-must-gather-rhel9` to `must-gather-rhel9` in `bundle/image-references` to match the actual Pyxis/registry delivery name.

Release pipeline fails with:
```
LabelValidationError: Component 'mce-2-11-backplane-must-gather' name label
('multicluster-engine/backplane-must-gather-rhel9') does not match expected
name ('multicluster-engine/must-gather-rhel9')
```

Companion PR: https://github.com/openshift-eng/ocp-build-data/pull/12010

Ref: HYPBLD-854

Made with [Cursor](https://cursor.com)