### PR TITLE
ACM-39570 - adding missing port for hcp proxy

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-manager-networkpolicy.yaml
@@ -10,6 +10,10 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
   egress:
   - {}
 {{- end }}


### PR DESCRIPTION
# Description

Add ingress rule to the hypershift-addon-manager NetworkPolicy to allow traffic on port 9443 (HCP proxy). Without this rule, the NetworkPolicy declares `Ingress` as a policy type but has no ingress rules, which denies all inbound traffic — blocking the kube-apiserver from forwarding aggregated API requests to the HCP proxy.

https://github.com/stolostron/hypershift-addon-operator/pull/760 PR that introduced a new port

## Related Issue

ACM-39570

## Changes Made

- **`hypershift-addon-manager-networkpolicy.yaml`** — Added ingress rule allowing TCP traffic on port 9443, which is the only port the hypershift-addon-manager pod exposes (the HCP proxy HTTPS server backing the `v1alpha1.hcp.ocm.io` APIService).

```yaml
ingress:
- ports:
  - port: 9443
    protocol: TCP
```

No other ports need ingress:
- The manager process does not expose metrics or health probe ports externally
- Port 9443 is the sole `containerPort` declared in the deployment
- The only Service targeting this pod is `hypershift-addon-hcp-proxy` (port 443 → targetPort 9443)

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- The NetworkPolicy previously had `policyTypes: [Ingress, Egress]` with only an egress rule (`- {}`), meaning all ingress was implicitly denied. This broke the HCP proxy's aggregated API flow where kube-apiserver needs to reach port 9443.
- Egress remains unrestricted (`- {}`) as the pod needs outbound connectivity to cluster-proxy, the kube-apiserver, and spoke clusters.

## Reviewers

/cc @yiraeChristineKim

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules to allow required TCP traffic on port 9443 for the Hypershift Addon Manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->