### PR TITLE
add update permission for clusterrolebindings so cluster-curatator-co…

### DIFF
--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-curator-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/cluster-curator-clusterrole.yaml
@@ -25,10 +25,13 @@ rules:
   verbs: ["create","get"]
 
 # rolebindings/curator and clusterrolebindings/curator-crb are also deleted as
-# part of the same post-curation RBAC cleanup.
+# part of the same post-curation RBAC cleanup. Update is needed because the
+# shared clusterrolebindings/curator-crb singleton is upserted: its subject
+# namespace is patched in place when a different Hypershift cluster's curation
+# takes it over, rather than deleting and recreating it.
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["rolebindings", "clusterrolebindings"]
-  verbs: ["create","get","delete"]
+  verbs: ["create","get","update","delete"]
 
 - apiGroups: ["hive.openshift.io"]
   resources: ["clusterdeployments"]

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -727,7 +727,7 @@ package main
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;delete;escalate;bind
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles,verbs=create;get;list;update;watch;patch;delete
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;clusterrolebindings,verbs=create;get;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;clusterrolebindings,verbs=create;get;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;delete;get;list;patch;update;watch;escalate;bind
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION
…ntroller can upsert curator-crb across namespaces

The curator-crb ClusterRoleBinding is a cluster-wide singleton that ApplyRBACHypershift patches in place (rather than delete+recreate) when a different Hypershift cluster's curation takes ownership of it. This requires the update verb in addition to create/get/delete.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

https://redhat.atlassian.net/browse/ACM-39828

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster lifecycle permissions to support modifying role and cluster role bindings.
  * Improved cleanup and in-place updates for curator-managed access bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->