### PR TITLE
ACM-37785: add OCP version mismatch ConsoleNotification banner (2.17)

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -109,7 +109,7 @@ var (
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs,verbs=list
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs;discoveredclusters,verbs=create;get;list;watch;update;delete;deletecollection;patch;approve;escalate;bind
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions,verbs=get;list;watch;
-// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts;consolenotifications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update;patch
 
 // AgentServiceConfig webhook delete check
@@ -317,6 +317,11 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		currentOCPVersion, err := r.getClusterVersion(ctx)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to detect clusterversion: %w", err)
+		}
+
+		// Ensure OCP compliance banner reflects current version (create or remove as needed)
+		if bannerErr := r.ensureOCPComplianceBanner(ctx, backplaneConfig, currentOCPVersion); bannerErr != nil {
+			r.Log.Error(bannerErr, "Failed to reconcile OCP compliance ConsoleNotification banner")
 		}
 
 		if err := version.ValidOCPVersion(currentOCPVersion); err != nil {
@@ -2247,6 +2252,11 @@ func (r *MultiClusterEngineReconciler) finalizeBackplaneConfig(ctx context.Conte
 				log.Info("Error ensuring plugin is removed from console resource")
 				return ctrl.Result{}, err
 			}
+		}
+
+		if err := r.cleanupConsoleNotifications(ctx, backplaneConfig); err != nil {
+			log.Error(err, "Failed to clean up ConsoleNotification banners")
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/controllers/console_notification.go
+++ b/controllers/console_notification.go
@@ -1,0 +1,116 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	consolev1 "github.com/openshift/api/console/v1"
+	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
+	"github.com/stolostron/backplane-operator/pkg/version"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ocpComplianceBannerName = "mce-ocp-version-compliance"
+	bannerBackgroundColor   = "var(--pf-v6-c-banner--m-danger--BackgroundColor, var(--pf-v5-c-banner--m-red--BackgroundColor))"
+	bannerTextColor         = "var(--pf-v6-c-banner--m-danger--Color, var(--pf-v5-global--Color--100))"
+	bannerSupportLinkHref   = "https://access.redhat.com/support"
+	bannerSupportLinkText   = "Contact Red Hat Support"
+)
+
+func ocpComplianceBannerText(currentVersion, minimumVersion string) string {
+	return fmt.Sprintf(
+		"WARNING: MCE in unsupported configuration: OCP %s is below the minimum supported version %s.",
+		currentVersion, minimumVersion,
+	)
+}
+
+func (r *MultiClusterEngineReconciler) ensureOCPComplianceBanner(ctx context.Context,
+	mce *backplanev1.MultiClusterEngine,
+	ocpVersion string) error {
+
+	if ocpVersion == "" {
+		return r.removeOCPComplianceBanner(ctx)
+	}
+
+	// If OCP version is valid, remove banner
+	if err := version.ValidOCPVersion(ocpVersion); err == nil {
+		return r.removeOCPComplianceBanner(ctx)
+	}
+
+	desired := &consolev1.ConsoleNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ocpComplianceBannerName,
+			Labels: map[string]string{
+				"installer.name":      mce.GetName(),
+				"installer.namespace": mce.GetNamespace(),
+			},
+		},
+		Spec: consolev1.ConsoleNotificationSpec{
+			Text:            ocpComplianceBannerText(ocpVersion, version.MinimumOCPVersion),
+			Location:        consolev1.BannerTop,
+			BackgroundColor: bannerBackgroundColor,
+			Color:           bannerTextColor,
+			Link: &consolev1.Link{
+				Text: bannerSupportLinkText,
+				Href: bannerSupportLinkHref,
+			},
+		},
+	}
+
+	existing := &consolev1.ConsoleNotification{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, existing)
+	if errors.IsNotFound(err) {
+		log.Info("Creating OCP compliance ConsoleNotification banner")
+		if err := r.Client.Create(ctx, desired); err != nil {
+			return fmt.Errorf("failed to create ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+	}
+
+	if existing.Spec.Text != desired.Spec.Text ||
+		existing.Spec.BackgroundColor != desired.Spec.BackgroundColor ||
+		existing.Spec.Color != desired.Spec.Color ||
+		existing.Spec.Location != desired.Spec.Location {
+		patch := client.MergeFrom(existing.DeepCopy())
+		existing.Spec = desired.Spec
+		existing.Labels = desired.Labels
+		log.Info("Updating OCP compliance ConsoleNotification banner")
+		if err := r.Client.Patch(ctx, existing, patch); err != nil {
+			return fmt.Errorf("failed to patch ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *MultiClusterEngineReconciler) removeOCPComplianceBanner(ctx context.Context) error {
+	notification := &consolev1.ConsoleNotification{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+	}
+
+	log.Info("Removing OCP compliance ConsoleNotification banner")
+	return r.Client.Delete(ctx, notification)
+}
+
+func (r *MultiClusterEngineReconciler) cleanupConsoleNotifications(ctx context.Context,
+	mce *backplanev1.MultiClusterEngine) error {
+	return r.Client.DeleteAllOf(ctx, &consolev1.ConsoleNotification{}, client.MatchingLabels{
+		"installer.name":      mce.GetName(),
+		"installer.namespace": mce.GetNamespace(),
+	})
+}

--- a/controllers/console_notification_test.go
+++ b/controllers/console_notification_test.go
@@ -1,0 +1,170 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+
+	consolev1 "github.com/openshift/api/console/v1"
+	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
+	"github.com/stolostron/backplane-operator/pkg/version"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("OCP compliance ConsoleNotification banner", func() {
+	var (
+		ctx context.Context
+		mce *backplanev1.MultiClusterEngine
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		mce = &backplanev1.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multiclusterengine",
+				Namespace: "multicluster-engine",
+			},
+		}
+	})
+
+	AfterEach(func() {
+		// Clean up banner if it exists
+		notification := &consolev1.ConsoleNotification{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification); err == nil {
+			_ = k8sClient.Delete(ctx, notification)
+		}
+	})
+
+	Context("ensureOCPComplianceBanner", func() {
+		It("creates a banner when OCP version is below minimum", func() {
+			err := reconciler.ensureOCPComplianceBanner(ctx, mce, "4.18.0")
+			Expect(err).NotTo(HaveOccurred())
+
+			notification := &consolev1.ConsoleNotification{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(notification.Spec.Text).To(Equal(ocpComplianceBannerText("4.18.0", version.MinimumOCPVersion)))
+			Expect(notification.Spec.Location).To(Equal(consolev1.BannerTop))
+			Expect(notification.Spec.BackgroundColor).To(Equal(bannerBackgroundColor))
+			Expect(notification.Spec.Color).To(Equal(bannerTextColor))
+			Expect(notification.Spec.Link).NotTo(BeNil())
+			Expect(notification.Spec.Link.Href).To(Equal(bannerSupportLinkHref))
+			Expect(notification.Spec.Link.Text).To(Equal(bannerSupportLinkText))
+			Expect(notification.Labels["installer.name"]).To(Equal(mce.GetName()))
+			Expect(notification.Labels["installer.namespace"]).To(Equal(mce.GetNamespace()))
+		})
+
+		It("does not create a banner when OCP version meets minimum", func() {
+			err := reconciler.ensureOCPComplianceBanner(ctx, mce, version.MinimumOCPVersion)
+			Expect(err).NotTo(HaveOccurred())
+
+			notification := &consolev1.ConsoleNotification{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("removes existing banner when OCP version meets minimum", func() {
+			// Pre-create a banner
+			existing := &consolev1.ConsoleNotification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ocpComplianceBannerName,
+					Labels: map[string]string{
+						"installer.name":      mce.GetName(),
+						"installer.namespace": mce.GetNamespace(),
+					},
+				},
+				Spec: consolev1.ConsoleNotificationSpec{
+					Text:            "old warning",
+					Location:        consolev1.BannerTop,
+					BackgroundColor: bannerBackgroundColor,
+					Color:           bannerTextColor,
+				},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			// Now pass a valid OCP version
+			err := reconciler.ensureOCPComplianceBanner(ctx, mce, version.MinimumOCPVersion)
+			Expect(err).NotTo(HaveOccurred())
+
+			notification := &consolev1.ConsoleNotification{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("does not create a banner when OCP version is empty", func() {
+			err := reconciler.ensureOCPComplianceBanner(ctx, mce, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			notification := &consolev1.ConsoleNotification{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("updates an existing banner when OCP version changes", func() {
+			// Create initial banner
+			Expect(reconciler.ensureOCPComplianceBanner(ctx, mce, "4.18.0")).To(Succeed())
+
+			notification := &consolev1.ConsoleNotification{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)).To(Succeed())
+			oldText := notification.Spec.Text
+
+			// Now reconcile with a different below-minimum version
+			// Force a text change by temporarily patching the existing banner text
+			notification.Spec.Text = "stale text"
+			Expect(k8sClient.Update(ctx, notification)).To(Succeed())
+
+			Expect(reconciler.ensureOCPComplianceBanner(ctx, mce, "4.18.0")).To(Succeed())
+
+			updated := &consolev1.ConsoleNotification{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, updated)).To(Succeed())
+			Expect(updated.Spec.Text).To(Equal(oldText))
+		})
+	})
+
+	Context("removeOCPComplianceBanner", func() {
+		It("removes an existing banner", func() {
+			existing := &consolev1.ConsoleNotification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ocpComplianceBannerName,
+					Labels: map[string]string{
+						"installer.name":      mce.GetName(),
+						"installer.namespace": mce.GetNamespace(),
+					},
+				},
+				Spec: consolev1.ConsoleNotificationSpec{
+					Text:     "warning",
+					Location: consolev1.BannerTop,
+				},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			Eventually(func() error {
+				return reconciler.removeOCPComplianceBanner(ctx)
+			}).Should(Succeed())
+
+			Eventually(func() bool {
+				notification := &consolev1.ConsoleNotification{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+				return err != nil
+			}).Should(BeTrue())
+		})
+
+		It("is a no-op when banner does not exist", func() {
+			Expect(reconciler.removeOCPComplianceBanner(ctx)).To(Succeed())
+		})
+	})
+
+	Context("ocpComplianceBannerText", func() {
+		It("includes current and minimum version in text", func() {
+			text := ocpComplianceBannerText("4.18.0", "4.19.0")
+			Expect(text).To(ContainSubstring("4.18.0"))
+			Expect(text).To(ContainSubstring("4.19.0"))
+			Expect(text).To(ContainSubstring("WARNING"))
+		})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	openshift_consolev1 "github.com/openshift/api/console/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hiveconfig "github.com/openshift/hive/apis/hive/v1"
 
@@ -158,6 +159,9 @@ var _ = BeforeSuite(func() {
 	err = addToSchemeIgnoringDuplicate(operatorv1.AddToScheme, scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = addToSchemeIgnoringDuplicate(openshift_consolev1.AddToScheme, scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = os.Setenv("POD_NAMESPACE", "default")
 	Expect(err).NotTo(HaveOccurred())
 
@@ -207,6 +211,9 @@ var _ = BeforeSuite(func() {
 	err = configv1.AddToScheme(mgrScheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = operatorv1.AddToScheme(mgrScheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = openshift_consolev1.AddToScheme(mgrScheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{

--- a/hack/unit-test-crds/consolenotification.yaml
+++ b/hack/unit-test-crds/consolenotification.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
+    capability.openshift.io/name: Console
+    description: Extension for configuring openshift web console notifications.
+    displayName: ConsoleNotification
+  name: consolenotifications.console.openshift.io
+spec:
+  group: console.openshift.io
+  names:
+    kind: ConsoleNotification
+    listKind: ConsoleNotificationList
+    plural: consolenotifications
+    singular: consolenotification
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: ConsoleNotification is the Schema for the consolenotifications API
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleNotificationSpec defines the desired state of ConsoleNotification
+            type: object
+            required:
+            - text
+            properties:
+              backgroundColor:
+                type: string
+              color:
+                type: string
+              link:
+                type: object
+                properties:
+                  href:
+                    type: string
+                  text:
+                    type: string
+              location:
+                type: string
+              text:
+                type: string

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"open-cluster-management.io/sdk-go/pkg/servingcert"
 
 	configv1 "github.com/openshift/api/config/v1"
+	openshift_consolev1 "github.com/openshift/api/console/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hiveconfig "github.com/openshift/hive/apis/hive/v1"
 	operatorsapiv2 "github.com/operator-framework/api/pkg/operators/v2"
@@ -112,6 +113,8 @@ func init() {
 	utilruntime.Must(configv1.AddToScheme(scheme))
 
 	utilruntime.Must(operatorv1.AddToScheme(scheme))
+
+	utilruntime.Must(openshift_consolev1.AddToScheme(scheme))
 
 	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,7 +15,7 @@ var Version string
 
 // MinimumOCPVersion is the minimum version of OCP this operator supports.
 // Can be overridden by setting the env variable DISABLE_OCP_MIN_VERSION
-var MinimumOCPVersion string = "4.10.0"
+var MinimumOCPVersion string = "4.19.0"
 
 func init() {
 	if value, exists := os.LookupEnv("OPERATOR_VERSION"); exists {


### PR DESCRIPTION
## Summary

Displays a red ConsoleNotification banner at the top of the OCP console when MCE is installed on an OCP version below the minimum supported version. Includes a "Contact Red Hat Support" link.

This mirrors the pattern implemented in multiclusterhub-operator for ACM-37782.

## Changes

- **`controllers/console_notification.go`** — new file with `ensureOCPComplianceBanner()`, `removeOCPComplianceBanner()`, `cleanupConsoleNotifications()`
- **`controllers/console_notification_test.go`** — Ginkgo tests for banner lifecycle
- **`controllers/backplaneconfig_controller.go`** — wire banner into reconcile loop (before blocking on OCP version failure) and finalizer cleanup; add `consolenotifications` to RBAC marker
- **`main.go`** — register `console/v1` scheme
- **`controllers/suite_test.go`** — register `console/v1` scheme for envtest
- **`pkg/version/version.go`** — bump `MinimumOCPVersion` from `4.10.0` → `4.19.0`
- **`hack/unit-test-crds/consolenotification.yaml`** — ConsoleNotification CRD for envtest

## Design notes

- Banner uses PatternFly CSS variables for colors (PFv6 with PFv5 fallback) — consistent with MCH implementation
- Banner is created **before** `ValidOCPVersion` returns the blocking error, so it persists while reconciliation is stopped
- Banner is removed automatically when OCP version meets minimum
- Banner is cleaned up on MCE deletion via `cleanupConsoleNotifications()` in `finalizeBackplaneConfig()`

## Testing

- `go build ./...` passes
- `go vet ./...` passes
- `go test ./pkg/version/...` passes
- Controller Ginkgo tests require kubebuilder envtest binaries (run in CI)

Fixes: [ACM-37785](https://redhat.atlassian.net/browse/ACM-37785)


[ACM-37785]: https://redhat.atlassian.net/browse/ACM-37785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ