### PR TITLE
[main] Fix CPE label version in Dockerfile.rhtap

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -36,7 +36,7 @@ LABEL org.label-schema.vendor="Red Hat" \
       io.k8s.description="Installer operator for Red Hat multicluster engine for Kubernetes" \
       com.redhat.component="multicluster-engine-operator-container" \
       io.openshift.tags="data,images" \
-      cpe="cpe:/a:redhat:multicluster_engine:5.0::el9"
+      cpe="cpe:/a:redhat:multicluster_engine:5.1::el9"
 
 WORKDIR /app
 COPY --from=builder /workspace/backplane-operator .


### PR DESCRIPTION
Fixes the `cpe` label in `build/Dockerfile.rhtap` on main. It was stale at `5.0`; updated to `5.1` to match the current development version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image metadata to identify Multicluster Engine version 5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->