### PR TITLE
MCE to ART: Add OPERATOR_VERSION and OPERATOR_PACKAGE env vars to CSV

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -3524,6 +3524,10 @@ spec:
                   value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/ose-baremetal-cluster-api-controllers-rhel9:latest
                 - name: OPERAND_IMAGE_POSTGRESQL_13
                   value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/postgresql-13:latest
+                - name: OPERATOR_VERSION
+                  value: "2.11.4"
+                - name: OPERATOR_PACKAGE
+                  value: multicluster-engine
                 image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-operator:latest
                 imagePullPolicy: IfNotPresent
                 livenessProbe:


### PR DESCRIPTION
The operator panics at startup with "OPERATOR_VERSION not defined" because these required env vars are missing from the CSV deployment spec. Add them with the current version (2.11.4) which will be updated to the build version by art.yaml during bundle generation.