### PR TITLE
[ACM-40127] Force-disable maestro-preview component in MCE 5.0

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -48,7 +48,6 @@ const (
 	ManagedServiceAccount            = "managedserviceaccount"
 	ManagedServiceAccountPreview     = "managedserviceaccount-preview"
 	ServerFoundation                 = "server-foundation"
-	Maestro                          = "maestro"
 	MaestroPreview                   = "maestro-preview"
 
 	// CRD directory names
@@ -103,7 +102,6 @@ var AllComponents = []string{
 	ManagedServiceAccount,
 	ManagedServiceAccountPreview,
 	ServerFoundation,
-	// Maestro, Uncomment until stable release is available
 	MaestroPreview,
 }
 
@@ -129,7 +127,6 @@ var MCEComponents = []string{
 	ImageBasedInstallOperator,
 	ManagedServiceAccount,
 	ServerFoundation,
-	// Maestro, Uncomment until stable release is available
 	MaestroPreview,
 }
 
@@ -146,7 +143,6 @@ var PreviewComponents = []string{
 	HyperShiftPreview,
 	ImageBasedInstallOperatorPreview,
 	ManagedServiceAccountPreview,
-	// MaestroPreview, // Uncomment when stable release is available
 }
 
 /*
@@ -162,7 +158,6 @@ var PreviewToStable = map[string]string{
 	HyperShiftPreview:                HyperShift,                // Upgraded in ACM 2.8 / MCE 2.3
 	ImageBasedInstallOperatorPreview: ImageBasedInstallOperator, // Upgraded in ACM 2.12 / MCE 2.7
 	ManagedServiceAccountPreview:     ManagedServiceAccount,     // Upgraded in ACM 2.9 / MCE 2.4
-	// MaestroPreview:                   Maestro,                   // Upgraded in ACM 2.17 / MCE 2.12
 }
 
 /*

--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -67,6 +67,7 @@ var (
 	ErrInvalidAvailability  = errors.New("invalid AvailabilityConfig")
 	ErrInvalidInfraNS       = errors.New("invalid InfrastructureCustomNamespace")
 	ErrComponentExclusivity = errors.New("component exclusivity violation")
+	ErrMaestroDeprecated    = errors.New("maestro component is deprecated in MCE 5.0 and cannot be enabled")
 
 	blockDeletionResources = []BlockDeletionResource{
 		{
@@ -182,6 +183,9 @@ func (r *MultiClusterEngine) ValidateCreate(ctx context.Context, obj *MultiClust
 			if !validComponent(c) {
 				return nil, fmt.Errorf("%w: %s is not a known component", ErrInvalidComponent, c.Name)
 			}
+			if c.Name == MaestroPreview && c.Enabled {
+				return nil, fmt.Errorf("%w: %s cannot be enabled", ErrMaestroDeprecated, c.Name)
+			}
 		}
 	}
 
@@ -261,6 +265,9 @@ func (r *MultiClusterEngine) ValidateUpdate(ctx context.Context, oldObj, newObj 
 		for _, c := range newObj.Spec.Overrides.Components {
 			if !validComponent(c) {
 				return nil, fmt.Errorf("%w: %s is not a known component", ErrInvalidComponent, c.Name)
+			}
+			if c.Name == MaestroPreview && c.Enabled && !oldObj.Enabled(MaestroPreview) {
+				return nil, fmt.Errorf("%w: %s cannot be enabled", ErrMaestroDeprecated, c.Name)
 			}
 		}
 	}

--- a/api/v1/multiclusterengine_webhook_test.go
+++ b/api/v1/multiclusterengine_webhook_test.go
@@ -105,6 +105,26 @@ var _ = Describe("Multiclusterengine webhook", func() {
 				}
 				Expect(k8sClient.Create(ctx, mce)).NotTo(BeNil(), "Invalid components not allowed in config")
 			})
+			By("because maestro-preview is deprecated", func() {
+				mce := &MultiClusterEngine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        fmt.Sprintf("%s-maestro", multiClusterEngineName),
+						Annotations: map[string]string{"deploymentmode": string(ModeHosted)},
+					},
+					Spec: MultiClusterEngineSpec{
+						TargetNamespace: "maestro-ns",
+						Overrides: &Overrides{
+							Components: []ComponentConfig{
+								{
+									Name:    MaestroPreview,
+									Enabled: true,
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, mce)).NotTo(BeNil(), "maestro-preview component should be blocked")
+			})
 		})
 
 		It("Should fail to update multiclusterengine", func() {
@@ -138,6 +158,19 @@ var _ = Describe("Multiclusterengine webhook", func() {
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())
 				mce.Spec.Overrides = &Overrides{}
 				Expect(k8sClient.Update(ctx, mce)).To(Succeed())
+			})
+
+			By("because maestro-preview cannot be enabled", func() {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())
+				mce.Spec.Overrides = &Overrides{
+					Components: []ComponentConfig{
+						{
+							Name:    MaestroPreview,
+							Enabled: true,
+						},
+					},
+				}
+				Expect(k8sClient.Update(ctx, mce)).NotTo(BeNil(), "maestro-preview cannot be enabled")
 			})
 
 			By("because of existing local-cluster resource", func() {

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -204,6 +204,17 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Check if any deprecated fields are present within the backplaneConfig spec.
 	r.CheckDeprecatedFieldUsage(backplaneConfig)
 
+	// Auto-disable maestro-preview if enabled
+	if backplaneConfig.Enabled(backplanev1.MaestroPreview) {
+		r.Log.Info("Auto-disabling maestro-preview component")
+		backplaneConfig.Disable(backplanev1.MaestroPreview)
+		if err := r.Client.Update(ctx, backplaneConfig); err != nil {
+			r.Log.Error(err, "Failed to disable maestro-preview")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	// reset status manager
 	r.StatusManager.Reset("")
 	for _, c := range backplaneConfig.Status.Conditions {

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -3269,6 +3270,61 @@ func Test_CleanupVersionedAddOnTemplates(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func Test_AutoDisableMaestroPreview(t *testing.T) {
+	registerScheme()
+
+	mce := &backplanev1.MultiClusterEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mce-maestro",
+		},
+		Spec: backplanev1.MultiClusterEngineSpec{
+			TargetNamespace: "test-ns",
+			Overrides: &backplanev1.Overrides{
+				Components: []backplanev1.ComponentConfig{
+					{
+						Name:    backplanev1.MaestroPreview,
+						Enabled: true,
+					},
+				},
+			},
+		},
+	}
+
+	s := runtime.NewScheme()
+	_ = backplanev1.AddToScheme(s)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(mce).Build()
+
+	r := &MultiClusterEngineReconciler{
+		Client:        c,
+		Scheme:        s,
+		Log:           logr.Discard(),
+		StatusManager: &status.StatusTracker{Client: c},
+	}
+
+	// Verify maestro-preview is initially enabled
+	if !mce.Enabled(backplanev1.MaestroPreview) {
+		t.Fatal("Expected maestro-preview to be enabled before reconcile")
+	}
+
+	result, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: mce.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if !result.Requeue {
+		t.Error("Expected Requeue=true after auto-disabling maestro-preview")
+	}
+
+	updatedMCE := &backplanev1.MultiClusterEngine{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: mce.Name}, updatedMCE); err != nil {
+		t.Fatalf("Failed to get updated MCE: %v", err)
+	}
+	if updatedMCE.Enabled(backplanev1.MaestroPreview) {
+		t.Error("Expected maestro-preview to be disabled after reconcile")
 	}
 }
 


### PR DESCRIPTION
# Description

Force-disable the maestro-preview (tech preview) component in MCE 5.0 to ensure no clusters are running Maestro when the code is fully removed in MCE 5.1. This provides a clean deprecation path and protects users from breakage during upgrade.

## Related Issue

- [ACM-40127](https://redhat.atlassian.net/browse/ACM-40127)

## Changes Made

- **Controller auto-disable**: If maestro-preview is enabled on an existing MCE CR, the operator auto-disables it early in reconcile (update + requeue pattern)
- **Webhook validation**: `ValidateCreate` rejects MCE resources with maestro-preview enabled. `ValidateUpdate` blocks enabling maestro-preview but allows upgrades from 2.17 → 5.0 where it was already enabled (controller handles disabling on next reconcile)
- **Constant cleanup**: Removed unused `Maestro` (stable) constant that never reached GA, cleaned up commented-out Maestro references in component lists
- **Tests**: Added unit tests for auto-disable reconcile behavior and webhook rejection for both create and update

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Resource cleanup is handled by the existing `ensureNoMaestro()` function in `toggle_components.go` — when maestro-preview is disabled, the toggle logic automatically cleans up the maestro namespace, deployments, services, routes, configmaps, and gRPC server configuration.

Pattern follows the edge-manager-preview force-disable implemented in multiclusterhub-operator (release-2.13/2.14).

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

[ACM-40127]: https://redhat.atlassian.net/browse/ACM-40127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecated `maestro-preview` can no longer be newly enabled when creating or updating a configuration.
  * Existing configurations with `maestro-preview` enabled are automatically updated to disable it.
  * Configuration reconciliation now saves the change and retries as needed.
  * Added validation coverage for preventing and automatically correcting deprecated component usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->