### PR TITLE
ACM-37873: Add NetworkPolicies for server-foundation chart

### DIFF
--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/stolostron/backplane-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -286,6 +288,8 @@ func TestNonOCPRender(t *testing.T) {
 
 	os.Setenv("DIRECTORY_OVERRIDE", "../../")
 	defer os.Unsetenv("DIRECTORY_OVERRIDE")
+	originalDeployOnOCP := utils.DeployOnOCP()
+	defer utils.SetDeployOnOCP(originalDeployOnOCP)
 	utils.SetDeployOnOCP(false)
 	availabilityList := []string{"clusterclaims-controller", "cluster-curator-controller", "managedcluster-import-controller-v2", "ocm-controller", "ocm-proxyserver", "ocm-webhook"}
 	backplaneNodeSelector := map[string]string{"select": "test", "select2": "test2"}
@@ -815,6 +819,359 @@ func TestManagedServiceAccountNetworkPolicies(t *testing.T) {
 			t.Error("NetworkPolicy should not be embedded in AddOnTemplate when networkPolicies.enabled=false")
 		}
 	})
+}
+
+func TestServerFoundationNetworkPolicies(t *testing.T) {
+	os.Setenv("DIRECTORY_OVERRIDE", "../../")
+	defer os.Unsetenv("DIRECTORY_OVERRIDE")
+	os.Setenv("POD_NAMESPACE", "default")
+	defer os.Unsetenv("POD_NAMESPACE")
+	os.Setenv("ACM_HUB_OCP_VERSION", "4.12.0")
+	defer os.Unsetenv("ACM_HUB_OCP_VERSION")
+	// ocm-proxyserver (and its NetworkPolicy) are OCP-only; pin deployOnOCP so
+	// earlier tests that flip the package-level flag cannot flake this assertion.
+	originalDeployOnOCP := utils.DeployOnOCP()
+	defer utils.SetDeployOnOCP(originalDeployOnOCP)
+	utils.SetDeployOnOCP(true)
+
+	testImages := map[string]string{}
+	for _, v := range utils.GetTestImages() {
+		testImages[v] = "quay.io/test/test:Test"
+	}
+
+	sfChart := "pkg/templates/charts/toggle/server-foundation"
+	expectedNPNames := map[string]bool{
+		"managedcluster-import-controller-network-policy": false,
+		"ocm-controller-network-policy":                   false,
+		"ocm-webhook-network-policy":                      false,
+		"ocm-proxyserver-network-policy":                  false,
+	}
+
+	t.Run("NetworkPolicies enabled renders hub NPs and controller flag", func(t *testing.T) {
+		mce := &backplane.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-mce"},
+			Spec: backplane.MultiClusterEngineSpec{
+				TargetNamespace: "default",
+				NetworkPolicies: &backplane.NetworkPoliciesConfig{Enabled: true},
+			},
+		}
+
+		templates, errs := RenderChart(sfChart, mce, testImages, map[string]string{})
+		if len(errs) > 0 {
+			t.Fatalf("RenderChart failed: %v", errs)
+		}
+
+		found := map[string]bool{}
+		for name := range expectedNPNames {
+			found[name] = false
+		}
+		ocmControllerFlag := false
+		for _, tmpl := range templates {
+			if tmpl.GetKind() == "NetworkPolicy" {
+				if _, ok := found[tmpl.GetName()]; ok {
+					found[tmpl.GetName()] = true
+					assertServerFoundationNetworkPolicy(t, tmpl)
+				} else {
+					t.Errorf("unexpected NetworkPolicy name: %s", tmpl.GetName())
+				}
+			}
+			if tmpl.GetKind() == "Deployment" && tmpl.GetName() == "ocm-controller" {
+				containers, foundContainers, err := unstructured.NestedSlice(tmpl.Object, "spec", "template", "spec", "containers")
+				if err != nil {
+					t.Fatalf("ocm-controller containers NestedSlice: %v", err)
+				}
+				if !foundContainers {
+					t.Fatal("ocm-controller missing spec.template.spec.containers")
+				}
+				for i, c := range containers {
+					container, ok := c.(map[string]interface{})
+					if !ok {
+						t.Fatalf("ocm-controller containers[%d] is not a map", i)
+					}
+					args, foundArgs, err := unstructured.NestedStringSlice(container, "args")
+					if err != nil {
+						t.Fatalf("ocm-controller containers[%d] args NestedStringSlice: %v", i, err)
+					}
+					if !foundArgs {
+						t.Fatalf("ocm-controller containers[%d] missing args", i)
+					}
+					for _, arg := range args {
+						if arg == "--enable-network-policies=true" {
+							ocmControllerFlag = true
+						}
+					}
+				}
+			}
+		}
+		for name, ok := range found {
+			if !ok {
+				t.Errorf("expected NetworkPolicy %s when networkPolicies.enabled=true", name)
+			}
+		}
+		if !ocmControllerFlag {
+			t.Error("expected ocm-controller --enable-network-policies=true when networkPolicies.enabled=true")
+		}
+	})
+
+	t.Run("NetworkPolicies disabled excludes hub NPs and sets flag false", func(t *testing.T) {
+		mce := &backplane.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-mce"},
+			Spec: backplane.MultiClusterEngineSpec{
+				TargetNamespace: "default",
+				NetworkPolicies: &backplane.NetworkPoliciesConfig{Enabled: false},
+			},
+		}
+
+		templates, errs := RenderChart(sfChart, mce, testImages, map[string]string{})
+		if len(errs) > 0 {
+			t.Fatalf("RenderChart failed: %v", errs)
+		}
+
+		foundOCMController := false
+		foundDisabledFlag := false
+		for _, tmpl := range templates {
+			if tmpl.GetKind() == "NetworkPolicy" {
+				t.Errorf("NetworkPolicy should not be rendered when networkPolicies.enabled=false: %s", tmpl.GetName())
+			}
+			if tmpl.GetKind() == "Deployment" && tmpl.GetName() == "ocm-controller" {
+				foundOCMController = true
+				containers, foundContainers, err := unstructured.NestedSlice(tmpl.Object, "spec", "template", "spec", "containers")
+				if err != nil {
+					t.Fatalf("ocm-controller containers NestedSlice: %v", err)
+				}
+				if !foundContainers {
+					t.Fatal("ocm-controller missing spec.template.spec.containers")
+				}
+				for i, c := range containers {
+					container, ok := c.(map[string]interface{})
+					if !ok {
+						t.Fatalf("ocm-controller containers[%d] is not a map", i)
+					}
+					args, foundArgs, err := unstructured.NestedStringSlice(container, "args")
+					if err != nil {
+						t.Fatalf("ocm-controller containers[%d] args NestedStringSlice: %v", i, err)
+					}
+					if !foundArgs {
+						t.Fatalf("ocm-controller containers[%d] missing args", i)
+					}
+					for _, arg := range args {
+						if arg == "--enable-network-policies=true" {
+							t.Error("ocm-controller should not have --enable-network-policies=true when disabled")
+						}
+						if arg == "--enable-network-policies=false" {
+							foundDisabledFlag = true
+						}
+					}
+				}
+			}
+		}
+		if !foundOCMController {
+			t.Error("expected ocm-controller Deployment when rendering server-foundation chart")
+		}
+		if !foundDisabledFlag {
+			t.Error("expected ocm-controller --enable-network-policies=false when networkPolicies.enabled=false")
+		}
+	})
+
+	t.Run("non-OCP omits proxyserver Deployment and NetworkPolicy", func(t *testing.T) {
+		utils.SetDeployOnOCP(false)
+		defer utils.SetDeployOnOCP(true)
+
+		mce := &backplane.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-mce"},
+			Spec: backplane.MultiClusterEngineSpec{
+				TargetNamespace: "default",
+				NetworkPolicies: &backplane.NetworkPoliciesConfig{Enabled: true},
+			},
+		}
+
+		templates, errs := RenderChart(sfChart, mce, testImages, map[string]string{})
+		if len(errs) > 0 {
+			t.Fatalf("RenderChart failed: %v", errs)
+		}
+
+		expectedNonOCP := map[string]bool{
+			"managedcluster-import-controller-network-policy": false,
+			"ocm-controller-network-policy":                   false,
+			"ocm-webhook-network-policy":                      false,
+		}
+		for _, tmpl := range templates {
+			if tmpl.GetKind() == "Deployment" && tmpl.GetName() == "ocm-proxyserver" {
+				t.Error("ocm-proxyserver Deployment should not render when deployOnOCP=false")
+			}
+			if tmpl.GetKind() != "NetworkPolicy" {
+				continue
+			}
+			if tmpl.GetName() == "ocm-proxyserver-network-policy" {
+				t.Error("ocm-proxyserver-network-policy should not render when deployOnOCP=false")
+				continue
+			}
+			if _, ok := expectedNonOCP[tmpl.GetName()]; ok {
+				expectedNonOCP[tmpl.GetName()] = true
+				assertServerFoundationNetworkPolicy(t, tmpl)
+			} else {
+				t.Errorf("unexpected NetworkPolicy name: %s", tmpl.GetName())
+			}
+		}
+		for name, ok := range expectedNonOCP {
+			if !ok {
+				t.Errorf("expected NetworkPolicy %s when networkPolicies.enabled=true on non-OCP", name)
+			}
+		}
+	})
+}
+
+func npPort(proto corev1.Protocol, port int32) networkingv1.NetworkPolicyPort {
+	p := port
+	protocol := proto
+	return networkingv1.NetworkPolicyPort{
+		Protocol: &protocol,
+		Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: p},
+	}
+}
+
+func sfDNSEgress() networkingv1.NetworkPolicyEgressRule {
+	return networkingv1.NetworkPolicyEgressRule{
+		Ports: []networkingv1.NetworkPolicyPort{
+			npPort(corev1.ProtocolUDP, 53),
+			npPort(corev1.ProtocolTCP, 53),
+			npPort(corev1.ProtocolUDP, 5353),
+			npPort(corev1.ProtocolTCP, 5353),
+		},
+	}
+}
+
+func sfAPIEgress() networkingv1.NetworkPolicyEgressRule {
+	return networkingv1.NetworkPolicyEgressRule{
+		Ports: []networkingv1.NetworkPolicyPort{
+			npPort(corev1.ProtocolTCP, 443),
+			npPort(corev1.ProtocolTCP, 6443),
+		},
+	}
+}
+
+func expectedServerFoundationNetworkPolicySpec(name string) (networkingv1.NetworkPolicySpec, bool) {
+	defaultDenyTypes := []networkingv1.PolicyType{
+		networkingv1.PolicyTypeIngress,
+		networkingv1.PolicyTypeEgress,
+	}
+	switch name {
+	case "managedcluster-import-controller-network-policy":
+		return networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+				"app": "managedcluster-import-controller-v2",
+			}},
+			PolicyTypes: defaultDenyTypes,
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"policy-group.network.openshift.io/ingress": "",
+						}},
+						PodSelector: &metav1.LabelSelector{},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{npPort(corev1.ProtocolTCP, 9091)},
+				},
+				{Ports: []networkingv1.NetworkPolicyPort{npPort(corev1.ProtocolTCP, 8383)}},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{sfDNSEgress(), sfAPIEgress()},
+		}, true
+	case "ocm-controller-network-policy":
+		return networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+				"control-plane": "ocm-controller",
+			}},
+			PolicyTypes: defaultDenyTypes,
+			Egress:      []networkingv1.NetworkPolicyEgressRule{sfDNSEgress(), sfAPIEgress()},
+		}, true
+	case "ocm-webhook-network-policy":
+		return networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+				"control-plane": "ocm-webhook",
+			}},
+			PolicyTypes: defaultDenyTypes,
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{Ports: []networkingv1.NetworkPolicyPort{npPort(corev1.ProtocolTCP, 8000)}},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{sfDNSEgress(), sfAPIEgress()},
+		}, true
+	case "ocm-proxyserver-network-policy":
+		return networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+				"control-plane": "ocm-proxyserver",
+			}},
+			PolicyTypes: defaultDenyTypes,
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{Ports: []networkingv1.NetworkPolicyPort{npPort(corev1.ProtocolTCP, 6443)}},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				sfDNSEgress(),
+				sfAPIEgress(),
+				{
+					To: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"component": "cluster-proxy-addon-user",
+						}},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{npPort(corev1.ProtocolTCP, 9092)},
+				},
+			},
+		}, true
+	default:
+		return networkingv1.NetworkPolicySpec{}, false
+	}
+}
+
+// assertServerFoundationNetworkPolicy checks podSelector, default-deny policyTypes,
+// and exact ingress/egress peers/ports. Also rejects allow-all rules and health-probe
+// ports that must stay closed (ocm-controller :8000).
+func assertServerFoundationNetworkPolicy(t *testing.T, tmpl *unstructured.Unstructured) {
+	t.Helper()
+	expected, ok := expectedServerFoundationNetworkPolicySpec(tmpl.GetName())
+	if !ok {
+		t.Errorf("no expected NetworkPolicy spec for %s", tmpl.GetName())
+		return
+	}
+
+	var np networkingv1.NetworkPolicy
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(tmpl.Object, &np); err != nil {
+		t.Fatalf("convert NetworkPolicy %s: %v", tmpl.GetName(), err)
+	}
+
+	if !reflect.DeepEqual(np.Spec.PodSelector, expected.PodSelector) {
+		t.Errorf("%s podSelector = %#v, want %#v", tmpl.GetName(), np.Spec.PodSelector, expected.PodSelector)
+	}
+	if !reflect.DeepEqual(np.Spec.PolicyTypes, expected.PolicyTypes) {
+		t.Errorf("%s policyTypes = %#v, want %#v", tmpl.GetName(), np.Spec.PolicyTypes, expected.PolicyTypes)
+	}
+	if !reflect.DeepEqual(np.Spec.Ingress, expected.Ingress) {
+		t.Errorf("%s ingress = %#v, want %#v", tmpl.GetName(), np.Spec.Ingress, expected.Ingress)
+	}
+	if !reflect.DeepEqual(np.Spec.Egress, expected.Egress) {
+		t.Errorf("%s egress = %#v, want %#v", tmpl.GetName(), np.Spec.Egress, expected.Egress)
+	}
+
+	for i, rule := range np.Spec.Ingress {
+		if len(rule.Ports) == 0 {
+			t.Errorf("%s ingress[%d] has no ports (overly broad allow-all ingress)", tmpl.GetName(), i)
+		}
+	}
+	for i, rule := range np.Spec.Egress {
+		if len(rule.Ports) == 0 {
+			t.Errorf("%s egress[%d] has no ports (overly broad allow-all egress)", tmpl.GetName(), i)
+		}
+	}
+
+	// ocm-controller serves health on :8000; default-deny ingress must not open that port.
+	if tmpl.GetName() == "ocm-controller-network-policy" {
+		for i, rule := range np.Spec.Ingress {
+			for _, p := range rule.Ports {
+				if p.Port != nil && p.Port.IntVal == 8000 {
+					t.Errorf("%s ingress[%d] exposes health-probe port 8000", tmpl.GetName(), i)
+				}
+			}
+		}
+	}
 }
 
 func TestRenderChartInvalidPath(t *testing.T) {

--- a/pkg/templates/charts/toggle/server-foundation/templates/managedcluster-import-controller-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/managedcluster-import-controller-networkpolicy.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Purpose: Default-deny for managedcluster-import-controller-v2, then allow
+# agent-registration ingress from OpenShift ingress/router, metrics ingress,
+# and DNS/API egress. Health probes omitted (kubelet probes are not blocked
+# by NetworkPolicy). Gaps: API egress limited to :443/:6443; DNS is
+# port-only; MIC may reach Hive/registries only via those HTTPS ports.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: managedcluster-import-controller-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: managedcluster-import-controller-v2
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # agent-registration Route (:9091) — OpenShift ingress/router only.
+  # podSelector: {} includes hostNetwork ingress pods (required on OVN-Kubernetes).
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+      podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 9091
+  # metrics (:8383)
+  - ports:
+    - protocol: TCP
+      port: 8383
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-controller-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-controller-networkpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Purpose: Default-deny for ocm-controller, then allow DNS and Kubernetes API
+# egress. No ingress rules — health probes (:8000) are not blocked by
+# NetworkPolicy. Gaps: API egress limited to :443/:6443; DNS is port-only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ocm-controller-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: ocm-controller
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-controller.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-controller.yaml
@@ -40,6 +40,7 @@ spec:
         - /controller
         - "--enable-agent-deploy=true"
         - "--agent-addon-image={{ .Values.global.imageOverrides.multicloud_manager }}"
+        - "--enable-network-policies={{ .Values.global.networkPolicies.enabled }}"
         env:
 {{- if .Values.hubconfig.proxyConfigs }}
         - name: HTTP_PROXY

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver-networkpolicy.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.global.networkPolicies.enabled .Values.global.deployOnOCP }}
+# Purpose: Default-deny for ocm-proxyserver (OCP-only workload), then allow
+# aggregated API ingress on secure port (:6443), DNS/API egress, and
+# same-namespace egress to cluster-proxy-addon-user (:9092). Probe ports
+# omitted (exec probes). Gaps: API egress limited to :443/:6443; DNS is
+# port-only; empty "from" on ingress for aggregated API / hostNetwork clients.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ocm-proxyserver-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: ocm-proxyserver
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # aggregated API Service 443 → pod :6443
+  - ports:
+    - protocol: TCP
+      port: 6443
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # cluster-proxy user-server (same namespace)
+  - to:
+    - podSelector:
+        matchLabels:
+          component: cluster-proxy-addon-user
+    ports:
+    - protocol: TCP
+      port: 9092
+{{- end }}

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-webhook-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-webhook-networkpolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Purpose: Default-deny for ocm-webhook, then allow admission webhook ingress
+# on the pod target port (:8000) and DNS/API egress. Probe ports omitted
+# (exec probes). Empty "from" for portability — kube-apiserver is often
+# hostNetwork. Gaps: API egress limited to :443/:6443; DNS is port-only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ocm-webhook-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: ocm-webhook
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # admission webhook Service 443 → pod :8000
+  - ports:
+    - protocol: TCP
+      port: 8000
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}


### PR DESCRIPTION
## Summary
- Add opt-in NetworkPolicies for server-foundation hub workloads: managedcluster-import-controller, ocm-controller, ocm-webhook, and ocm-proxyserver (ACM-37873).
- Wire `--enable-network-policies={{ .Values.global.networkPolicies.enabled }}` on ocm-controller so the work-manager addon agent NetworkPolicy can be applied on managed clusters (companion change in multicloud-operators-foundation).
- Default-deny with explicit DNS/API egress and component-specific ingress; health probe ports omitted. ocm-proxyserver NP is OCP-gated with the Deployment.

## Test plan
- [x] `go test ./pkg/rendering/ -run TestServerFoundationNetworkPolicies`
- [ ] Install/upgrade MCE with `spec.networkPolicies.enabled=true` and confirm the four hub NetworkPolicies are applied
- [ ] Confirm webhook, agent-registration, import, and proxyserver→cluster-proxy-user paths still work
- [ ] Confirm ocm-controller passes `--enable-network-policies=true` and spoke work-manager agent receives its NP (after multicloud-manager image includes the MOF change)
- [ ] Disable networkPolicies and confirm hub NPs are removed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Kubernetes NetworkPolicy enforcement for server foundation components.
  - Introduced conditional NetworkPolicies for managed cluster import controller, OCM controller, OCM webhook, and (when deployed to OCP) OCM proxy, restricting traffic to required DNS, Kubernetes API, and specific ports.
  - Updated the OCM controller to pass `--enable-network-policies` based on the global setting.

- **Tests**
  - Improved test isolation to prevent configuration leakage between test cases.
  - Added validation for exact NetworkPolicy rendering and correct controller flag behavior for enabled vs. disabled, including non-OCP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->