### PR TITLE
Bump Go to 1.26.3 and controller-tools to v0.19.0 (backplane-2.6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the backplane-operator binary
-FROM golang:1.24 as builder
+FROM golang:1.26 as builder
 
 ARG LDFLAGS
 

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,5 +1,5 @@
 # Build the backplane-operator binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the backplane-operator binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.test.prow
+++ b/Dockerfile.test.prow
@@ -1,5 +1,5 @@
 # Build the backplane-operator binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,5 +1,5 @@
 # Build the backplane-operator binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -6,7 +6,7 @@ RUN microdnf install -y git findutils
 COPY hack/scripts hack/scripts
 
 # Build the backplane-operator binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -1,5 +1,5 @@
 # Build the backplane-operator binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
+++ b/config/crd/bases/multicluster.openshift.io_multiclusterengines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: multiclusterengines.multicluster.openshift.io
 spec:
   group: multicluster.openshift.io
@@ -168,6 +168,11 @@ spec:
                     type:
                       description: Type is the type of the cluster condition.
                       type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
               conditions:
@@ -197,6 +202,11 @@ spec:
                     type:
                       description: Type is the type of the cluster condition.
                       type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
               currentVersion:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,44 +8,21 @@ rules:
   - ""
   resources:
   - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - configmaps/status
+  - events
   - namespaces
   - secrets
   - serviceaccounts
   - services
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - ""
   resources:
-  - configmaps
+  - configmaps/status
   - endpoints
-  - events
-  - namespaces
   - persistentvolumeclaims
-  - secrets
   - secrets/finalizers
-  - serviceaccounts
   - serviceaccounts/finalizers
-  - services
   - services/finalizers
   verbs:
   - create
@@ -58,214 +35,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - events
-  - namespaces
-  - secrets
-  - serviceaccounts
-  - services
-  - services/finalizers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - events
-  - secrets
-  - services
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
   - jobs
-  - namespaces
-  - pods
-  - secrets
   verbs:
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - namespaces
-  - serviceaccounts
-  - services
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - persistentvolumeclaims
-  - secrets
-  - serviceaccounts
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - serviceaccounts
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  - nodes
-  - pods
-  - secrets
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  - pods
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  - serviceaccounts
-  - services
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - pods
-  - pods/portforward
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
   - list
   - watch
 - apiGroups:
   - ""
   resources:
   - nodes
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - pods
   - pods/log
   verbs:
   - get
@@ -274,42 +51,21 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
+  - pods
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - ""
   resources:
-  - serviceaccounts
+  - pods/portforward
   verbs:
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  - services
-  verbs:
-  - get
-  - list
-  - watch
+  - '*'
 - apiGroups:
   - ""
   resources:
   - serviceaccounts/token
   verbs:
   - create
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - list
 - apiGroups:
   - ""
   - apiextensions.k8s.io
@@ -345,10 +101,18 @@ rules:
   - tower.ansible.com
   resources:
   - ansiblejobs
-  - clusterdeployments
   - jobs
-  - machinepools
   - serviceaccounts
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  - batch
+  - tower.ansible.com
+  resources:
+  - clusterdeployments
+  - machinepools
   verbs:
   - get
 - apiGroups:
@@ -356,10 +120,7 @@ rules:
   - batch
   - tower.ansible.com
   resources:
-  - ansiblejobs
-  - jobs
   - secrets
-  - serviceaccounts
   verbs:
   - create
 - apiGroups:
@@ -396,20 +157,6 @@ rules:
   - watch
 - apiGroups:
   - ""
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
   - internal.open-cluster-management.io
   resources:
   - managedclusterinfos
@@ -431,37 +178,7 @@ rules:
   - action.open-cluster-management.io
   resources:
   - managedclusteractions
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - action.open-cluster-management.io
-  resources:
-  - managedclusteractions
   - managedclusteractions/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - action.open-cluster-management.io
-  resources:
-  - managedclusteractions/status
-  verbs:
-  - patch
-  - update
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - addondeploymentconfigs
   verbs:
   - create
   - delete
@@ -476,37 +193,6 @@ rules:
   - addondeploymentconfigs
   - addontemplates
   verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - addondeploymentconfigs
-  - clustermanagementaddons
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - addontemplates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - clustermanagementaddons
-  verbs:
   - create
   - delete
   - get
@@ -519,123 +205,17 @@ rules:
   resources:
   - clustermanagementaddons
   - clustermanagementaddons/finalizers
-  - clustermanagementaddons/status
   - managedclusteraddons
   - managedclusteraddons/finalizers
-  - managedclusteraddons/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - clustermanagementaddons
-  - clustermanagementaddons/finalizers
-  - clustermanagementaddons/status
-  - managedclusteraddons
   - managedclusteraddons/status
   verbs:
   - '*'
 - apiGroups:
   - addon.open-cluster-management.io
   resources:
-  - clustermanagementaddons
-  - clustermanagementaddons/finalizers
-  - managedclusteraddons
-  - managedclusteraddons/finalizers
-  - managedclusteraddons/status
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - clustermanagementaddons
-  - managedclusteraddons
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - clustermanagementaddons/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - clustermanagementaddons/finalizers
-  - managedclusteraddons/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
   - clustermanagementaddons/status
-  verbs:
-  - patch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - clustermanagementaddons/status
-  - managedclusteraddons/status
-  verbs:
-  - patch
-  - update
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - managedclusteraddons
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - managedclusteraddons
-  - managedclusteraddons/finalizers
-  verbs:
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - managedclusteraddons/finalizers
   verbs:
   - '*'
-  - update
-- apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - managedclusteraddons/status
-  verbs:
-  - patch
-  - update
 - apiGroups:
   - admission.hive.openshift.io
   resources:
@@ -655,14 +235,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - admission.hive.openshift.io
-  resources:
-  - dnszones
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
@@ -673,16 +245,6 @@ rules:
   - get
   - list
   - patch
-  - update
-  - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
-  verbs:
-  - create
-  - get
-  - list
   - update
   - watch
 - apiGroups:
@@ -722,42 +284,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - agent-install.openshift.io
-  resources:
-  - agents
-  - agentserviceconfigs
-  - infraenvs
-  - nmstateconfigs
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - agent-install.openshift.io
-  resources:
-  - agents
-  - infraenvs
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - agent-install.openshift.io
-  resources:
-  - agentserviceconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - agent-install.openshift.io
-  resources:
-  - infraenvs
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - agent-install.openshift.io
   resources:
@@ -819,18 +345,6 @@ rules:
   - apiregistration.k8s.io
   resources:
   - apiservices
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apiregistration.k8s.io
-  resources:
-  - apiservices
   - apiservices/finalizers
   verbs:
   - create
@@ -852,8 +366,8 @@ rules:
   resources:
   - daemonsets
   - daemonsets/finalizers
-  - deployments
   - deployments/finalizers
+  - replicasets
   - statefulsets
   verbs:
   - create
@@ -867,71 +381,14 @@ rules:
   - apps
   resources:
   - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - deployments/finalizers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - deployments/scale
   verbs:
   - '*'
 - apiGroups:
   - apps
   resources:
-  - deployments
-  - replicasets
+  - deployments/scale
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
+  - '*'
 - apiGroups:
   - apps.open-cluster-management.io
   resources:
@@ -977,18 +434,6 @@ rules:
   - authentication.k8s.io
   resources:
   - tokenrequests
-  verbs:
-  - create
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenrequests
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authentication.k8s.io
-  resources:
   - tokenreviews
   verbs:
   - create
@@ -1064,15 +509,6 @@ rules:
   - certificates.k8s.io
   resources:
   - certificatesigningrequests
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests
   - certificatesigningrequests/approval
   verbs:
   - create
@@ -1084,8 +520,6 @@ rules:
 - apiGroups:
   - certificates.k8s.io
   resources:
-  - certificatesigningrequests
-  - certificatesigningrequests/approval
   - certificatesigningrequests/status
   verbs:
   - get
@@ -1093,31 +527,18 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests/approval
-  verbs:
-  - update
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests/approval
-  - certificatesigningrequests/status
-  verbs:
-  - update
 - apiGroups:
   - certificates.k8s.io
   resources:
   - signers
   verbs:
   - '*'
-  - approve
-  - sign
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - addonplacementscores
+  - addonplacementscores/status
+  - managedclustersetbindings
   verbs:
   - create
   - delete
@@ -1130,107 +551,26 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
-  - addonplacementscores
-  - addonplacementscores/status
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - addonplacementscores
-  - managedclustersetbindings
-  - placements
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - addonplacementscores/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
   - clustercurators
   - clustercurators/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - clustercurators
   - managedclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - clustercurators
-  - managedclusters
-  - managedclustersetbindings
-  - managedclustersets
-  - placementdecisions
-  - placements
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - clustercurators/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclusters
-  - managedclusters/accept
   - managedclusters/finalizers
   - managedclusters/status
-  - managedclustersetbindings
-  - managedclustersetbindings/finalizers
   - managedclustersets
+  - placementdecisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters/accept
+  - managedclustersetbindings/finalizers
   - managedclustersets/bind
   - managedclustersets/finalizers
   - managedclustersets/join
@@ -1246,53 +586,8 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
-  - managedclusters
-  - managedclusters/finalizers
-  - managedclusters/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclusters
-  - managedclustersetbindings
-  - managedclustersets
-  verbs:
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclusters
-  - managedclustersets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclusters/status
-  verbs:
-  - patch
-  - update
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclusters/status
   - managedclustersetbindings/status
   - managedclustersets/status
-  - placementdecisions/status
   - placements/status
   verbs:
   - patch
@@ -1300,67 +595,13 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
-  - managedclustersetbindings
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclustersets
-  - placementdecisions
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclustersets
-  - placementdecisions
   - placementdecisions/status
   verbs:
   - get
   - list
+  - patch
   - update
   - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclustersets/bind
-  verbs:
-  - create
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - managedclustersets/join
-  verbs:
-  - create
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - placements
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.open-cluster-management.io
-  resources:
-  - placements/finalizers
-  verbs:
-  - update
 - apiGroups:
   - clusterview.open-cluster-management.io
   resources:
@@ -1386,35 +627,11 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - apiservers
-  - proxies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
   - clusteroperators
   - clusterversions
   - dnses
-  - infrastructures
+  - ingresses
   - proxies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusterversions
   verbs:
   - get
   - list
@@ -1428,14 +645,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - config.openshift.io
@@ -1493,26 +702,6 @@ rules:
   - leases
   verbs:
   - '*'
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - discovery.open-cluster-management.io
-  resources:
-  - discoveredclusters
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - discovery.open-cluster-management.io
   resources:
@@ -1534,41 +723,8 @@ rules:
   - discovery.open-cluster-management.io
   resources:
   - discoveredclusters/finalizers
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - discovery.open-cluster-management.io
-  resources:
   - discoveredclusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - discovery.open-cluster-management.io
-  resources:
-  - discoveryconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - discovery.open-cluster-management.io
-  resources:
   - discoveryconfigs/finalizers
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - discovery.open-cluster-management.io
-  resources:
   - discoveryconfigs/status
   verbs:
   - get
@@ -1583,38 +739,7 @@ rules:
 - apiGroups:
   - extensions.hive.openshift.io
   resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - extensions.hive.openshift.io
-  resources:
   - agentclusterinstalls
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - extensions.hive.openshift.io
-  resources:
-  - agentclusterinstalls/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - extensions.hive.openshift.io
-  resources:
-  - agentclusterinstalls/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - extensions.hive.openshift.io
-  resources:
   - imageclusterinstalls
   verbs:
   - create
@@ -1627,17 +752,27 @@ rules:
 - apiGroups:
   - extensions.hive.openshift.io
   resources:
+  - agentclusterinstalls/finalizers
   - imageclusterinstalls/finalizers
   verbs:
   - update
 - apiGroups:
   - extensions.hive.openshift.io
   resources:
+  - agentclusterinstalls/status
   - imageclusterinstalls/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - extensions.hive.openshift.io
+  - hive.openshift.io
+  - hiveinternal.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
 - apiGroups:
   - flowcontrol.apiserver.k8s.io
   resources:
@@ -1650,79 +785,12 @@ rules:
 - apiGroups:
   - hive.openshift.io
   resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - hive.openshift.io
-  resources:
-  - clusterclaims
-  - clusterdeployments
-  - clusterdeprovisions
-  - clusterimagesets
-  - clusterpools
-  - clusterprovisions
-  - machinepools
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - hive.openshift.io
-  resources:
   - clusterclaims
   - clusterdeployments
   - clusterpools
   - machinepools
   verbs:
   - '*'
-  - approve
-  - bind
-  - create
-  - delete
-  - deletecollection
-  - escalate
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - hive.openshift.io
-  resources:
-  - clusterclaims
-  - clusterpools
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - hive.openshift.io
-  resources:
-  - clusterdeployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - hive.openshift.io
-  resources:
-  - clusterdeployments
-  - selectorsyncsets
-  - syncsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - hive.openshift.io
   resources:
@@ -1740,7 +808,17 @@ rules:
 - apiGroups:
   - hive.openshift.io
   resources:
+  - clusterdeprovisions
+  - clusterprovisions
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
   - clusterimagesets
+  - selectorsyncsets
+  - syncsets
   verbs:
   - create
   - delete
@@ -1763,21 +841,7 @@ rules:
 - apiGroups:
   - hiveinternal.openshift.io
   resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - hiveinternal.openshift.io
-  resources:
   - clustersyncs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - hypershift.openshift.io
-  resources:
-  - hostedclusters
   verbs:
   - get
   - list
@@ -1793,14 +857,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - imageregistry.open-cluster-management.io
-  resources:
-  - managedclusterimageregistries
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - imageregistry.open-cluster-management.io
@@ -1823,14 +879,6 @@ rules:
   - internal.open-cluster-management.io
   resources:
   - managedclusterinfos
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - internal.open-cluster-management.io
-  resources:
-  - managedclusterinfos
   - managedclusterinfos/status
   verbs:
   - create
@@ -1841,13 +889,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - internal.open-cluster-management.io
-  resources:
-  - managedclusterinfos/status
-  verbs:
-  - patch
-  - update
-- apiGroups:
   - metal3.io
   resources:
   - baremetalhosts
@@ -1856,14 +897,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - metal3.io
-  resources:
-  - baremetalhosts
-  - provisionings
-  verbs:
-  - list
   - watch
 - apiGroups:
   - metal3.io
@@ -1891,6 +924,8 @@ rules:
   - provisionings
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - migration.k8s.io
   resources:
@@ -1907,18 +942,6 @@ rules:
   - monitoring.coreos.com
   resources:
   - prometheusrules
-  - servicemonitors
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
   - servicemonitors
   verbs:
   - create
@@ -2066,21 +1089,12 @@ rules:
   resources:
   - managedproxyconfigurations
   verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - proxy.open-cluster-management.io
   resources:
-  - managedproxyconfigurations
   - managedproxyconfigurations/finalizers
   - managedproxyconfigurations/status
-  - managedproxyserviceresolvers
   - managedproxyserviceresolvers/finalizers
   - managedproxyserviceresolvers/status
   verbs:
@@ -2088,63 +1102,15 @@ rules:
 - apiGroups:
   - proxy.open-cluster-management.io
   resources:
-  - managedproxyconfigurations
   - managedproxyserviceresolvers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  verbs:
-  - bind
-  - create
-  - delete
-  - escalate
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles
   - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - rolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
   - roles
   verbs:
   - bind
@@ -2164,21 +1130,6 @@ rules:
   - get
   - update
 - apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  - roles
-  verbs:
-  - bind
-  - create
-  - delete
-  - escalate
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - register.open-cluster-management.io
   resources:
   - managedclusters/accept
@@ -2190,18 +1141,6 @@ rules:
   - managedclusters/clientcertificates
   verbs:
   - renew
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - route.openshift.io
   resources:
@@ -2253,12 +1192,12 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
   - view.open-cluster-management.io
   resources:
-  - managedclusterviews
   - managedclusterviews/status
   verbs:
   - create
@@ -2267,13 +1206,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - view.open-cluster-management.io
-  resources:
-  - managedclusterviews/status
-  verbs:
-  - patch
-  - update
 - apiGroups:
   - wgpolicyk8s.io
   resources:
@@ -2325,7 +1257,6 @@ rules:
 - apiGroups:
   - work.open-cluster-management.io
   resources:
-  - manifestworks
   - manifestworks/finalizers
   verbs:
   - create

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/backplane-operator
 
-go 1.24.13
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/pkg/status/deployment.go
+++ b/pkg/status/deployment.go
@@ -63,7 +63,7 @@ func mapDeployment(ds *appsv1.Deployment) bpv1.ComponentCondition {
 	}
 	if successfulDeploy(ds) {
 		ret.Available = true
-		ret.Message = ""
+		ret.Message = "Deployment is available"
 	}
 
 	// Because our definition of success is different than the deployment's it is possible we indicate failure

--- a/pkg/status/deployment_test.go
+++ b/pkg/status/deployment_test.go
@@ -39,6 +39,7 @@ func Test_mapDeployment(t *testing.T) {
 				Type:      "Available",
 				Status:    metav1.ConditionTrue,
 				Reason:    "Available",
+				Message:   "Deployment is available",
 				Available: true,
 			},
 		},

--- a/pkg/status/generic.go
+++ b/pkg/status/generic.go
@@ -183,6 +183,7 @@ func (s PresentStatus) Status(k8sClient client.Client) bpv1.ComponentCondition {
 			Type:      "Present",
 			Status:    metav1.ConditionTrue,
 			Reason:    DeploySuccessReason,
+			Message:   "Resource is present",
 			Available: true,
 		}
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -63,10 +63,10 @@ func (sm *StatusTracker) ReportStatus(mce bpv1.MultiClusterEngine) bpv1.MultiClu
 
 	// Infer available condition from component health
 	if allComponentsReady(components) {
-		sm.AddCondition(NewCondition(bpv1.MultiClusterEngineAvailable, metav1.ConditionTrue, ComponentsAvailableReason, ""))
+		sm.AddCondition(NewCondition(bpv1.MultiClusterEngineAvailable, metav1.ConditionTrue, ComponentsAvailableReason, "All components available"))
 
 	} else {
-		sm.AddCondition(NewCondition(bpv1.MultiClusterEngineAvailable, metav1.ConditionFalse, ComponentsUnavailableReason, ""))
+		sm.AddCondition(NewCondition(bpv1.MultiClusterEngineAvailable, metav1.ConditionFalse, ComponentsUnavailableReason, "Not all components available"))
 	}
 
 	conditions := sm.reportConditions()


### PR DESCRIPTION
# Description

Bumps `backplane-2.6` from Go 1.24.13 to Go 1.26.3 and `controller-tools` from v0.14.0 to v0.19.0, aligning this branch with the rest of the active release branches (2.8-2.17, main are already on newer Go/controller-tools versions).

## Related Issue

Fixes the `pull-ci-stolostron-backplane-operator-backplane-2.6-test-unit` Prow job failure seen on PR #3857:
```
# golang.org/x/tools/internal/tokeninternal
.../golang.org/x/tools@v0.16.1/internal/tokeninternal/tokeninternal.go:78:9:
invalid array length -delta * delta (constant -256 of type int64)
make: *** [Makefile:181: bin/controller-gen] Error 1
```
Root cause: `controller-tools@v0.14.0` pulls in `golang.org/x/tools@v0.16.1`, which fails to compile under Go 1.25.11+ (the Go toolchain Prow's `test-unit` job downloads via `GOTOOLCHAIN=auto`, per `go.mod`'s `go` directive resolution). Reproduced locally on Go 1.25.11 and Go 1.26.x.

## Changes Made

- `go.mod`: `go 1.24.13` → `go 1.26.3`
- All Go builder images bumped from 1.24 → 1.26, across every Dockerfile variant found in this repo (including root-level legacy copies still present on this branch):
  - `Dockerfile`: `golang:1.24` → `golang:1.26`
  - `Dockerfile.prow`, `Dockerfile.test.prow`, `build/Dockerfile.prow`, `build/Dockerfile.test.prow`: `go1.24-linux` → `go1.26-linux` (tag confirmed in use across other stolostron repos, e.g. `discovery`, `multiclusterhub-operator`, `backplane-operator@main`)
  - `Dockerfile.rhtap`, `build/Dockerfile.rhtap` (Konflux/RHTAP hermetic build): `openshift-golang-builder:rhel_9_1.24` → `rhel_9_1.26`
- `Makefile`: `CONTROLLER_TOOLS_VERSION` `v0.14.0` → `v0.19.0` (matches what `backplane-2.8`-`2.17` already use; confirmed v0.19.0 installs cleanly on Go 1.26.3, unlike v0.14.0/v0.15.0/v0.16.0 which all hit the same `x/tools` incompatibility)
- Regenerated `config/crd/bases/...` and `config/rbac/role.yaml` via `make manifests generate` with the new controller-gen version:
  - `role.yaml`: large diff, but verified programmatically to be pure deduplication — controller-gen v0.14.0 was emitting fragmented/overlapping rule blocks for the same resources; v0.19.0 consolidates them. Confirmed **zero** change in effective `(apiGroup, resource, verb)` permission coverage.
  - CRD: controller-gen v0.19.0 correctly adds `required: [message, reason, status, type]` to two `Condition` schemas in the `MultiClusterEngine` CRD (matching the Go type's existing `+required` kubebuilder markers). This is **kept**, not reverted — every other active branch (`2.8`-`2.17`, `main`) already has this same `required` constraint.
- **Backported a pre-existing bug fix** from `backplane-2.8` (originally fixed in commit `93cfa82b`, Oct 2025, during that branch's own Go-version-bump effort): `pkg/status/status.go`, `pkg/status/deployment.go`, and `pkg/status/generic.go` were setting empty-string `Message` fields on some `Condition`/`ComponentCondition` objects. The old, lenient CRD (v0.14.0) silently allowed this; the correctly-generated v0.19.0 CRD's `required` constraint rejects it, causing 3 unit tests to fail against the real envtest API server (`status.conditions[1].message: Required value`). Fixed by giving these conditions the same non-empty, descriptive messages already used on every other branch (`"All components available"`, `"Not all components available"`, `"Deployment is available"`, `"Resource is present"`), plus the matching test-expectation update in `pkg/status/deployment_test.go`.
- `go mod tidy` run; no `go.sum` changes were needed.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

`make test` now passes locally (13/13 specs). The 3 failures seen in earlier revisions of this PR (`should error due to missing secret`, `should error due to bad OCP version`, `should not deploy resources in regular fashion`) were a genuine pre-existing bug in this branch's status-condition code, exposed by the stricter (and correct) controller-gen v0.19.0 CRD output — not a regression caused by this PR. Root-caused and fixed by backporting the identical fix already present on every other active branch.

This is part of a broader effort to resync Go versions to 1.26.3 across `backplane-operator`, `discovery`, and `multiclusterhub-operator` release branches. Companion PRs: #3908, #3909, #3910, #3911, #3912.

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [x] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
