### PR TITLE
MCE on ART (PQC) - Switch ubi-minimal base image to PQC variant

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as cloner
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest as cloner
 
 RUN microdnf install -y git findutils
 COPY hack/scripts hack/scripts


### PR DESCRIPTION
Replace registry.access.redhat.com/ubi9/ubi-minimal:latest (and registry.redhat.io/ubi9/ubi-minimal:latest) with
registry.redhat.io/ubi9/ubi-minimal-pqc:latest for post-quantum cryptography support.

Ref: ACM-40663
