### PR TITLE
chore: auto-create Python venv for bundle-automation tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ testbin/*
 .DS_STORE
 .vscode/*
 venv
+.venv/
 
 bin/
 

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -34,6 +34,20 @@ endif
 # Bundle repo to validate against
 BUNDLE ?= mce-operator-bundle
 
+# Python venv setup (opt-in via USE_VENV, default true)
+# Avoids "externally-managed-environment" pip errors on newer Python installs
+# (e.g. Homebrew Python / PEP 668). Set USE_VENV=false to use system python3/pip3.
+VENV_DIR ?= .venv
+USE_VENV ?= true
+
+ifeq ($(USE_VENV),true)
+PYTHON_CMD := $(VENV_DIR)/bin/python3
+PIP_CMD := $(VENV_DIR)/bin/pip3
+else
+PYTHON_CMD := python3
+PIP_CMD := pip3
+endif
+
 ##@ Dev. targets
 
 .PHONY: subscriptions
@@ -42,14 +56,12 @@ subscriptions: ## Applies upstream community subscriptions (Hive, Cluster-manage
 	oc apply -k hack/subscriptions
 
 .PHONY: add-images
-add-images: ## Retrieves latest manifest and injects image definitions directly into the deployment template
-	pip3 install -r ./hack/bundle-automation/requirements.txt
-	python3 ./hack/scripts/dev-update-image-references.py
+add-images: install-requirements ## Retrieves latest manifest and injects image definitions directly into the deployment template
+	$(PYTHON_CMD) ./hack/scripts/dev-update-image-references.py
 
 .PHONY: add-images-local
-add-images-local:  ## Generates a local image manifest. Source this file to define necessary environment variables to run the operator locally
-	pip3 install -r ./hack/bundle-automation/requirements.txt
-	python3 ./hack/scripts/dev-update-image-references.py --local
+add-images-local: install-requirements  ## Generates a local image manifest. Source this file to define necessary environment variables to run the operator locally
+	$(PYTHON_CMD) ./hack/scripts/dev-update-image-references.py --local
 
 .PHONY: upstream-install
 upstream-install: ## Installs the upstream Backplane Operator by deploying a CatalogSource and Subscription
@@ -57,42 +69,49 @@ upstream-install: ## Installs the upstream Backplane Operator by deploying a Cat
 
 .PHONY: install-requirements
 install-requirements:
-	pip3 install -r hack/bundle-automation/requirements.txt
+ifeq ($(USE_VENV),true)
+	@if [ ! -x "$(VENV_DIR)/bin/python3" ]; then \
+		echo "Creating Python venv at $(VENV_DIR)..."; \
+		python3 -m venv $(VENV_DIR); \
+		$(VENV_DIR)/bin/pip3 install --upgrade pip; \
+	fi
+endif
+	$(PIP_CMD) install -r hack/bundle-automation/requirements.txt
 
 ## Lints the operator bundles
 .PHONY: lint-operator-bundles
 lint-operator-bundles: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --lint-bundles --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
+	$(PYTHON_CMD) ./hack/bundle-automation/generate-shell.py --lint-bundles --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Regenerates the operator bundles
 .PHONY: refresh-image-aliases
 refresh-image-aliases: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --refresh-image-aliases --org $(ORG) --repo $(REPO) --branch $(BRANCH) --pipeline-repo $(PIPELINE_REPO) --pipeline-branch $(PIPELINE_BRANCH) --component "$(COMPONENT)"
+	$(PYTHON_CMD) ./hack/bundle-automation/generate-shell.py --refresh-image-aliases --org $(ORG) --repo $(REPO) --branch $(BRANCH) --pipeline-repo $(PIPELINE_REPO) --pipeline-branch $(PIPELINE_BRANCH) --component "$(COMPONENT)"
 
 ## Regenerates the operator charts from bundles
 .PHONY: regenerate-charts-from-bundles
 regenerate-charts-from-bundles: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --update-charts-from-bundles --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
+	$(PYTHON_CMD) ./hack/bundle-automation/generate-shell.py --update-charts-from-bundles --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Regenerates the operator bundles
 .PHONY: regenerate-operator-sha-commits
 regenerate-operator-sha-commits: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --update-commits --org $(ORG) --repo $(REPO) --branch $(BRANCH) --pipeline-repo $(PIPELINE_REPO) --pipeline-branch $(PIPELINE_BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
+	$(PYTHON_CMD) ./hack/bundle-automation/generate-shell.py --update-commits --org $(ORG) --repo $(REPO) --branch $(BRANCH) --pipeline-repo $(PIPELINE_REPO) --pipeline-branch $(PIPELINE_BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Regenerates the charts
 .PHONY: regenerate-charts
 regenerate-charts: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --update-charts --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
+	$(PYTHON_CMD) ./hack/bundle-automation/generate-shell.py --update-charts --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Regenerates the operator bundles
 .PHONY: copy-charts
 copy-charts: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --copy-charts --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
+	$(PYTHON_CMD) ./hack/bundle-automation/generate-shell.py --copy-charts --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Onboard new OLM/Chart component
 .PHONY: onboard-new-component
 onboard-new-component: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --onboard-new-component --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)"
+	$(PYTHON_CMD) ./hack/bundle-automation/generate-shell.py --onboard-new-component --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)"
 
 ## Validate that all required image keys exist in the bundle
 .PHONY: validate-image-keys
@@ -106,7 +125,7 @@ validate-image-keys: install-requirements
 	@echo "Checking out bundle branch: $(BUNDLE_BRANCH)"
 	@cd $(BUNDLE) && git checkout $(BUNDLE_BRANCH)
 	@echo "Successfully checked out branch: $$(cd $(BUNDLE) && git branch --show-current)"
-	@python3 ./hack/bundle-automation/generate-shell.py --validate-image-keys --org $(ORG) --repo $(REPO) --branch $(BRANCH) --bundle $(BUNDLE)
+	@$(PYTHON_CMD) ./hack/bundle-automation/generate-shell.py --validate-image-keys --org $(ORG) --repo $(REPO) --branch $(BRANCH) --bundle $(BUNDLE)
 	@echo "Cleaning up cloned bundle..."
 	@rm -rf $(BUNDLE)
 


### PR DESCRIPTION
# Description

Updates `Makefile.dev` so that the `install-requirements` target (used by `regenerate-charts`, `refresh-image-aliases`, `lint-operator-bundles`, etc.) automatically creates and uses a local `.venv/` virtual environment for the `hack/bundle-automation` Python dependencies. Avoids the `externally-managed-environment` pip error raised by newer Python installs (Homebrew Python / PEP 668).

## Related Issue

N/A — developer experience improvement.

## Changes Made

- `Makefile.dev`: introduce `VENV_DIR`, `USE_VENV`, `PYTHON_CMD`, and `PIP_CMD` variables. `install-requirements` now creates `.venv/` on first run (if `USE_VENV=true`, the default), and all Python invocations in `Makefile.dev` now use `$(PYTHON_CMD)` instead of a hardcoded `python3`.
- `.gitignore`: add `.venv/`.

Behavior:
- Default (`USE_VENV=true`): `make regenerate-charts COMPONENT=...` (and other bundle-automation targets) auto-create `.venv/` on first run, then reuse it. No manual activation needed.
- Opt-out: `make regenerate-charts COMPONENT=... USE_VENV=false` uses system `python3`/`pip3` as before.
- Non-breaking for CI: existing GitHub Actions workflows that call these `make` targets continue to work unchanged (venv creation is harmless in ephemeral CI runners).

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Split out of the `disable-prometheus-managed-serviceaccount` branch as an independent, unrelated tooling change. See #3991 for the other half of the split.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
