### PR TITLE
Bump Go to 1.26.3 (backplane-2.11)

### DIFF
--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,5 +1,5 @@
 # Build the backplane-operator binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -6,7 +6,7 @@ RUN microdnf install -y git findutils
 COPY hack/scripts hack/scripts
 
 # Build the backplane-operator binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -1,5 +1,5 @@
 # Build the backplane-operator binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/backplane-operator
 
-go 1.25.11
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
# Description

Bumps `backplane-2.11` from Go 1.25.11 to Go 1.26.3, aligning this branch with `backplane-2.17` and `main` (already on Go 1.26.3).

## Related Issue

Part of a broader effort to resync Go versions to 1.26.3 across active `backplane-operator`, `discovery`, and `multiclusterhub-operator` release branches (see #3907 for `backplane-2.6`, which needed additional `controller-tools` changes).

## Changes Made

- `go.mod`: `go 1.25.11` → `go 1.26.3`
- Go builder images bumped from 1.25 → 1.26 (root `Dockerfile` was already on `golang:1.26`):
  - `build/Dockerfile.prow`, `build/Dockerfile.test.prow`: `go1.25-linux` → `go1.26-linux`
  - `build/Dockerfile.rhtap` (Konflux/RHTAP hermetic build): `rhel_9_1.25` → `rhel_9_1.26`
- No `Makefile`/`controller-tools` change needed — already on `CONTROLLER_TOOLS_VERSION v0.19.0`, confirmed compatible with Go 1.26.3.
- `go mod tidy` run; `make manifests generate fmt vet` run and produced **no diff**.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Local `make test` was not run for this PR — deferring to CI (`test-unit`) per team preference.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [x] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
