### PR TITLE
Align remaining image-references from.name URLs with CSV placeholders

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -46,7 +46,7 @@ spec:
   - name: mce-capi-webhook-config-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/mce-capi-webhook-config-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-webhook-config-rhel9:latest
   - name: cluster-curator-controller-rhel9
     from:
       kind: DockerImage
@@ -74,7 +74,7 @@ spec:
   - name: discovery-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/discovery-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/discovery-operator-rhel9:latest
   - name: hive-rhel9
     from:
       kind: DockerImage
@@ -82,7 +82,7 @@ spec:
   - name: hypershift-addon-rhel9-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-addon-rhel9-operator:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-addon-operator-rhel9:latest
   - name: hypershift-cli-rhel9
     from:
       kind: DockerImage
@@ -90,15 +90,15 @@ spec:
   - name: hypershift-rhel9-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-rhel9-operator:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-release-rhel9:latest
   - name: image-based-install-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/image-based-install-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/image-based-install-operator-rhel9:latest
   - name: kube-rbac-proxy-mce-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/kube-rbac-proxy-mce-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/kube-rbac-proxy-rhel9:latest
   - name: managed-serviceaccount-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
Six components have unreplaced CSV image references because the from.name URL in image-references uses the RPA delivery name instead of the name the CSV actually references. This is the same issue fixed for backplane-must-gather and backplane-operator in PR #3808.

ART matches CSV placeholders against image-references from.name to perform replacement. When these don't match, the placeholders remain as internal registry URLs, causing image pull failures at runtime.
