### PR TITLE
Disable prometheus monitoring for managed-serviceaccount addon

### DIFF
--- a/hack/bundle-automation/chart-values/managed-serviceaccount/overwriteValues.yaml
+++ b/hack/bundle-automation/chart-values/managed-serviceaccount/overwriteValues.yaml
@@ -8,7 +8,7 @@ agentImagePullSecret: ""
 enableAddOnDeploymentConfig: true
 hubDeployMode: AddOnTemplate
 prometheus:
-  enabled: true
+  enabled: false
 networkPolicies:
   enabled: true
 global: {}

--- a/pkg/templates/charts/toggle/managed-serviceaccount/templates/managed-serviceaccount-addontemplate.yaml
+++ b/pkg/templates/charts/toggle/managed-serviceaccount/templates/managed-serviceaccount-addontemplate.yaml
@@ -130,9 +130,6 @@ spec:
           - ports:
             - port: 8000
               protocol: TCP
-          - ports:
-            - port: 38080
-              protocol: TCP
           podSelector:
             matchLabels:
               addon-agent: managed-serviceaccount
@@ -140,19 +137,6 @@ spec:
           - Ingress
           - Egress
       {{- end }}
-      - apiVersion: monitoring.coreos.com/v1
-        kind: ServiceMonitor
-        metadata:
-          name: managed-serviceaccount-addon-agent
-          namespace: open-cluster-management-agent-addon
-        spec:
-          endpoints:
-          - path: /metrics
-            port: metrics
-            scheme: http
-          selector:
-            matchLabels:
-              addon-agent: managed-serviceaccount
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:


### PR DESCRIPTION
# Description

Disables prometheus monitoring for the managed-serviceaccount addon.

## Related Issue

N/A

## Changes Made

- `hack/bundle-automation/chart-values/managed-serviceaccount/overwriteValues.yaml`: set `prometheus.enabled` to `false`.
- `pkg/templates/charts/toggle/managed-serviceaccount/templates/managed-serviceaccount-addontemplate.yaml`: removed the resulting `ServiceMonitor` resource and the port `38080` network policy egress/ingress rule for the addon agent.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Split out from the dev-tooling venv/Makefile changes (see #3990), which are unrelated to this change.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
