### PR TITLE
ACM-37751 - Search Indexer proxy egress NetworkPolicy

### DIFF
--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -1211,6 +1211,9 @@ func expectedServerFoundationNetworkPolicySpec(name string) (networkingv1.Networ
 					}},
 					Ports: []networkingv1.NetworkPolicyPort{npPort(corev1.ProtocolTCP, 9092)},
 				},
+				{
+					Ports: []networkingv1.NetworkPolicyPort{npPort(corev1.ProtocolTCP, 3010)},
+				},
 			},
 		}, true
 	default:

--- a/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/server-foundation/templates/ocm-proxyserver-networkpolicy.yaml
@@ -45,4 +45,8 @@ spec:
     ports:
     - protocol: TCP
       port: 9092
+  # search-indexer (proxied managed-cluster collector traffic)
+  - ports:
+    - protocol: TCP
+      port: 3010
 {{- end }}


### PR DESCRIPTION
# Description

ocm-proxyserver NetworkPolicy needed an egress to :3010 for managed cluster Search pods to reach the hub cluster Indexer via the proxy server.

## Related Issue

https://redhat.atlassian.net/browse/ACM-37751

## Changes Made

Add an egress rule to TCP to :3010, namespace is variable so didn't utilize namespace/pod selectors

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [] I have added necessary comments to the code, especially in complex or unclear sections.
- [] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules to allow the proxy server to connect to the search indexer on TCP port 3010.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->