### PR TITLE
Add missing managedclusters get RBAC to provider-credential clusterrole

### DIFF
--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/provider-credential-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/provider-credential-clusterrole.yaml
@@ -13,6 +13,15 @@ rules:
   resources: ["secrets"]
   verbs: ["get","list","update","watch","patch"]
 
+# Used to confirm a copied secret's namespace belongs to a Joined
+# ManagedCluster before propagating rotated credentials into it.
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+
 # Leader election
 - apiGroups:
   - ""


### PR DESCRIPTION
The provider-credential controller needs to get managedclusters to confirm a copied secret's namespace belongs to a joined ManagedCluster before propagating rotated credentials into it.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
