### PR TITLE
[backplane-2.6] add deletion permissions so that cluster-curatator-controller can del…

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -415,10 +415,8 @@ rules:
   - ""
   - rbac.authorization.k8s.io
   resources:
-  - clusterrolebindings
   - clusterroles
   - namespaces
-  - rolebindings
   - roles
   verbs:
   - create

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-curator-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-curator-clusterrole.yaml
@@ -13,9 +13,24 @@ rules:
   resources: ["ansiblejobs","jobs","clusterdeployments","serviceaccounts", "machinepools"]
   verbs: ["get"]
 
+# Delete the cluster-installer ServiceAccount once curation completes, so it
+# cannot be used to mint tokens between curations (post-curation RBAC cleanup).
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["delete"]
+
 - apiGroups: ["rbac.authorization.k8s.io",""]
-  resources: ["roles","rolebindings", "clusterroles", "clusterrolebindings", "namespaces"]
+  resources: ["roles", "clusterroles", "namespaces"]
   verbs: ["create","get"]
+
+# rolebindings/curator and clusterrolebindings/curator-crb are also deleted as
+# part of the same post-curation RBAC cleanup. Update is needed because the
+# shared clusterrolebindings/curator-crb singleton is upserted: its subject
+# namespace is patched in place when a different Hypershift cluster's curation
+# takes it over, rather than deleting and recreating it.
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings", "clusterrolebindings"]
+  verbs: ["create","get","update","delete"]
 
 - apiGroups: ["hive.openshift.io"]
   resources: ["clusterdeployments"]

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -55,6 +55,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=list;get;watch
 //+kubebuilder:rbac:groups="",resources=secrets;configmaps;events;services,verbs=get;list;watch;create;update;delete;deletecollection;patch
 //+kubebuilder:rbac:groups="",resources=secrets;namespaces,verbs=list;get;watch;delete
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
 //+kubebuilder:rbac:groups="",resources=serviceaccounts;serviceaccounts/finalizers;secrets;secrets/finalizers;services;services/finalizers;endpoints;events;configmaps;namespaces;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts;services,verbs=get;list;watch
@@ -302,11 +303,12 @@ package main
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;delete;escalate;bind
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles,verbs=create;get;list;update;watch;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;clusterrolebindings,verbs=create;get;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;delete;get;list;patch;update;watch;escalate;bind
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;delete
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io;"",resources=roles;rolebindings;clusterroles;clusterrolebindings;namespaces,verbs=create;get
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io;"",resources=roles;clusterroles;namespaces,verbs=create;get
 //+kubebuilder:rbac:groups=register.open-cluster-management.io,resources=managedclusters/accept,verbs=update
 //+kubebuilder:rbac:groups=register.open-cluster-management.io,resources=managedclusters/accept,verbs=update
 //+kubebuilder:rbac:groups=register.open-cluster-management.io,resources=managedclusters/accept,verbs=update


### PR DESCRIPTION
…ete sa, rolebinding, clusterrolebinding once the curation completes

# Description

Please provide a brief description of the purpose of this pull request.

Grant delete permission for cluster-curator-controller to do 
- Delete the cluster-installer ServiceAccount once curation completes
- rolebindings/curator and clusterrolebindings/curator-crb are also deleted as part of the same post-curation RBAC cleanup.

## Related Issue
https://redhat.atlassian.net/browse/ACM-39828

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [X] I have tested the changes locally and they are functioning as expected.
- [X] I have updated the documentation (if necessary) to reflect the changes.
- [X] I have added/updated relevant unit tests (if applicable).
- [X] I have ensured that my code follows the project's coding standards.
- [X] I have checked for any potential security issues and addressed them.
- [X] I have added necessary comments to the code, especially in complex or unclear sections.
- [X] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster lifecycle permissions to support deleting service accounts, role bindings, and cluster role bindings.
  * Preserved existing permissions for creating and viewing roles, cluster roles, and namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->