### PR TITLE
MCE 5.0 to ART - bundle: add OLM feature annotations to CSV

### DIFF
--- a/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-engine.clusterserviceversion.yaml
@@ -15,6 +15,16 @@ metadata:
       ]
     capabilities: Basic Install
     createdAt: "2026-08-18T20:48:25Z"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: multicluster-engine.v5.0.0


### PR DESCRIPTION
The MCE 5.0 CSV was regenerated from operator-sdk scaffolding and lost the features.operators.openshift.io/* annotations that existed in 2.11. These are required by verify-conforma's olm.feature_annotations_format policy and block stage releases without them.

Values match MCE 2.11 (backplane-2.11).
