### PR TITLE
ACM-32324: Grant AnsibleWorkflow read access for console-mce backend

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -1211,6 +1211,7 @@ spec:
           - tower.ansible.com
           resources:
           - ansiblejobs
+          - ansibleworkflows
           - clusterversions
           - consolelinks
           - featuregates

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1250,6 +1250,7 @@ rules:
   - tower.ansible.com
   resources:
   - ansiblejobs
+  - ansibleworkflows
   - clusterversions
   - consolelinks
   - featuregates

--- a/pkg/templates/charts/toggle/console-mce/templates/console-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console-mce/templates/console-clusterrole.yaml
@@ -74,6 +74,7 @@ rules:
   - projects
   - featuregates
   - ansiblejobs
+  - ansibleworkflows
   - clusterversions
 
 - verbs:

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -430,7 +430,7 @@ package main
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch;patch;update
-//+kubebuilder:rbac:groups=config.openshift.io;console.openshift.io;project.openshift.io;tower.ansible.com,resources=infrastructures;consolelinks;projects;featuregates;ansiblejobs;clusterversions,verbs=list;get;watch
+//+kubebuilder:rbac:groups=config.openshift.io;console.openshift.io;project.openshift.io;tower.ansible.com,resources=infrastructures;consolelinks;projects;featuregates;ansiblejobs;ansibleworkflows;clusterversions,verbs=list;get;watch
 //+kubebuilder:rbac:groups=console.open-cluster-management.io,resources=userpreferences,verbs=create;get;list;patch;watch
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleclidownloads,verbs=get;list;create;delete;update;patch
 //+kubebuilder:rbac:groups=containerinstance.azure.com,resources=containergroups,verbs=create;delete;get;list;patch;update;watch


### PR DESCRIPTION
## Summary

- Grants `get`/`list`/`watch` on `tower.ansible.com/ansibleworkflows` for the console-mce ClusterRole so the console backend can watch `AnsibleWorkflow` resources without `Forbidden` errors.
- Updates generated operator RBAC (`config/rbac/role.yaml`, `pkg/templates/rbac_gen.go`) and the bundle CSV.
- Required companion for [stolostron/console#6734](https://github.com/stolostron/console/pull/6734) / ACM-32324.

## Root cause

[console#6734](https://github.com/stolostron/console/pull/6734) added an `AnsibleWorkflow` watch in the backend `/events` stream. Local dev (`npm run setup`) and deployed MCE use the `console-mce` service account token, which already had `ansiblejobs` but not `ansibleworkflows`, producing:

```
ERROR:watch  kind:AnsibleWorkflow  apiVersion:tower.ansible.com/v1alpha1  status:Forbidden
```

## Test plan

- [ ] `go generate` + `make manifests` produce no unexpected diff beyond `ansibleworkflows`
- [ ] RBAC gen CI passes
- [ ] After MCE/console update, `oc auth can-i list ansibleworkflows --all-namespaces --as=system:serviceaccount:<mce-ns>:console-mce` returns `yes`
- [ ] Console backend no longer logs Forbidden for `AnsibleWorkflow` watch
- [ ] Cluster curator pre/post hook **View logs** opens workflow URLs when `ansibleWorkflowResult.url` is present


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access to Ansible workflow resources by granting the required read permissions.
  - Ensured workflows can be discovered and monitored consistently across the application’s access configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->