### PR TITLE
Fix NetworkPolicy label selector to match backplaneconfig.name

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-engine
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -14,8 +14,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-07-24T14:28:34Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    createdAt: "2026-08-18T20:48:25Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: multicluster-engine.v0.0.1
   namespace: placeholder
@@ -96,7 +96,6 @@ spec:
           - events
           - namespaces
           - secrets
-          - serviceaccounts
           - services
           verbs:
           - '*'
@@ -117,6 +116,13 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - groups
+          - users
+          verbs:
+          - impersonate
         - apiGroups:
           - ""
           resources:
@@ -153,6 +159,12 @@ spec:
           - ""
           resources:
           - pods/portforward
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
           verbs:
           - '*'
         - apiGroups:
@@ -264,10 +276,8 @@ spec:
           - ""
           - rbac.authorization.k8s.io
           resources:
-          - clusterrolebindings
           - clusterroles
           - namespaces
-          - rolebindings
           - roles
           verbs:
           - create

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: multicluster-engine
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/controllers/networkpolicy.go
+++ b/controllers/networkpolicy.go
@@ -16,16 +16,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ensureNetworkPolicies relies on existing installer labels to track NetworkPolicy ownership:
+// ensureNetworkPolicies relies on the existing backplaneconfig.name label to track
+// NetworkPolicy ownership:
 //
-// Labels (applied by rendering):
-//   - installer.name = "multiclusterengine"
-//   - installer.namespace = "multicluster-engine"
+// Labels (applied by rendering via utils.AddBackplaneConfigLabels):
+//   - backplaneconfig.name = "<mce.Name>" (e.g. "multiclusterengine")
 //
 // Annotations (applied by rendering):
 //   - installer.open-cluster-management.io/release-version = "5.0.0"
 //
-// These are sufficient to identify MCE-created NetworkPolicies for deletion when disabled.
+// The backplaneconfig.name label is sufficient to identify MCE-created NetworkPolicies
+// for deletion when disabled.
 
 // ensureNetworkPolicies implements the create-once NetworkPolicy pattern:
 // - component enabled + networkPolicies enabled → CREATE (if missing), SKIP (if exists)
@@ -45,8 +46,7 @@ func (r *MultiClusterEngineReconciler) ensureNetworkPolicies(
 	if !networkPoliciesEnabled {
 		npList := &networkingv1.NetworkPolicyList{}
 		if err := r.Client.List(ctx, npList, client.InNamespace(mce.Spec.TargetNamespace), client.MatchingLabels{
-			"installer.name":      mce.Name,
-			"installer.namespace": mce.Spec.TargetNamespace,
+			"backplaneconfig.name": mce.Name,
 		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to list NetworkPolicies: %w", err)
 		}

--- a/controllers/networkpolicy_test.go
+++ b/controllers/networkpolicy_test.go
@@ -55,8 +55,7 @@ var _ = Describe("NetworkPolicy Controller", Ordered, func() {
 				Name:      networkPolicyName,
 				Namespace: targetNS,
 				Labels: map[string]string{
-					"installer.name":      mceName,
-					"installer.namespace": targetNS,
+					"backplaneconfig.name": mceName,
 				},
 			},
 			Spec: networkingv1.NetworkPolicySpec{
@@ -137,8 +136,7 @@ var _ = Describe("NetworkPolicy Controller", Ordered, func() {
 				err := k8sClient.List(ctx, npList,
 					client.InNamespace(targetNS),
 					client.MatchingLabels{
-						"installer.name":      mceName,
-						"installer.namespace": targetNS,
+						"backplaneconfig.name": mceName,
 					})
 				if err != nil {
 					return -1
@@ -153,7 +151,7 @@ var _ = Describe("NetworkPolicy Controller", Ordered, func() {
 			// Create NetworkPolicy for different MCE
 			otherNP := np.DeepCopy()
 			otherNP.Name = "other-mce-networkpolicy"
-			otherNP.Labels["installer.name"] = "other-mce"
+			otherNP.Labels["backplaneconfig.name"] = "other-mce"
 
 			Expect(k8sClient.Create(ctx, np)).To(Succeed())
 			Expect(k8sClient.Create(ctx, otherNP)).To(Succeed())


### PR DESCRIPTION
# Description

Fixes a label mismatch that prevented NetworkPolicies from being deleted when `.spec.networkPolicies.enabled` is set to `false`.

## Related Issue

Discovered while testing `.spec.networkPolicies.enabled: false` on a live cluster: all MCE-created NetworkPolicies remained after disabling the feature.

## Changes Made

`ensureNetworkPolicies` in `controllers/networkpolicy.go` listed NetworkPolicies to delete using:

```go
client.MatchingLabels{
    "installer.name":      mce.Name,
    "installer.namespace": mce.Spec.TargetNamespace,
}
```

However, rendering only ever applies the `backplaneconfig.name` label via `utils.AddBackplaneConfigLabels()` — `installer.name`/`installer.namespace` are never set on rendered NetworkPolicy manifests. Verified on a live cluster: all 19 MCE-created NetworkPolicies carry only `backplaneconfig.name: <mce-name>`. Because the selector never matched, disabling NetworkPolicies via the CR was a silent no-op.

This PR updates the selector (and the doc comment above it) to use the label that's actually applied:

```go
client.MatchingLabels{
    "backplaneconfig.name": mce.Name,
}
```

Also updated `controllers/networkpolicy_test.go` fixtures to use `backplaneconfig.name` so tests reflect real-world labeling.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Verified via `go test ./controllers/...` (envtest, KUBEBUILDER_ASSETS 1.35.0): 24/24 specs pass, including all `NetworkPolicy Controller` deletion scenarios (single NP, multiple NPs, other-MCE isolation, no-op when none exist).

Also confirmed against a live cluster: existing NetworkPolicies are labeled only `backplaneconfig.name: multiclusterengine`, matching the new selector.

## Reviewers

/cc

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
