### PR TITLE
[ACM-41650] Update backplane-operator Dockerfile base image to PQC

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -24,7 +24,7 @@ ARG LDFLAGS
 # Build
 RUN CGO_ENABLED=1 go build -mod=readonly -ldflags "${LDFLAGS}" -o backplane-operator main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 LABEL org.label-schema.vendor="Red Hat" \
       org.label-schema.name="backplane-operator" \


### PR DESCRIPTION
# Description

Update the runtime base image in `build/Dockerfile.rhtap` from `registry.access.redhat.com/ubi9/ubi-minimal:latest` to `registry.redhat.io/ubi9/ubi-minimal-pqc:latest` to enable Post-Quantum Cryptography (PQC) in OpenSSL, as required for the ACM 5.0 / MCE 5.0 release.

## Related Issue

[ACM-41650](https://redhat.atlassian.net/browse/ACM-41650) (sub-task of [ACM-41564](https://redhat.atlassian.net/browse/ACM-41564))

## Changes Made

- Swapped final-stage base image to the PQC-enabled UBI9 minimal image.
- The unused `cloner` build stage (still on the non-PQC base) is left unchanged since it does not ship in the final image.

## Screenshots (if applicable)

N/A

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Verification of no regression in regular and FIPS modes is required before merge; testing card to be linked to OCPSTRAT-3113.

## Reviewers

/cc @gparvin

[ACM-41650]: https://redhat.atlassian.net/browse/ACM-41650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41564]: https://redhat.atlassian.net/browse/ACM-41564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s runtime image to use the UBI 9 minimal PQC image.
  * No user-facing functionality or application behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->