### PR TITLE
Add backplane-rhel9-operator to image-references

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -11,6 +11,10 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/azure-service-operator-rhel9:latest
+  - name: backplane-rhel9-operator
+    from:
+      kind: DockerImage
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-rhel9-operator:latest
   - name: must-gather-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
## Summary

Add the operator image (`backplane-rhel9-operator`) to `bundle/image-references`. ART needs it there to resolve the operator's image during bundle build.

Matches the ACM pattern where `multiclusterhub-operator` is included in image-references:
https://github.com/stolostron/multiclusterhub-operator/blob/release-2.16/bundle/image-references#L94

Companion PR: https://github.com/openshift-eng/ocp-build-data/pull/12028

Ref: HYPBLD-854

Made with [Cursor](https://cursor.com)