### PR TITLE
[backplane-2.11] CVE-2026-66794: add POD_NAMESPACE env var to cluster-proxy-addon user-server

### DIFF
--- a/pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml
@@ -109,6 +109,10 @@ spec:
           - "--service-proxy-ca-cert=/proxy-ca/ca.crt" # service-proxy is also sign by the singer ca of cluster-proxy. So here we use the same CA cert.
           - "--agent-install-namespace=open-cluster-management-agent-addon"
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         {{- if .Values.hubconfig.proxyConfigs }}
         - name: HTTP_PROXY
           value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}


### PR DESCRIPTION
## Summary

Add `POD_NAMESPACE` env var to the user-server container in the cluster-proxy-addon Helm chart.

The user-server's service allowlist watcher (introduced in CVE-2026-66794) reads `POD_NAMESPACE` at startup to know which namespace to watch for the `cluster-proxy-exposed-services` ConfigMap. Without this env var, the binary exits fatally on startup.

## Change

`pkg/templates/charts/toggle/cluster-proxy-addon/templates/user-deployment.yaml` — add to user-server container `env:`:
```yaml
- name: POD_NAMESPACE
  valueFrom:
    fieldRef:
      fieldPath: metadata.namespace
```

## Upstream source

Synced from stolostron/cluster-proxy#663


Fixes: https://redhat.atlassian.net/browse/ACM-41767