### PR TITLE
ACM-37793: Grant ClusterExtension read access for OLMv1 detection

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -2765,6 +2765,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - olm.operatorframework.io
+          resources:
+          - clusterextensions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - operators.coreos.com
           resources:
           - subscriptions

--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -2674,6 +2674,14 @@ spec:
           - patch
           - update
         - apiGroups:
+          - olm.operatorframework.io
+          resources:
+          - clusterextensions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - operationalinsights.azure.com
           resources:
           - workspaces
@@ -2763,14 +2771,6 @@ spec:
           - list
           - patch
           - update
-          - watch
-        - apiGroups:
-          - olm.operatorframework.io
-          resources:
-          - clusterextensions
-          verbs:
-          - get
-          - list
           - watch
         - apiGroups:
           - operators.coreos.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2692,6 +2692,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operators.coreos.com
   resources:
   - subscriptions

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2601,6 +2601,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operationalinsights.azure.com
   resources:
   - workspaces
@@ -2690,14 +2698,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - olm.operatorframework.io
-  resources:
-  - clusterextensions
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - operators.coreos.com

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -171,6 +171,7 @@ var (
 // +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=clustercurators;clustercurators/status,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="config.open-cluster-management.io",resources=klusterletconfigs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=subscriptions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="olm.operatorframework.io",resources=clusterextensions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=operatorconditions,verbs=create;get;list;patch;update;delete;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenrequests,verbs=create

--- a/pkg/templates/charts/toggle/console-mce/templates/console-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-clusterrole.yaml
@@ -32,6 +32,15 @@ rules:
   - watch
 
 - apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
   - operator.open-cluster-management.io
   resources:
   - multiclusterhubs

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -701,6 +701,7 @@ package main
 //+kubebuilder:rbac:groups=notificationhubs.azure.com,resources=namespaces/finalizers;namespaces/status;namespacesauthorizationrules/finalizers;namespacesauthorizationrules/status;notificationhubs/finalizers;notificationhubs/status;notificationhubsauthorizationrules/finalizers;notificationhubsauthorizationrules/status,verbs=get;patch;update
 //+kubebuilder:rbac:groups=notificationhubs.azure.com,resources=namespaces;namespacesauthorizationrules;notificationhubs;notificationhubsauthorizationrules,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=notificationhubs.azure.com,resources=namespaces;namespacesauthorizationrules;notificationhubs;notificationhubsauthorizationrules,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=operationalinsights.azure.com,resources=workspaces,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=operationalinsights.azure.com,resources=workspaces,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=operationalinsights.azure.com,resources=workspaces/finalizers;workspaces/status,verbs=get;patch;update


### PR DESCRIPTION
## Summary
- Grants `get`/`list`/`watch` on `olm.operatorframework.io/clusterextensions` so the console can watch OLMv1 `ClusterExtension` resources without Forbidden errors.
- Updates operator RBAC markers, generated role, bundle CSV, console-mce ClusterRole, and `rbac_gen.go`.
- Required companion for [stolostron/console#6590](https://github.com/stolostron/console/pull/6590) / [ACM-37793](https://redhat.atlassian.net/browse/ACM-37793).

## Test plan
- [ ] Confirm generated RBAC CI passes (`go generate` + `controller-gen` no diff)
- [ ] Deploy/update MCE and verify console-mce ClusterRole includes `clusterextensions`
- [ ] On a hub with OLMv1, confirm console SSE/watch of `ClusterExtension` is no longer Forbidden
- [ ] On a hub without the CRD, confirm existing Subscription-based detection still works

## Reviewers
/cc @gparvin  @dislbenn 

Made with [Cursor](https://cursor.com)

[ACM-37793]: https://redhat.atlassian.net/browse/ACM-37793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only access to cluster extension information.
  * Improved compatibility with environments that use cluster extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->