### PR TITLE
fix: handle non-git context in GIT_TREESTATE detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,7 @@ SHELL = /usr/bin/env bash -o pipefail
 GIT_VERSION ?= $(shell git describe --match='v*' --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
 BUILDDATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-GIT_TREESTATE = "clean"
-DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
-ifeq ($(DIFF), 1)
-    GIT_TREESTATE = "dirty"
-endif
+GIT_TREESTATE = $(shell git diff --quiet >/dev/null 2>&1; rc=$$?; if [ $$rc -eq 0 ]; then echo "clean"; elif [ $$rc -eq 1 ]; then echo "dirty"; else echo "unknown"; fi)
 
 VERSION_PKG = "github.com/stolostron/backplane-operator/pkg/version"
 LDFLAGS = "-X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \


### PR DESCRIPTION
## Summary
- When building from a source archive without `.git`, `git diff --quiet` fails with a non-zero/non-one exit code
- The previous logic defaulted to "clean" in this case, which is incorrect
- Replaced the multi-line `DIFF` variable + `ifeq` pattern with a single `$(shell ...)` that checks the exit code: 0 = clean, 1 = dirty, anything else = unknown

## Test plan
- [x] Verified `GIT_TREESTATE` evaluates to `dirty` when there are uncommitted changes
- [ ] Verify `GIT_TREESTATE` evaluates to `clean` on a clean working tree
- [ ] Verify `GIT_TREESTATE` evaluates to `unknown` when building outside a git repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified repository state detection.
  * Repository status now reports as clean, dirty, or unknown based on changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->