### PR TITLE
[ACM-42758] Add hcp-cli-download deployment status tracking to backplane-5.0

### DIFF
--- a/controllers/toggle_components.go
+++ b/controllers/toggle_components.go
@@ -1672,6 +1672,10 @@ func (r *MultiClusterEngineReconciler) ensureHyperShift(ctx context.Context, mce
 	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
 	r.StatusManager.AddComponent(status.NewPresentStatus(types.NamespacedName{Name: "hypershift-addon"}, clusterManagementAddOnGVK))
 
+	namespacedName = types.NamespacedName{Name: "hcp-cli-download", Namespace: mce.Spec.TargetNamespace}
+	r.StatusManager.RemoveComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
+	r.StatusManager.AddComponent(toggle.EnabledStatus(namespacedName))
+
 	// Ensure that the InternalHubComponent CR instance is created for component in MCE.
 	if result, err := r.ensureInternalEngineComponent(ctx, mce, backplanev1.HyperShift); err != nil {
 		return result, err
@@ -1765,6 +1769,10 @@ func (r *MultiClusterEngineReconciler) ensureNoHyperShift(ctx context.Context,
 		return ctrl.Result{RequeueAfter: requeuePeriod}, nil
 	}
 
+	r.StatusManager.AddComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
+
+	namespacedName = types.NamespacedName{Name: "hcp-cli-download", Namespace: mce.Spec.TargetNamespace}
+	r.StatusManager.RemoveComponent(toggle.EnabledStatus(namespacedName))
 	r.StatusManager.AddComponent(toggle.DisabledStatus(namespacedName, []*unstructured.Unstructured{}))
 
 	// Renders all templates from charts


### PR DESCRIPTION
# Description

Targeted backport to `backplane-5.0` adding status tracking for the `hcp-cli-download` deployment, split out from #3932.

## Related Issue

[ACM-42758](https://redhat.atlassian.net/browse/ACM-42758) — Deployments missing from status.components map (multicluster-integrations, managedcluster-import-controller-v2, hcp-cli-download)

## Changes Made

- Adds `hcp-cli-download` status tracking in `ensureHyperShift()` (enabled) and `ensureNoHyperShift()` (disabled), following the same pattern used for `hypershift-addon-manager`.
- Intentionally excludes the `managedcluster-import-controller-v2` status tracking portion of #3932, since `backplane-5.0` already has that tracking added separately.
- A prior cherry-pick attempt (#3931) included both changes and caused `managedcluster-import-controller-v2` to be duplicated on this branch; it was closed in favor of this targeted PR.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Verified `controllers/toggle_components.go` on `backplane-5.0` already contains `managedcluster-import-controller-v2` tracking and did not previously contain `hcp-cli-download` tracking before this change. Build (`go build ./...`) and `go vet ./controllers/...` pass clean.

## Reviewers

/cc

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


[ACM-42758]: https://redhat.atlassian.net/browse/ACM-42758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ