### PR TITLE
[backplane-2.8] Add managedcluster-import-controller-v2 deployment status tracking

### DIFF
--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -725,6 +725,10 @@ func (r *MultiClusterEngineReconciler) ensureServerFoundation(ctx context.Contex
 	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 
+	namespacedName = types.NamespacedName{Name: "managedcluster-import-controller-v2", Namespace: mce.Spec.TargetNamespace}
+	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
+	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
+
 	// Ensure that the InternalHubComponent CR instance is created for component in MCE.
 	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.ServerFoundation); err != nil {
 		return result, err
@@ -789,6 +793,10 @@ func (r *MultiClusterEngineReconciler) ensureNoServerFoundation(ctx context.Cont
 	}
 
 	namespacedName = types.NamespacedName{Name: "ocm-webhook", Namespace: mce.Spec.TargetNamespace}
+	r.StatusManager.RemoveComponent(toggle.EnabledStatus(namespacedName))
+	r.StatusManager.AddComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
+
+	namespacedName = types.NamespacedName{Name: "managedcluster-import-controller-v2", Namespace: mce.Spec.TargetNamespace}
 	r.StatusManager.RemoveComponent(toggle.EnabledStatus(namespacedName))
 	r.StatusManager.AddComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 


### PR DESCRIPTION
# Description

The `managedcluster-import-controller-v2` deployment is rendered as part of the server-foundation chart but was not being tracked by the StatusManager, meaning its availability was not reflected in the MultiClusterEngine status.

## Related Issue

N/A

## Changes Made

- Added status tracking for the `managedcluster-import-controller-v2` deployment in `ensureServerFoundation()`, following the same pattern used for the other server-foundation components (`ocm-controller`, `ocm-proxyserver`, `ocm-webhook`).

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This deployment already exists in the rendered server-foundation chart; this change only adds status tracking so its health is surfaced in the MCE status.

## Reviewers

/cc

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
