### PR TITLE
Add COMPONENT input to regenerate workflows

### DIFF
--- a/.github/workflows/regenerate-charts.yml
+++ b/.github/workflows/regenerate-charts.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: 'stolostron'
         type: string
+      component_arg:
+        description: 'COMPONENT to regenerate (e.g. cluster-manager). Leave empty for all.'
+        required: false
+        default: ''
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -73,8 +78,10 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Regenerate Charts
         id: generate_chart
+        env:
+          COMPONENT: ${{ github.event.inputs.component_arg || '' }}
         run: |
-          make regenerate-charts
+          make regenerate-charts COMPONENT="${COMPONENT}"
           exit_code=$?
           if [ $exit_code -ne 0 ]; then
             echo "Regenerate Charts step failed with exit code $exit_code"

--- a/.github/workflows/regenerate-operator-bundles.yml
+++ b/.github/workflows/regenerate-operator-bundles.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: "stolostron"
         type: string
+      component_arg:
+        description: 'COMPONENT to regenerate (e.g. cluster-manager). Leave empty for all.'
+        required: false
+        default: ''
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -89,8 +94,10 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Regenerate Operator Charts From Bundles
         id: generate_charts_from_bundles
+        env:
+          COMPONENT: ${{ github.event.inputs.component_arg || '' }}
         run: |
-          make regenerate-charts-from-bundles
+          make regenerate-charts-from-bundles COMPONENT="${COMPONENT}"
           exit_code=$?
           if [ $exit_code -ne 0 ]; then
             echo "Regenerate Operator Charts From Bundles step failed with exit code $exit_code"


### PR DESCRIPTION
## Summary
- Adds `component_arg` input to `regenerate-operator-bundles` and `regenerate-charts` workflows
- Allows targeting a single component (e.g. `cluster-manager`) when manually triggering from the GitHub Actions UI
- Empty value (default) runs all components as before

## Test plan
- [ ] Manually trigger workflow with `component_arg` set to a specific component
- [ ] Manually trigger workflow with `component_arg` left empty (should regenerate all)

/cc @cameronmwall @ngraham20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Manual regeneration workflows now support selecting a specific chart or operator-bundle component.
  * Leaving the component selection blank continues to regenerate all components.
  * This enables more targeted regeneration runs and can reduce unnecessary processing during maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->