### PR TITLE
Add networkPolicies.enabled to managed-serviceaccount overwriteValues

### DIFF
--- a/hack/bundle-automation/chart-values/managed-serviceaccount/overwriteValues.yaml
+++ b/hack/bundle-automation/chart-values/managed-serviceaccount/overwriteValues.yaml
@@ -7,4 +7,8 @@ featureGates:
 agentImagePullSecret: ""
 enableAddOnDeploymentConfig: true
 hubDeployMode: AddOnTemplate
+prometheus:
+  enabled: true
+networkPolicies:
+  enabled: true
 global: {}

--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/managed-serviceaccount-addontemplate.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/managed-serviceaccount-addontemplate.yaml
@@ -102,55 +102,57 @@ spec:
             targetPort: metrics
           selector:
             addon-agent: managed-serviceaccount
-{{- if .Values.global.networkPolicies.enabled }}
-      # ACM override: upstream uses .Values.networkPolicies.enabled; backplane uses
-      # .Values.global.networkPolicies.enabled (from MCE spec.networkPolicies.enabled).
-      # Purpose: Default-deny for managed-serviceaccount-addon-agent on the managed
-      # cluster, then allow DNS + hub/spoke API egress. Health ingress (:8000) allows
-      # kubelet livenessProbe /healthz. Metrics ingress (:38080) is opened because the
-      # AddOnTemplate always exposes the metrics Service (no separate prometheus toggle
-      # in this chart). Peers are port-based for portability across Kubernetes vendors.
+      {{- if .Values.global.networkPolicies.enabled }}
       - apiVersion: networking.k8s.io/v1
         kind: NetworkPolicy
         metadata:
-          name: managed-serviceaccount-addon-agent-network-policy
-          namespace: open-cluster-management-agent-addon
           labels:
             addon-agent: managed-serviceaccount
+          name: managed-serviceaccount-addon-agent-network-policy
+          namespace: open-cluster-management-agent-addon
         spec:
+          egress:
+          - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+            - port: 5353
+              protocol: UDP
+            - port: 5353
+              protocol: TCP
+          - ports:
+            - port: 443
+              protocol: TCP
+            - port: 6443
+              protocol: TCP
+          ingress:
+          - ports:
+            - port: 8000
+              protocol: TCP
+          - ports:
+            - port: 38080
+              protocol: TCP
           podSelector:
             matchLabels:
               addon-agent: managed-serviceaccount
           policyTypes:
           - Ingress
           - Egress
-          ingress:
-          # kubelet livenessProbe /healthz
-          - ports:
-            - protocol: TCP
-              port: 8000
-          # metrics Service (:38080)
-          - ports:
-            - protocol: TCP
-              port: 38080
-          egress:
-          # DNS (:53 common; :5353 used by some distributions)
-          - ports:
-            - protocol: UDP
-              port: 53
-            - protocol: TCP
-              port: 53
-            - protocol: UDP
-              port: 5353
-            - protocol: TCP
-              port: 5353
-          # Hub kubeconfig API and spoke kube-apiserver
-          - ports:
-            - protocol: TCP
-              port: 443
-            - protocol: TCP
-              port: 6443
-{{- end }}
+      {{- end }}
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: managed-serviceaccount-addon-agent
+          namespace: open-cluster-management-agent-addon
+        spec:
+          endpoints:
+          - path: /metrics
+            port: metrics
+            scheme: http
+          selector:
+            matchLabels:
+              addon-agent: managed-serviceaccount
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:


### PR DESCRIPTION
# Description

Upstream managed-serviceaccount chart (backplane-5.0) defaults `networkPolicies.enabled` to `false`. Without this override, `helm template` skips the NetworkPolicy block embedded in the AddOnTemplate manifests, causing `regenerate-charts` to produce an addontemplate without the NetworkPolicy.

## Related Issue

- https://github.com/stolostron/backplane-operator/pull/3731
- https://github.com/stolostron/installer-dev-tools/pull/168

## Changes Made

- Added `networkPolicies.enabled: true` to `hack/bundle-automation/chart-values/managed-serviceaccount/overwriteValues.yaml` so `helm template` renders the NetworkPolicy block from upstream.
- Regenerated `managed-serviceaccount-addontemplate.yaml` with the NetworkPolicy block now present and wrapped with `{{- if .Values.global.networkPolicies.enabled }}` / `{{- end }}` (wrapping provided by the companion installer-dev-tools PR).

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Depends on https://github.com/stolostron/installer-dev-tools/pull/168 which adds `ensure_addontemplate_network_policies()` to wrap embedded NetworkPolicy manifests inside AddOnTemplates with the `global.networkPolicies.enabled` conditional.

## Reviewers

/cc @dislbenn

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled network policies for the managed service account deployment.

* **Bug Fixes**
  * Restricted incoming traffic to the agent’s health endpoint.
  * Removed unnecessary inbound access to the metrics port while preserving required DNS and API connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->