### PR TITLE
feat(ACM-38894): add OCP version mismatch ConsoleNotification banner (2.11)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1145,6 +1145,7 @@ rules:
 - apiGroups:
   - console.openshift.io
   resources:
+  - consolenotifications
   - consoleplugins
   - consolequickstarts
   verbs:

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -107,7 +107,7 @@ var (
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs,verbs=list
 // +kubebuilder:rbac:groups="discovery.open-cluster-management.io",resources=discoveryconfigs;discoveredclusters,verbs=create;get;list;watch;update;delete;deletecollection;patch;approve;escalate;bind
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch;
-// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;consolequickstarts;consolenotifications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update;patch
 
 // AgentServiceConfig webhook delete check
@@ -302,6 +302,11 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		currentOCPVersion, err := r.getClusterVersion(ctx)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to detect clusterversion: %w", err)
+		}
+
+		// Ensure OCP compliance banner reflects current version (create or remove as needed)
+		if bannerErr := r.ensureOCPComplianceBanner(ctx, backplaneConfig, currentOCPVersion); bannerErr != nil {
+			log.Error(bannerErr, "Failed to reconcile OCP compliance ConsoleNotification banner")
 		}
 
 		if err := version.ValidOCPVersion(currentOCPVersion); err != nil {
@@ -2074,6 +2079,11 @@ func (r *MultiClusterEngineReconciler) finalizeBackplaneConfig(ctx context.Conte
 				log.Info("Error ensuring plugin is removed from console resource")
 				return ctrl.Result{}, err
 			}
+		}
+
+		if err := r.cleanupConsoleNotifications(ctx, backplaneConfig); err != nil {
+			log.Error(err, "Failed to clean up ConsoleNotification banners")
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -830,7 +830,7 @@ var _ = Describe("BackplaneConfig controller", func() {
 			})
 		})
 
-			Context("and OCP Console is disabled", func() {
+		Context("and OCP Console is disabled", func() {
 			It("should deploy sub components", func() {
 				os.Setenv("ACM_HUB_OCP_VERSION", "4.18.0")
 				defer os.Unsetenv("ACM_HUB_OCP_VERSION")

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	configv1 "github.com/openshift/api/config/v1"
+	openshift_consolev1 "github.com/openshift/api/console/v1"
 
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	"github.com/stolostron/backplane-operator/pkg/status"
@@ -829,9 +830,9 @@ var _ = Describe("BackplaneConfig controller", func() {
 			})
 		})
 
-		Context("and OCP Console is disabled", func() {
+			Context("and OCP Console is disabled", func() {
 			It("should deploy sub components", func() {
-				os.Setenv("ACM_HUB_OCP_VERSION", "4.12.0")
+				os.Setenv("ACM_HUB_OCP_VERSION", "4.18.0")
 				defer os.Unsetenv("ACM_HUB_OCP_VERSION")
 				createCtx := context.Background()
 				By("creating the backplane config")
@@ -866,7 +867,7 @@ var _ = Describe("BackplaneConfig controller", func() {
 			It("should deploy sub components", func() {
 				createCtx := context.Background()
 				By("creating the backplane config with everything enabled")
-				os.Setenv("ACM_HUB_OCP_VERSION", "4.12.0")
+				os.Setenv("ACM_HUB_OCP_VERSION", "4.18.0")
 				defer os.Unsetenv("ACM_HUB_OCP_VERSION")
 				backplaneConfig := &backplanev1.MultiClusterEngine{
 					TypeMeta: metav1.TypeMeta{
@@ -1642,6 +1643,7 @@ var _ = Describe("BackplaneConfig controller", func() {
 func registerScheme() {
 	backplanev1.AddToScheme(scheme.Scheme)
 	configv1.AddToScheme(scheme.Scheme)
+	openshift_consolev1.AddToScheme(scheme.Scheme)
 }
 
 func Test_getComponentConfig(t *testing.T) {

--- a/controllers/console_notification.go
+++ b/controllers/console_notification.go
@@ -1,0 +1,119 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	consolev1 "github.com/openshift/api/console/v1"
+	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
+	"github.com/stolostron/backplane-operator/pkg/version"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ocpComplianceBannerName = "mce-ocp-version-compliance"
+	bannerBackgroundColor   = "var(--pf-v6-c-banner--m-danger--BackgroundColor, var(--pf-v5-c-banner--m-red--BackgroundColor))"
+	bannerTextColor         = "var(--pf-v6-c-banner--m-danger--Color, var(--pf-v5-global--Color--100))"
+	bannerSupportLinkHref   = "https://access.redhat.com/support"
+	bannerSupportLinkText   = "Contact Red Hat Support"
+)
+
+func ocpComplianceBannerText(currentVersion, minimumVersion string) string {
+	return fmt.Sprintf(
+		"WARNING: MCE in unsupported configuration: OCP %s is below the minimum supported version %s.",
+		currentVersion, minimumVersion,
+	)
+}
+
+func (r *MultiClusterEngineReconciler) ensureOCPComplianceBanner(ctx context.Context,
+	mce *backplanev1.MultiClusterEngine,
+	ocpVersion string) error {
+
+	if ocpVersion == "" {
+		return r.removeOCPComplianceBanner(ctx)
+	}
+
+	// If OCP version is valid, remove banner
+	if err := version.ValidOCPVersion(ocpVersion); err == nil {
+		return r.removeOCPComplianceBanner(ctx)
+	}
+
+	desired := &consolev1.ConsoleNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ocpComplianceBannerName,
+			Labels: map[string]string{
+				"installer.name":      mce.GetName(),
+				"installer.namespace": mce.GetNamespace(),
+			},
+		},
+		Spec: consolev1.ConsoleNotificationSpec{
+			Text:            ocpComplianceBannerText(ocpVersion, version.MinimumOCPVersion),
+			Location:        consolev1.BannerTop,
+			BackgroundColor: bannerBackgroundColor,
+			Color:           bannerTextColor,
+			Link: &consolev1.Link{
+				Text: bannerSupportLinkText,
+				Href: bannerSupportLinkHref,
+			},
+		},
+	}
+
+	existing := &consolev1.ConsoleNotification{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, existing)
+	if errors.IsNotFound(err) {
+		log.Info("Creating OCP compliance ConsoleNotification banner")
+		if err := r.Client.Create(ctx, desired); err != nil {
+			return fmt.Errorf("failed to create ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+	}
+
+	if existing.Spec.Text != desired.Spec.Text ||
+		existing.Spec.BackgroundColor != desired.Spec.BackgroundColor ||
+		existing.Spec.Color != desired.Spec.Color ||
+		existing.Spec.Location != desired.Spec.Location {
+		patch := client.MergeFrom(existing.DeepCopy())
+		existing.Spec = desired.Spec
+		existing.Labels = desired.Labels
+		log.Info("Updating OCP compliance ConsoleNotification banner")
+		if err := r.Client.Patch(ctx, existing, patch); err != nil {
+			return fmt.Errorf("failed to patch ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *MultiClusterEngineReconciler) removeOCPComplianceBanner(ctx context.Context) error {
+	notification := &consolev1.ConsoleNotification{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+	}
+
+	log.Info("Removing OCP compliance ConsoleNotification banner")
+	if err := r.Client.Delete(ctx, notification); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete ConsoleNotification %s: %w", ocpComplianceBannerName, err)
+	}
+	return nil
+}
+
+func (r *MultiClusterEngineReconciler) cleanupConsoleNotifications(ctx context.Context,
+	mce *backplanev1.MultiClusterEngine) error {
+	return r.Client.DeleteAllOf(ctx, &consolev1.ConsoleNotification{}, client.MatchingLabels{
+		"installer.name":      mce.GetName(),
+		"installer.namespace": mce.GetNamespace(),
+	})
+}

--- a/controllers/console_notification_test.go
+++ b/controllers/console_notification_test.go
@@ -1,0 +1,176 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+
+	consolev1 "github.com/openshift/api/console/v1"
+	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
+	"github.com/stolostron/backplane-operator/pkg/version"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("OCP compliance ConsoleNotification banner", func() {
+	var (
+		ctx context.Context
+		mce *backplanev1.MultiClusterEngine
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		mce = &backplanev1.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multiclusterengine",
+				Namespace: "multicluster-engine",
+			},
+		}
+	})
+
+	AfterEach(func() {
+		// Clean up banner if it exists
+		notification := &consolev1.ConsoleNotification{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification); err == nil {
+			_ = k8sClient.Delete(ctx, notification)
+		}
+	})
+
+	Context("ensureOCPComplianceBanner", func() {
+		It("creates a banner when OCP version is below minimum", func() {
+			err := reconciler.ensureOCPComplianceBanner(ctx, mce, "4.17.0")
+			Expect(err).NotTo(HaveOccurred())
+
+			notification := &consolev1.ConsoleNotification{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(notification.Spec.Text).To(Equal(ocpComplianceBannerText("4.17.0", version.MinimumOCPVersion)))
+			Expect(notification.Spec.Location).To(Equal(consolev1.BannerTop))
+			Expect(notification.Spec.BackgroundColor).To(Equal(bannerBackgroundColor))
+			Expect(notification.Spec.Color).To(Equal(bannerTextColor))
+			Expect(notification.Spec.Link).NotTo(BeNil())
+			Expect(notification.Spec.Link.Href).To(Equal(bannerSupportLinkHref))
+			Expect(notification.Spec.Link.Text).To(Equal(bannerSupportLinkText))
+			Expect(notification.Labels["installer.name"]).To(Equal(mce.GetName()))
+			Expect(notification.Labels["installer.namespace"]).To(Equal(mce.GetNamespace()))
+		})
+
+		It("does not create a banner when OCP version meets minimum", func() {
+			err := reconciler.ensureOCPComplianceBanner(ctx, mce, version.MinimumOCPVersion)
+			Expect(err).NotTo(HaveOccurred())
+
+			notification := &consolev1.ConsoleNotification{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("removes existing banner when OCP version meets minimum", func() {
+			// Pre-create a banner
+			existing := &consolev1.ConsoleNotification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ocpComplianceBannerName,
+					Labels: map[string]string{
+						"installer.name":      mce.GetName(),
+						"installer.namespace": mce.GetNamespace(),
+					},
+				},
+				Spec: consolev1.ConsoleNotificationSpec{
+					Text:            "old warning",
+					Location:        consolev1.BannerTop,
+					BackgroundColor: bannerBackgroundColor,
+					Color:           bannerTextColor,
+				},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			// Now pass a valid OCP version
+			err := reconciler.ensureOCPComplianceBanner(ctx, mce, version.MinimumOCPVersion)
+			Expect(err).NotTo(HaveOccurred())
+
+			notification := &consolev1.ConsoleNotification{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("does not create a banner when OCP version is empty", func() {
+			err := reconciler.ensureOCPComplianceBanner(ctx, mce, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			notification := &consolev1.ConsoleNotification{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("updates an existing banner when OCP version changes", func() {
+			// Create initial banner
+			Expect(reconciler.ensureOCPComplianceBanner(ctx, mce, "4.17.0")).To(Succeed())
+
+			notification := &consolev1.ConsoleNotification{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)).To(Succeed())
+			expectedText := ocpComplianceBannerText("4.17.0", version.MinimumOCPVersion)
+
+			// Force a stale text via direct update to simulate out-of-sync state
+			notification.Spec.Text = "stale text"
+			Expect(k8sClient.Update(ctx, notification)).To(Succeed())
+
+			// Retry until the reconciler's cached client sees the update and patches it back
+			Eventually(func() error {
+				return reconciler.ensureOCPComplianceBanner(ctx, mce, "4.17.0")
+			}).Should(Succeed())
+
+			Eventually(func() string {
+				updated := &consolev1.ConsoleNotification{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, updated); err != nil {
+					return ""
+				}
+				return updated.Spec.Text
+			}).Should(Equal(expectedText))
+		})
+	})
+
+	Context("removeOCPComplianceBanner", func() {
+		It("removes an existing banner", func() {
+			existing := &consolev1.ConsoleNotification{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ocpComplianceBannerName,
+					Labels: map[string]string{
+						"installer.name":      mce.GetName(),
+						"installer.namespace": mce.GetNamespace(),
+					},
+				},
+				Spec: consolev1.ConsoleNotificationSpec{
+					Text:     "warning",
+					Location: consolev1.BannerTop,
+				},
+			}
+			Expect(k8sClient.Create(ctx, existing)).To(Succeed())
+
+			Eventually(func() error {
+				return reconciler.removeOCPComplianceBanner(ctx)
+			}).Should(Succeed())
+
+			Eventually(func() bool {
+				notification := &consolev1.ConsoleNotification{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: ocpComplianceBannerName}, notification)
+				return err != nil
+			}).Should(BeTrue())
+		})
+
+		It("is a no-op when banner does not exist", func() {
+			Expect(reconciler.removeOCPComplianceBanner(ctx)).To(Succeed())
+		})
+	})
+
+	Context("ocpComplianceBannerText", func() {
+		It("includes current and minimum version in text", func() {
+			text := ocpComplianceBannerText("4.18.0", "4.19.0")
+			Expect(text).To(ContainSubstring("4.18.0"))
+			Expect(text).To(ContainSubstring("4.19.0"))
+			Expect(text).To(ContainSubstring("WARNING"))
+		})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	openshift_consolev1 "github.com/openshift/api/console/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hiveconfig "github.com/openshift/hive/apis/hive/v1"
 
@@ -158,6 +159,9 @@ var _ = BeforeSuite(func() {
 	err = addToSchemeIgnoringDuplicate(operatorv1.AddToScheme, scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = addToSchemeIgnoringDuplicate(openshift_consolev1.AddToScheme, scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = os.Setenv("POD_NAMESPACE", "default")
 	Expect(err).NotTo(HaveOccurred())
 
@@ -207,6 +211,8 @@ var _ = BeforeSuite(func() {
 	err = configv1.AddToScheme(mgrScheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = operatorv1.AddToScheme(mgrScheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = openshift_consolev1.AddToScheme(mgrScheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{

--- a/hack/unit-test-crds/consolenotification.yaml
+++ b/hack/unit-test-crds/consolenotification.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
+    capability.openshift.io/name: Console
+    description: Extension for configuring openshift web console notifications.
+    displayName: ConsoleNotification
+  name: consolenotifications.console.openshift.io
+spec:
+  group: console.openshift.io
+  names:
+    kind: ConsoleNotification
+    listKind: ConsoleNotificationList
+    plural: consolenotifications
+    singular: consolenotification
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: ConsoleNotification is the Schema for the consolenotifications API
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleNotificationSpec defines the desired state of ConsoleNotification
+            type: object
+            required:
+            - text
+            properties:
+              backgroundColor:
+                type: string
+              color:
+                type: string
+              link:
+                type: object
+                properties:
+                  href:
+                    type: string
+                  text:
+                    type: string
+              location:
+                type: string
+              text:
+                type: string

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"open-cluster-management.io/sdk-go/pkg/servingcert"
 
 	configv1 "github.com/openshift/api/config/v1"
+	openshift_consolev1 "github.com/openshift/api/console/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	hiveconfig "github.com/openshift/hive/apis/hive/v1"
 	operatorsapiv2 "github.com/operator-framework/api/pkg/operators/v2"
@@ -111,6 +112,7 @@ func init() {
 	utilruntime.Must(configv1.AddToScheme(scheme))
 
 	utilruntime.Must(operatorv1.AddToScheme(scheme))
+	utilruntime.Must(openshift_consolev1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,7 +15,7 @@ var Version string
 
 // MinimumOCPVersion is the minimum version of OCP this operator supports.
 // Can be overridden by setting the env variable DISABLE_OCP_MIN_VERSION
-var MinimumOCPVersion string = "4.10.0"
+var MinimumOCPVersion string = "4.18.0"
 
 func init() {
 	if value, exists := os.LookupEnv("OPERATOR_VERSION"); exists {


### PR DESCRIPTION
# Description

Backport of [ACM-37785](https://redhat.atlassian.net/browse/ACM-37785) (backplane-2.17) to `backplane-2.11`, targeting MCE 2.11.4.

When MCE runs on OCP below the minimum supported version (4.18), a red ConsoleNotification banner appears at the top of the OpenShift console warning the administrator. The banner includes a "Contact Red Hat Support" link using PatternFly CSS variables for theming consistency.

## Related Issue

- [ACM-38894](https://redhat.atlassian.net/browse/ACM-38894) — [2.11.4] MCE: Display a Console Banner when MCE version is not supported for the installed OCP version

## Changes Made

- `controllers/console_notification.go` — **new**: `ensureOCPComplianceBanner`, `removeOCPComplianceBanner`, `cleanupConsoleNotifications`
- `controllers/console_notification_test.go` — **new**: full banner lifecycle unit tests
- `hack/unit-test-crds/consolenotification.yaml` — **new**: ConsoleNotification CRD for envtest
- `controllers/backplaneconfig_controller.go` — RBAC marker adds `consolenotifications`; `ensureOCPComplianceBanner` called in `Reconcile()` after version check; `cleanupConsoleNotifications` called in finalizer
- `controllers/suite_test.go` — register `console.openshift.io/v1` scheme
- `controllers/backplaneconfig_controller_test.go` — register `console.openshift.io/v1` scheme; update test OCP versions to `4.18.0` to meet new minimum
- `main.go` — register `console.openshift.io/v1` scheme
- `pkg/version/version.go` — `MinimumOCPVersion: "4.10.0" → "4.18.0"` (MCE 2.11 supports OCP 4.18–4.22)

**Key 2.11 adaptations vs 2.17:**
- Uses `github.com/Masterminds/semver` v1 (no `/v3` suffix)
- Calls `version.ValidOCPVersion()` directly (no `validVersion()` helper in 2.11)
- `MinimumOCPVersion = "4.18.0"` (MCE 2.11 supports OCP 4.18–4.22, not 4.19+ like 2.17)
- `removeOCPComplianceBanner` tolerates NotFound on Delete to avoid envtest races

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

[ACM-37785]: https://redhat.atlassian.net/browse/ACM-37785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-38894]: https://redhat.atlassian.net/browse/ACM-38894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ