### PR TITLE
MCE to ART: Align image-references from.name URLs with CSV placeholders

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -14,11 +14,11 @@ spec:
   - name: backplane-rhel9-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-rhel9-operator:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-operator:latest
   - name: must-gather-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/must-gather-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-must-gather-rhel9:latest
   - name: capoa-bootstrap-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
The CSV references multicluster-engine/backplane-must-gather-rhel9 and multicluster-engine/backplane-operator, but the image-references file used different paths (must-gather-rhel9 and backplane-rhel9-operator). 

ART's bundle automation replaces CSV references by matching them against the from.name field in image-references. 

Because these didn't match, the CSV placeholders were left unreplaced, causing verify-conforma to fail with olm.allowed_registries and olm.unmapped_references violations.
