### PR TITLE
Lower HCP proxy APIService priority below CRD default

### DIFF
--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-apiservice.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-apiservice.yaml
@@ -8,7 +8,7 @@ spec:
   group: hcp.ocm.io
   # Below the CRD default (1000) so unqualified `oc get hostedclusters`
   # prefers hypershift.openshift.io instead of this proxy API.
-  groupPriorityMinimum: 100
+  groupPriorityMinimum: 1
   service:
     name: hypershift-addon-hcp-proxy
     namespace: {{ .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-apiservice.yaml
+++ b/pkg/templates/charts/toggle/hypershift/templates/hypershift-addon-hcp-proxy-apiservice.yaml
@@ -6,7 +6,9 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
 spec:
   group: hcp.ocm.io
-  groupPriorityMinimum: 2000
+  # Below the CRD default (1000) so unqualified `oc get hostedclusters`
+  # prefers hypershift.openshift.io instead of this proxy API.
+  groupPriorityMinimum: 100
   service:
     name: hypershift-addon-hcp-proxy
     namespace: {{ .Values.global.namespace }}


### PR DESCRIPTION
Jira: [ACM-43034](https://redhat.atlassian.net/browse/ACM-43034)

## Summary
- Set `v1alpha1.hcp.ocm.io` `groupPriorityMinimum` to 1 (below the CRD default of 1000).
- Unqualified `oc get hostedclusters` then prefers `hypershift.openshift.io` instead of the HCP proxy.
- Proxy clients should keep using `hostedclusters.hcp.ocm.io`.

Companion change in hypershift-addon-operator returns Kubernetes Status-shaped proxy errors: https://github.com/stolostron/hypershift-addon-operator/pull/790

## Test plan
- [ ] After MCE install, `oc api-resources | grep hostedcluster` still lists both groups
- [ ] `oc get hostedclusters <name> -n clusters` uses `hypershift.openshift.io`
- [ ] `oc get hostedclusters.hcp.ocm.io` still reaches the proxy

[ACM-43034]: https://redhat.atlassian.net/browse/ACM-43034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted API service prioritization to ensure the preferred HyperShift resource group is selected when using unqualified resource commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->