### PR TITLE
ACM-37874: Add NetworkPolicy for clusterlifecycle-state-metrics

### DIFF
--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -740,6 +740,102 @@ func TestNetworkPoliciesValueInjection(t *testing.T) {
 	})
 }
 
+func TestClusterLifecycleStateMetricsNetworkPolicies(t *testing.T) {
+	t.Setenv("DIRECTORY_OVERRIDE", "../../")
+	t.Setenv("POD_NAMESPACE", "default")
+	t.Setenv("ACM_HUB_OCP_VERSION", "4.12.0")
+
+	testImages := map[string]string{}
+	for _, v := range utils.GetTestImages() {
+		testImages[v] = "quay.io/test/test:Test"
+	}
+
+	clcChart := "pkg/templates/charts/toggle/cluster-lifecycle"
+	const npName = "clusterlifecycle-state-metrics-network-policy"
+
+	t.Run("NetworkPolicies enabled renders CLSM NP", func(t *testing.T) {
+		mce := &backplane.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-mce"},
+			Spec: backplane.MultiClusterEngineSpec{
+				TargetNamespace: "default",
+				NetworkPolicies: &backplane.NetworkPoliciesConfig{Enabled: true},
+			},
+		}
+
+		templates, errs := RenderChart(clcChart, mce, testImages, map[string]string{})
+		if len(errs) > 0 {
+			t.Fatalf("RenderChart failed: %v", errs)
+		}
+
+		var np *unstructured.Unstructured
+		for _, tmpl := range templates {
+			if tmpl.GetKind() == "NetworkPolicy" {
+				if tmpl.GetName() != npName {
+					t.Errorf("unexpected NetworkPolicy name: %s", tmpl.GetName())
+					continue
+				}
+				np = tmpl
+			}
+		}
+		if np == nil {
+			t.Fatalf("expected NetworkPolicy %s when networkPolicies.enabled=true", npName)
+		}
+
+		podSelector, found, err := unstructured.NestedStringMap(np.Object, "spec", "podSelector", "matchLabels")
+		if err != nil || !found {
+			t.Fatalf("podSelector NestedStringMap: found=%v err=%v", found, err)
+		}
+		if podSelector["app"] != "clusterlifecycle-state-metrics-v2" {
+			t.Errorf("unexpected podSelector: %v", podSelector)
+		}
+
+		ingress, found, err := unstructured.NestedSlice(np.Object, "spec", "ingress")
+		if err != nil || !found || len(ingress) == 0 {
+			t.Fatalf("expected ingress rules, found=%v err=%v len=%d", found, err, len(ingress))
+		}
+		rule, ok := ingress[0].(map[string]interface{})
+		if !ok {
+			t.Fatal("ingress[0] is not a map")
+		}
+		from, found, err := unstructured.NestedSlice(rule, "from")
+		if err != nil || !found || len(from) == 0 {
+			t.Fatalf("expected ingress from openshift-monitoring, found=%v err=%v", found, err)
+		}
+		peer, ok := from[0].(map[string]interface{})
+		if !ok {
+			t.Fatal("ingress from[0] is not a map")
+		}
+		nsLabels, found, err := unstructured.NestedStringMap(peer, "namespaceSelector", "matchLabels")
+		if err != nil || !found {
+			t.Fatalf("namespaceSelector NestedStringMap: found=%v err=%v", found, err)
+		}
+		if nsLabels["kubernetes.io/metadata.name"] != "openshift-monitoring" {
+			t.Errorf("unexpected ingress namespaceSelector: %v", nsLabels)
+		}
+	})
+
+	t.Run("NetworkPolicies disabled excludes CLSM NP", func(t *testing.T) {
+		mce := &backplane.MultiClusterEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-mce"},
+			Spec: backplane.MultiClusterEngineSpec{
+				TargetNamespace: "default",
+				NetworkPolicies: &backplane.NetworkPoliciesConfig{Enabled: false},
+			},
+		}
+
+		templates, errs := RenderChart(clcChart, mce, testImages, map[string]string{})
+		if len(errs) > 0 {
+			t.Fatalf("RenderChart failed: %v", errs)
+		}
+
+		for _, tmpl := range templates {
+			if tmpl.GetKind() == "NetworkPolicy" {
+				t.Errorf("NetworkPolicy should not be rendered when networkPolicies.enabled=false: %s", tmpl.GetName())
+			}
+		}
+	})
+}
+
 func TestManagedServiceAccountNetworkPolicies(t *testing.T) {
 	os.Setenv("DIRECTORY_OVERRIDE", "../../")
 	defer os.Unsetenv("DIRECTORY_OVERRIDE")

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/clusterlifecycle-state-metrics-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/clusterlifecycle-state-metrics-networkpolicy.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Purpose: Default-deny for clusterlifecycle-state-metrics-v2, then allow
+# HTTPS metrics scrape from openshift-monitoring (:8443) and DNS/API egress.
+# Health probes (:8081) omitted (kubelet probes are not blocked by
+# NetworkPolicy). Gaps: API egress limited to :443/:6443; DNS is port-only;
+# HTTP metrics (:8080) not exposed by the Service, so not allowed.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: clusterlifecycle-state-metrics-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: clusterlifecycle-state-metrics-v2
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # HTTPS metrics (:8443) — ServiceMonitor scrapes port "https"
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8443
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}


### PR DESCRIPTION
## Summary
* Add deny-by-default NetworkPolicy for `clusterlifecycle-state-metrics-v2` in the MCE `cluster-lifecycle` chart (ACM-37874)
* Allow HTTPS metrics ingress (`:8443`) from `openshift-monitoring` only, plus DNS and kube-apiserver egress
* Gated by existing `MCE.spec.networkPolicies.enabled` / create-once reconcile path

## Test plan
- [x] Unit test `TestClusterLifecycleStateMetricsNetworkPolicies` passes
- [ ] Deploy MCE with `networkPolicies.enabled=true` and confirm `clusterlifecycle-state-metrics-network-policy` is created
- [ ] Confirm Prometheus can still scrape CLSM HTTPS metrics and the controller continues talking to the API


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network traffic controls for cluster lifecycle state metrics.
  * Metrics ingress is limited to secure HTTPS traffic from the monitoring namespace.
  * Egress is restricted to DNS services and the Kubernetes API.
  * Network policies are generated only when network policy support is enabled.

* **Tests**
  * Added coverage verifying network policy creation, configuration, and disabled-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->