### PR TITLE
[ACM-43021][ACM-43022] chore: bump go.mod directive to 1.26.7

### DIFF
--- a/.tekton/backplane-operator-main-unit-test.yaml
+++ b/.tekton/backplane-operator-main-unit-test.yaml
@@ -47,7 +47,7 @@ spec:
               dnf -y install jq git make podman
 
               # Install golang with a given version
-              export GOVERSION=1.26.3
+              export GOVERSION=1.26.7
               curl -O -J https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
               rm -rf /usr/local/go && tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/backplane-operator
 
-go 1.26.3
+go 1.26.7
 
 require (
 	github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
Fixes ACM-43021, ACM-43022

**Change:** `go.mod` directive `go 1.26.3` → `go 1.26.7`

**Why:** This repo's Konflux builder
(`brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26`)
currently resolves to `golang-1.26.7-1.el9_8`, well ahead of the
`go.mod` directive (1.26.3). The directive was stale.

**CVE context (not affected, hygiene only):**
- CVE-2024-45336 (net/http: sensitive headers sent after cross-domain
  redirect) — fixed upstream in Go 1.22.11 / 1.23.5 / 1.24.0-rc.2
- CVE-2025-22866 (crypto/internal/nistec: P-256 timing sidechannel on
  ppc64le) — fixed upstream in Go 1.22.12 / 1.23.6 / 1.24.0-rc.3

Both CVEs have open z-stream Vulnerability trackers in Jira, but this
repo is **not affected on `main`** — the floating Konflux builder
already ships a Go stdlib version well past both fixes. Verified via
`govulncheck`:
- Binary mode against the shipped `backplane-rhel9-operator:v2.11.6`
  image (built with `go1.26.5`): both CVEs absent
- Source mode against `main` (`go1.26.7` toolchain): both CVEs absent

This PR is **hygiene only** — it aligns the declared `go.mod` minimum
with the builder's actual floor so version/SBOM-based scanners (Grype,
homegrown reachability tools) stop flagging this repo for CVEs the
builder has already resolved.

**Validation performed** (no unit tests run, per reviewer request —
version-bump-only change):
- `go build -mod=readonly -o backplane-operator main.go` (matches the
  production `build/Dockerfile.rhtap` build command exactly) — succeeds,
  binary reports `go1.26.7`
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `go.sum` unchanged (no dependency changes)

**Dev-branch tracking issues:**
- [ACM-43021](https://redhat.atlassian.net/browse/ACM-43021) — CVE-2024-45336, links z-streams ACM-40047, ACM-40048, ACM-40049, ACM-40050, ACM-40051
- [ACM-43022](https://redhat.atlassian.net/browse/ACM-43022) — CVE-2025-22866, links z-streams ACM-40259, ACM-40260, ACM-40261, ACM-40262, ACM-40263

Created via the `cve-sustaining-handoff` workflow.

[ACM-43021]: https://redhat.atlassian.net/browse/ACM-43021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go language version used by the project to 1.26.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->