### PR TITLE
bundle: treat assisted images as ART-built on MCE 5.0

### DIFF
--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -4,24 +4,7 @@ updates:
   update_list:
   - search: "5.0.0"
     replace: "5.0.0"
-# TODO: The assisted-* digests below are placeholders borrowed from MCE 2.11.
-# Replace with MCE 5.0 digests once the assisted-installer team publishes them.
 external-images:
-- name: assisted-image-service
-  search: "image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-image-service-rhel9:latest"
-  replace: "registry.redhat.io/multicluster-engine/assisted-image-service-rhel9@sha256:48305470fa7e55e78165734d094022a14ac9d083573974036c1f40021c362ba1"
-- name: assisted-installer
-  search: "image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-rhel9:latest"
-  replace: "registry.redhat.io/multicluster-engine/assisted-installer-rhel9@sha256:4dd8f3992fcc23dc8f1e14dbfe4e3c3e447b592d88152fbf5d92ccd469653377"
-- name: assisted-installer-agent
-  search: "image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-agent-rhel9:latest"
-  replace: "registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel9@sha256:72427b669fe6feb4b46bcabf100bbd633ffd13bd0d3583b2e544f5709f680b73"
-- name: assisted-installer-controller
-  search: "image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-controller-rhel9:latest"
-  replace: "registry.redhat.io/multicluster-engine/assisted-installer-controller-rhel9@sha256:b3d2b3c7c5bef17dfea7985eb854a6fe77720dfc185a968adc2db831081546ee"
-- name: assisted-service
-  search: "image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-service-9-rhel9:latest"
-  replace: "registry.redhat.io/multicluster-engine/assisted-service-9-rhel9@sha256:eb11d23849d00fc2ec07284054335921158f00f6dd7e4347c54fd606e80c8a2e"
 # TODO: The ose-cluster-api and ose-baremetal tags below are placeholders
 # borrowed from MCE 2.11 (openshift4:v4.21). Replace with openshift5:v5.0
 # once the OCP 5.0 images are published to registry.redhat.io.

--- a/bundle/image-references
+++ b/bundle/image-references
@@ -143,23 +143,23 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/work-rhel9:latest
-  - name: assisted-image-service
+  - name: assisted-image-service-rhel9
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-image-service-rhel9:latest
-  - name: assisted-installer
+  - name: assisted-installer-rhel9
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-rhel9:latest
-  - name: assisted-installer-agent
+  - name: assisted-installer-agent-rhel9
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-agent-rhel9:latest
-  - name: assisted-installer-controller
+  - name: assisted-installer-controller-rhel9
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-installer-controller-rhel9:latest
-  - name: assisted-service
+  - name: assisted-service-9-rhel9
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/multicluster-engine/assisted-service-9-rhel9:latest


### PR DESCRIPTION
Rename the five assisted image-references tags to the delivery-repo names registered by ocp-build-data#12764, and drop them from art.yaml external-images so the bundle rebase resolves ART builds instead of the 2.11 placeholder digests.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
