### PR TITLE
Add missing operand images to the MCE 5.0 ART CSV

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -3469,11 +3469,97 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: OPERAND_IMAGE_ADDON_MANAGER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/addon-manager-rhel9:latest
+                - name: OPERAND_IMAGE_AZURE_SERVICE_OPERATOR_RHEL9
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/azure-service-operator-rhel9:latest
+                - name: OPERAND_IMAGE_BACKPLANE_MUST_GATHER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-must-gather-rhel9:latest
+                - name: OPERAND_IMAGE_CLOUDEVENTS_CONDUCTOR
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cloudevents-conductor-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AGENT
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-provider-agent-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AWS_RHEL9
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-provider-aws-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AZURE_RHEL9
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-provider-azure-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_KUBEVIRT
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-provider-kubevirt-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_BOOTSTRAP
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/capoa-bootstrap-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_CONTROL_PLANE
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/capoa-control-plane-rhel9:latest
+                - name: OPERAND_IMAGE_MCE_CAPI_WEBHOOK_CONFIG_RHEL9
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-webhook-config-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTERCLAIMS_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/clusterclaims-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_CURATOR_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-curator-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_IMAGE_SET_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-image-set-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTERLIFECYCLE_STATE_METRICS
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/clusterlifecycle-state-metrics-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_PERMISSION
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-permission-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_PROXY
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-proxy-rhel9:latest
+                - name: OPERAND_IMAGE_CONSOLE_MCE
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/console-mce-rhel9:latest
+                - name: OPERAND_IMAGE_DISCOVERY_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/discovery-operator-rhel9:latest
+                - name: OPERAND_IMAGE_OPENSHIFT_HIVE
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hive-rhel9:latest
+                - name: OPERAND_IMAGE_HYPERSHIFT_ADDON_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-addon-operator-rhel9:latest
+                - name: OPERAND_IMAGE_HYPERSHIFT_CLI
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-cli-rhel9:latest
+                - name: OPERAND_IMAGE_HYPERSHIFT_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-release-rhel9:latest
+                - name: OPERAND_IMAGE_IMAGE_BASED_INSTALL_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/image-based-install-operator-rhel9:latest
+                - name: OPERAND_IMAGE_KUBE_RBAC_PROXY_MCE
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/kube-rbac-proxy-rhel9:latest
+                - name: OPERAND_IMAGE_MAESTRO
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/maestro-rhel9:latest
+                - name: OPERAND_IMAGE_MANAGEDCLUSTER_IMPORT_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/managedcluster-import-controller-rhel9:latest
+                - name: OPERAND_IMAGE_MANAGED_SERVICEACCOUNT
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/managed-serviceaccount-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLOUD_MANAGER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/multicloud-manager-rhel9:latest
+                - name: OPERAND_IMAGE_PROVIDER_CREDENTIAL_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/provider-credential-controller-rhel9:latest
+                - name: OPERAND_IMAGE_PLACEMENT
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/placement-rhel9:latest
+                - name: OPERAND_IMAGE_REGISTRATION
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/registration-rhel9:latest
+                - name: OPERAND_IMAGE_REGISTRATION_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/registration-operator-rhel9:latest
+                - name: OPERAND_IMAGE_WORK
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/work-rhel9:latest
+                - name: OPERAND_IMAGE_ASSISTED_IMAGE_SERVICE
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-image-service-rhel9:latest
+                - name: OPERAND_IMAGE_ASSISTED_INSTALLER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-rhel9:latest
+                - name: OPERAND_IMAGE_ASSISTED_INSTALLER_AGENT
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-agent-rhel9:latest
+                - name: OPERAND_IMAGE_ASSISTED_INSTALLER_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-controller-rhel9:latest
+                - name: OPERAND_IMAGE_ASSISTED_SERVICE_9
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-service-9-rhel9:latest
+                - name: OPERAND_IMAGE_OSE_CLUSTER_API_RHEL9
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/ose-cluster-api-rhel9:latest
+                - name: OPERAND_IMAGE_OSE_BAREMETAL_CLUSTER_API_CONTROLLERS_RHEL9
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/ose-baremetal-cluster-api-controllers-rhel9:latest
+                - name: OPERAND_IMAGE_POSTGRESQL_15
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/postgresql-15:latest
+                - name: OPERAND_IMAGE_POSTGRESQL_16
+                  value: image-registry.openshift-image-registry.svc:5000/multicluster-engine/postgresql-16:latest
                 - name: OPERATOR_VERSION
                   value: "5.0.0"
                 - name: OPERATOR_PACKAGE
                   value: multicluster-engine
-                image: quay.io/stolostron/backplane-operator:latest
+                image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-operator:latest
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -3573,4 +3659,91 @@ spec:
   provider:
     name: Red Hat
     url: https://multicluster-engine.domain
+  relatedImages:
+  - name: addon_manager
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/addon-manager-rhel9:latest
+  - name: azure_service_operator_rhel9
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/azure-service-operator-rhel9:latest
+  - name: backplane_must_gather
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/backplane-must-gather-rhel9:latest
+  - name: cloudevents_conductor
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cloudevents-conductor-rhel9:latest
+  - name: cluster_api_provider_agent
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-provider-agent-rhel9:latest
+  - name: cluster_api_provider_aws_rhel9
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-provider-aws-rhel9:latest
+  - name: cluster_api_provider_azure_rhel9
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-provider-azure-rhel9:latest
+  - name: cluster_api_provider_kubevirt
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-provider-kubevirt-rhel9:latest
+  - name: cluster_api_provider_openshift_assisted_bootstrap
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/capoa-bootstrap-rhel9:latest
+  - name: cluster_api_provider_openshift_assisted_control_plane
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/capoa-control-plane-rhel9:latest
+  - name: mce_capi_webhook_config_rhel9
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-api-webhook-config-rhel9:latest
+  - name: clusterclaims_controller
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/clusterclaims-controller-rhel9:latest
+  - name: cluster_curator_controller
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-curator-controller-rhel9:latest
+  - name: cluster_image_set_controller
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-image-set-controller-rhel9:latest
+  - name: clusterlifecycle_state_metrics
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/clusterlifecycle-state-metrics-rhel9:latest
+  - name: cluster_permission
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-permission-rhel9:latest
+  - name: cluster_proxy
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/cluster-proxy-rhel9:latest
+  - name: console_mce
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/console-mce-rhel9:latest
+  - name: discovery_operator
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/discovery-operator-rhel9:latest
+  - name: openshift_hive
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hive-rhel9:latest
+  - name: hypershift_addon_operator
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-addon-operator-rhel9:latest
+  - name: hypershift_cli
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-cli-rhel9:latest
+  - name: hypershift_operator
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/hypershift-release-rhel9:latest
+  - name: image_based_install_operator
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/image-based-install-operator-rhel9:latest
+  - name: kube_rbac_proxy_mce
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/kube-rbac-proxy-rhel9:latest
+  - name: maestro
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/maestro-rhel9:latest
+  - name: managedcluster_import_controller
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/managedcluster-import-controller-rhel9:latest
+  - name: managed_serviceaccount
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/managed-serviceaccount-rhel9:latest
+  - name: multicloud_manager
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/multicloud-manager-rhel9:latest
+  - name: provider_credential_controller
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/provider-credential-controller-rhel9:latest
+  - name: placement
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/placement-rhel9:latest
+  - name: registration
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/registration-rhel9:latest
+  - name: registration_operator
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/registration-operator-rhel9:latest
+  - name: work
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/work-rhel9:latest
+  - name: assisted_image_service
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-image-service-rhel9:latest
+  - name: assisted_installer
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-rhel9:latest
+  - name: assisted_installer_agent
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-agent-rhel9:latest
+  - name: assisted_installer_controller
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-controller-rhel9:latest
+  - name: assisted_service_9
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-service-9-rhel9:latest
+  - name: ose_cluster_api_rhel9
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/ose-cluster-api-rhel9:latest
+  - name: ose_baremetal_cluster_api_controllers_rhel9
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/ose-baremetal-cluster-api-controllers-rhel9:latest
+  - name: postgresql_15
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/postgresql-15:latest
+  - name: postgresql_16
+    image: image-registry.openshift-image-registry.svc:5000/multicluster-engine/postgresql-16:latest
   version: 5.0.0

--- a/pkg/overrides/csv_placeholders_test.go
+++ b/pkg/overrides/csv_placeholders_test.go
@@ -182,7 +182,7 @@ func helmImageOverrideKeys(t *testing.T, templatesDir string) []string {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() || !(strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")) {
+		if info.IsDir() || !strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml") {
 			return nil
 		}
 		raw, err := os.ReadFile(path)

--- a/pkg/overrides/csv_placeholders_test.go
+++ b/pkg/overrides/csv_placeholders_test.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package overrides
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// TestBundleCSVHasARTPlaceholders checks that the ART CSV template contains a
+// dummy pullspec for every image-references operand (except the operator
+// image itself) as OPERAND_IMAGE_* env vars and spec.relatedImages. ART
+// search-replaces those pullspecs at bundle rebase time; the env var names
+// are the image-keys MCE looks up at runtime.
+func TestBundleCSVHasARTPlaceholders(t *testing.T) {
+	root := repoRoot(t)
+
+	csvPath := mustGlobOne(t, filepath.Join(root, "bundle", "manifests", "*clusterserviceversion.yaml"))
+	csv := loadYAML(t, csvPath)
+
+	container := csvContainer(t, csv)
+	operatorImage := asString(t, container["image"])
+	operandEnv := operandImageEnv(t, container)
+	related := relatedImages(t, csv)
+
+	refDummies := imageReferenceDummies(t, filepath.Join(root, "bundle", "image-references"))
+	operandDummies := map[string]string{}
+	for name, dummy := range refDummies {
+		if dummy == operatorImage {
+			continue
+		}
+		operandDummies[name] = dummy
+	}
+
+	if len(operandEnv) != len(operandDummies) {
+		t.Errorf("OPERAND_IMAGE count %d != image-references operands %d", len(operandEnv), len(operandDummies))
+	}
+	if len(related) != len(operandEnv) {
+		t.Errorf("relatedImages count %d != OPERAND_IMAGE count %d", len(related), len(operandEnv))
+	}
+
+	envByDummy := map[string]string{}
+	for key, dummy := range operandEnv {
+		envByDummy[dummy] = key
+		if _, ok := related[key]; !ok {
+			t.Errorf("relatedImages missing name %q (from OPERAND_IMAGE_%s)", key, strings.ToUpper(key))
+		} else if related[key] != dummy {
+			t.Errorf("relatedImages[%s]=%s, want %s", key, related[key], dummy)
+		}
+	}
+
+	for _, dummy := range operandDummies {
+		if _, ok := envByDummy[dummy]; !ok {
+			t.Errorf("CSV is missing OPERAND_IMAGE env for dummy pullspec %s", dummy)
+		}
+	}
+
+	for key, dummy := range operandEnv {
+		found := false
+		for _, refDummy := range operandDummies {
+			if dummy == refDummy {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("OPERAND_IMAGE_%s value %s is not an image-references dummy", strings.ToUpper(key), dummy)
+		}
+	}
+
+	helmKeys := helmImageOverrideKeys(t, filepath.Join(root, "pkg", "templates"))
+	for _, key := range helmKeys {
+		if operandEnv[key] == "" {
+			t.Errorf("helm imageOverrides.%s has no OPERAND_IMAGE_%s in the CSV", key, strings.ToUpper(key))
+		}
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to determine test file path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "../.."))
+}
+
+func mustGlobOne(t *testing.T, pattern string) string {
+	t.Helper()
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %s: %v", pattern, err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match for %s, got %v", pattern, matches)
+	}
+	return matches[0]
+}
+
+func loadYAML(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := map[string]interface{}{}
+	if err := yaml.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return out
+}
+
+func csvContainer(t *testing.T, csv map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	deployments := mustSlice(t, mustMap(t, mustMap(t, mustMap(t, csv["spec"])["install"])["spec"])["deployments"])
+	if len(deployments) == 0 {
+		t.Fatal("CSV has no deployments")
+	}
+	containers := mustSlice(t, mustMap(t, mustMap(t, mustMap(t, mustMap(t, deployments[0])["spec"])["template"])["spec"])["containers"])
+	if len(containers) == 0 {
+		t.Fatal("CSV deployment has no containers")
+	}
+	return mustMap(t, containers[0])
+}
+
+func operandImageEnv(t *testing.T, container map[string]interface{}) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, item := range mustSlice(t, container["env"]) {
+		env := mustMap(t, item)
+		name := asString(t, env["name"])
+		if !strings.HasPrefix(name, OperandImagePrefix) {
+			continue
+		}
+		key := strings.ToLower(strings.TrimPrefix(name, OperandImagePrefix))
+		out[key] = asString(t, env["value"])
+	}
+	return out
+}
+
+func relatedImages(t *testing.T, csv map[string]interface{}) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	raw, ok := mustMap(t, csv["spec"])["relatedImages"]
+	if !ok {
+		return out
+	}
+	for _, item := range mustSlice(t, raw) {
+		ri := mustMap(t, item)
+		out[asString(t, ri["name"])] = asString(t, ri["image"])
+	}
+	return out
+}
+
+func imageReferenceDummies(t *testing.T, path string) map[string]string {
+	t.Helper()
+	doc := loadYAML(t, path)
+	out := map[string]string{}
+	for _, item := range mustSlice(t, mustMap(t, doc["spec"])["tags"]) {
+		tag := mustMap(t, item)
+		from := mustMap(t, tag["from"])
+		out[asString(t, tag["name"])] = asString(t, from["name"])
+	}
+	if len(out) == 0 {
+		t.Fatalf("no tags in %s", path)
+	}
+	return out
+}
+
+func helmImageOverrideKeys(t *testing.T, templatesDir string) []string {
+	t.Helper()
+	re := regexp.MustCompile(`imageOverrides\.([A-Za-z0-9_]+)`)
+	seen := map[string]struct{}{}
+	err := filepath.Walk(templatesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !(strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")) {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, match := range re.FindAllStringSubmatch(string(raw), -1) {
+			seen[match[1]] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", templatesDir, err)
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func mustMap(t *testing.T, v interface{}) map[string]interface{} {
+	t.Helper()
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", v)
+	}
+	return m
+}
+
+func mustSlice(t *testing.T, v interface{}) []interface{} {
+	t.Helper()
+	s, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("expected slice, got %T", v)
+	}
+	return s
+}
+
+func asString(t *testing.T, v interface{}) string {
+	t.Helper()
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", v)
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- ART bundle rebase only rewrites pullspecs that already appear in the CSV. The 5.0 `image-references` file listed operands, but the CSV had no `OPERAND_IMAGE_*` env vars or `spec.relatedImages`, so Doozer could not pin those images.
- This ports the 2.11 ART template: dummy `OPERAND_IMAGE_*` values (CPaaS extras image-keys) and matching `relatedImages`, using the dummy pullspecs from `bundle/image-references`.
- Points the operator container image at the same dummy registry pullspec as `image-references` so ART can rewrite it.
- Adds a test that the CSV placeholders stay in sync with `image-references` and helm `imageOverrides` keys.

## Test plan
- [x] `go test ./pkg/overrides -run TestBundleCSVHasARTPlaceholders`
- [ ] Doozer/Konflux bundle rebase for `mce-5.0` rewrites every dummy pullspec and writes digest `relatedImages`
- [ ] Installed MCE from that bundle still resolves operand images (`OPERAND_IMAGE_*` present on the operator deployment)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Updated the operator deployment to use images from the internal Multicluster Engine registry.
  * Added explicit image configuration for platform components and related images.

* **Tests**
  * Added validation to ensure configured operand images, related images, and Helm image overrides remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->