### PR TITLE
Add version ldflags injection to CI/CD Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,7 @@ SHELL = /usr/bin/env bash -o pipefail
 GIT_VERSION ?= $(shell git describe --match='v*' --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
 BUILDDATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-GIT_TREESTATE = "clean"
-DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
-ifeq ($(DIFF), 1)
-    GIT_TREESTATE = "dirty"
-endif
+GIT_TREESTATE = $(shell git diff --quiet >/dev/null 2>&1; rc=$$?; if [ $$rc -eq 0 ]; then echo "clean"; elif [ $$rc -eq 1 ]; then echo "dirty"; else echo "unknown"; fi)
 
 VERSION_PKG = "github.com/stolostron/backplane-operator/pkg/version"
 LDFLAGS = "-X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -15,8 +15,10 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
+ARG LDFLAGS
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o backplane-operator main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "${LDFLAGS}" -o backplane-operator main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -19,8 +19,10 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
+ARG LDFLAGS
+
 # Build
-RUN CGO_ENABLED=1 go build -mod=readonly -o backplane-operator main.go
+RUN CGO_ENABLED=1 go build -mod=readonly -ldflags "${LDFLAGS}" -o backplane-operator main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
# Description

Add version ldflags injection to `build/Dockerfile.prow` and `build/Dockerfile.rhtap` so that CI-produced operator binaries report accurate version information (`gitVersion`, `gitCommit`, `gitTreeState`, `buildDate`) instead of placeholder defaults.

## Related Issue

N/A

## Changes Made

The root `Dockerfile` and `Makefile` already define `LDFLAGS` and pass them via `--build-arg` and `-ldflags` respectively. However, two CI/CD Dockerfiles were missing this:

- **`build/Dockerfile.prow`**: Added `ARG LDFLAGS` and updated `go build` to include `-ldflags "${LDFLAGS}"`
- **`build/Dockerfile.rhtap`**: Added `ARG LDFLAGS` and updated `go build` to include `-ldflags "${LDFLAGS}"`

`build/Dockerfile.test.prow` was not modified because it builds test binaries with `ginkgo build`, not the operator binary.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

The Makefile already computes `LDFLAGS` and passes them as `--build-arg LDFLAGS=${LDFLAGS}` in the `docker-build` and `podman-build` targets. The CI pipelines using `Dockerfile.prow` and `Dockerfile.rhtap` will need to pass the `LDFLAGS` build arg similarly for full effect, but even without it the Dockerfiles will now accept the arg gracefully (defaulting to empty if not provided, which preserves current behavior).

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Added support for passing linker build options when creating the application container images.
  * Improved flexibility for customizing build metadata during image generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->