### PR TITLE
ACM-39871 Removed redundant log statement and added Namespace to existing statement

### DIFF
--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -232,7 +232,7 @@ func validateLocalClusterNameLength(name string) (err error) {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *MultiClusterEngine) ValidateUpdate(ctx context.Context, oldObj, newObj *MultiClusterEngine) (admission.Warnings, error) {
-	backplaneconfiglog.Info("validate update", "Kind", newObj.Kind, "Name", newObj.GetName(), "Namespace", newObj.Namespace)
+	backplaneconfiglog.Info("validate update", "Kind", newObj.Kind, "Name", newObj.GetName(), "Namespace", newObj.Spec.TargetNamespace)
 
 	if (newObj.Spec.TargetNamespace != oldObj.Spec.TargetNamespace) && (oldObj.Spec.TargetNamespace != "") {
 		return nil, fmt.Errorf("%w: changes cannot be made to target namespace", ErrInvalidNamespace)

--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -232,9 +232,8 @@ func validateLocalClusterNameLength(name string) (err error) {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *MultiClusterEngine) ValidateUpdate(ctx context.Context, oldObj, newObj *MultiClusterEngine) (admission.Warnings, error) {
-	backplaneconfiglog.Info("validate update", "Kind", newObj.Kind, "Name", newObj.GetName())
+	backplaneconfiglog.Info("validate update", "Kind", newObj.Kind, "Name", newObj.GetName(), "Namespace", newObj.Namespace)
 
-	backplaneconfiglog.Info("validating update", "oldTargetNamespace", oldObj.Spec.TargetNamespace)
 	if (newObj.Spec.TargetNamespace != oldObj.Spec.TargetNamespace) && (oldObj.Spec.TargetNamespace != "") {
 		return nil, fmt.Errorf("%w: changes cannot be made to target namespace", ErrInvalidNamespace)
 	}


### PR DESCRIPTION
# Description

This PR removed a redundant log statement and adds namespace to the existing statement.

## Related Issue

https://redhat.atlassian.net/browse/ACM-39871