### PR TITLE
MCE to ART: Add version replacement to art.yaml for FBC build

### DIFF
--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -1,4 +1,9 @@
 ---
+updates:
+- file: "manifests/multicluster-engine.clusterserviceversion.yaml"
+  update_list:
+  - search: "2.11.4"
+    replace: "2.11.5"
 external-images:
 - name: assisted-image-service
   search: "image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-image-service-rhel9:latest"


### PR DESCRIPTION
The FBC build fails with "multiple channel heads found in graph: multicluster-engine.v2.11.3, multicluster-engine.v2.11.4" because the CSV version and olm.skipRange are not updated to 2.11.5 during bundle generation. Add an updates section to art.yaml that replaces all occurrences of 2.11.4 with 2.11.5 in the CSV, covering spec.version, metadata.name, and olm.skipRange.
