### PR TITLE
[ACM-40205] Auto-prune removed maestro-preview component on upgrade

### DIFF
--- a/api/v1/multiclusterengine_methods.go
+++ b/api/v1/multiclusterengine_methods.go
@@ -48,6 +48,7 @@ const (
 	ManagedServiceAccount            = "managedserviceaccount"
 	ManagedServiceAccountPreview     = "managedserviceaccount-preview"
 	ServerFoundation                 = "server-foundation"
+	MaestroPreview                   = "maestro-preview" // Removed in MCE 5.1
 
 	// CRD directory names
 	AssistedServiceCRDDir            = "assisted-service"
@@ -158,6 +159,16 @@ var PreviewToStable = map[string]string{
 }
 
 /*
+RemovedComponents is a list of component names that have been completely removed from MCE.
+These components are no longer valid and are automatically pruned from existing MultiClusterEngine
+CRs during reconciliation, so that clusters upgrading from a version where the component still
+existed can be cleanly migrated without requiring manual user intervention.
+*/
+var RemovedComponents = []string{
+	MaestroPreview, // Removed in MCE 5.1
+}
+
+/*
 ComponentPresent checks if a component with the given name is present in the MultiClusterEngine's Overrides.
 Returns true if the component is present, otherwise false.
 */
@@ -263,6 +274,19 @@ Returns true if the component is valid, otherwise false.
 func validComponent(c ComponentConfig) bool {
 	for _, name := range AllComponents {
 		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+/*
+IsRemovedComponent checks if the given component name is in the RemovedComponents list.
+Returns true if the component has been completely removed from MCE.
+*/
+func IsRemovedComponent(name string) bool {
+	for _, removed := range RemovedComponents {
+		if name == removed {
 			return true
 		}
 	}

--- a/api/v1/multiclusterengine_webhook.go
+++ b/api/v1/multiclusterengine_webhook.go
@@ -180,6 +180,10 @@ func (r *MultiClusterEngine) ValidateCreate(ctx context.Context, obj *MultiClust
 	if obj.Spec.Overrides != nil {
 		for _, c := range obj.Spec.Overrides.Components {
 			if !validComponent(c) {
+				if IsRemovedComponent(c.Name) {
+					return nil, fmt.Errorf("%w: %s was removed and can no longer be added to a new resource",
+						ErrInvalidComponent, c.Name)
+				}
 				return nil, fmt.Errorf("%w: %s is not a known component", ErrInvalidComponent, c.Name)
 			}
 		}
@@ -257,9 +261,15 @@ func (r *MultiClusterEngine) ValidateUpdate(ctx context.Context, oldObj, newObj 
 	}
 
 	// Validate components
+	var warnings admission.Warnings
 	if newObj.Spec.Overrides != nil {
 		for _, c := range newObj.Spec.Overrides.Components {
 			if !validComponent(c) {
+				if IsRemovedComponent(c.Name) {
+					warnings = append(warnings, fmt.Sprintf(
+						"component %s was removed and will be automatically removed from this resource", c.Name))
+					continue
+				}
 				return nil, fmt.Errorf("%w: %s is not a known component", ErrInvalidComponent, c.Name)
 			}
 		}
@@ -333,7 +343,7 @@ func (r *MultiClusterEngine) ValidateUpdate(ctx context.Context, oldObj, newObj 
 		}
 	}
 
-	return nil, nil
+	return warnings, nil
 }
 
 var cfg *rest.Config

--- a/api/v1/multiclusterengine_webhook_test.go
+++ b/api/v1/multiclusterengine_webhook_test.go
@@ -105,6 +105,28 @@ var _ = Describe("Multiclusterengine webhook", func() {
 				}
 				Expect(k8sClient.Create(ctx, mce)).NotTo(BeNil(), "Invalid components not allowed in config")
 			})
+			By("because of a removed component", func() {
+				mce := &MultiClusterEngine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        fmt.Sprintf("%s-2", multiClusterEngineName),
+						Annotations: map[string]string{"deploymentmode": string(ModeHosted)},
+					},
+					Spec: MultiClusterEngineSpec{
+						TargetNamespace: "new",
+						Overrides: &Overrides{
+							Components: []ComponentConfig{
+								{
+									Name:    MaestroPreview,
+									Enabled: true,
+								},
+							},
+						},
+					},
+				}
+				err := k8sClient.Create(ctx, mce)
+				Expect(err).NotTo(BeNil(), "Removed components should not be permitted on new resources")
+				Expect(err.Error()).To(ContainSubstring("was removed"))
+			})
 		})
 
 		It("Should fail to update multiclusterengine", func() {
@@ -159,6 +181,30 @@ var _ = Describe("Multiclusterengine webhook", func() {
 				Expect(statusErr.ErrStatus.Code).To(Equal(int32(403)))
 				Expect(statusErr.ErrStatus.Message).To(ContainSubstring("local-cluster name"))
 				Expect(statusErr.ErrStatus.Message).To(ContainSubstring("35 characters"))
+			})
+		})
+
+		It("Should allow updating multiclusterengine with a removed component", func() {
+			mce := &MultiClusterEngine{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())
+
+			By("setting a removed component, simulating an upgrade from a version where it still existed", func() {
+				mce.Spec.Overrides = &Overrides{
+					Components: []ComponentConfig{
+						{
+							Name:    MaestroPreview,
+							Enabled: true,
+						},
+					},
+				}
+				Expect(k8sClient.Update(ctx, mce)).To(Succeed(),
+					"removed components should be accepted on update so they can be auto-pruned by the operator")
+			})
+
+			By("cleaning up the removed component", func() {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterEngineName}, mce)).To(Succeed())
+				mce.Spec.Overrides = &Overrides{}
+				Expect(k8sClient.Update(ctx, mce)).To(Succeed())
 			})
 		})
 

--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -2575,6 +2575,16 @@ func (r *MultiClusterEngineReconciler) setDefaults(ctx context.Context, m *backp
 		}
 	}
 
+	// Automatically prune components that have been removed from MCE entirely.
+	// This allows clusters upgrading from a version where the component still
+	// existed to be cleanly migrated without requiring manual user intervention.
+	for _, removed := range backplanev1.RemovedComponents {
+		if m.Prune(removed) {
+			log.Info("Pruning removed component", "component", removed)
+			updateNecessary = true
+		}
+	}
+
 	if utils.DeployOnOCP() {
 		// Set and store cluster Ingress domain for use later
 		clusterIngressDomain, err := r.getClusterIngressDomain(ctx, m)

--- a/controllers/backplaneconfig_controller_test.go
+++ b/controllers/backplaneconfig_controller_test.go
@@ -3276,3 +3276,59 @@ func Test_CleanupVersionedAddOnTemplates(t *testing.T) {
 func ptr(b bool) *bool {
 	return &b
 }
+
+// Test_setDefaults_PrunesRemovedComponents verifies that components which have been
+// completely removed from MCE (backplanev1.RemovedComponents) are automatically pruned
+// from a MultiClusterEngine's spec during reconciliation, so that clusters upgrading
+// from a version where the component still existed are cleanly migrated without
+// requiring manual user intervention.
+func Test_setDefaults_PrunesRemovedComponents(t *testing.T) {
+	registerScheme()
+
+	// setDefaults() branches into OCP-specific reconciliation (ingress domain,
+	// console URL, cluster version) when this is true. That path isn't relevant
+	// to removed-component pruning and isn't set up for this fake client, so
+	// disable it for the duration of this test and restore it afterward since
+	// it's shared global state.
+	previousDeployOnOCP := utils.DeployOnOCP()
+	utils.SetDeployOnOCP(false)
+	defer utils.SetDeployOnOCP(previousDeployOnOCP)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	reconciler := &MultiClusterEngineReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme.Scheme,
+		StatusManager: &status.StatusTracker{Client: fakeClient},
+	}
+
+	mce := &backplanev1.MultiClusterEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mce-removed-component",
+		},
+		Spec: backplanev1.MultiClusterEngineSpec{
+			TargetNamespace: "test-ns",
+			Overrides: &backplanev1.Overrides{
+				Components: []backplanev1.ComponentConfig{
+					{Name: backplanev1.MaestroPreview, Enabled: true},
+				},
+			},
+		},
+	}
+
+	if err := fakeClient.Create(context.TODO(), mce); err != nil {
+		t.Fatalf("failed to create MultiClusterEngine: %v", err)
+	}
+
+	if !mce.ComponentPresent(backplanev1.MaestroPreview) {
+		t.Fatalf("expected removed component %q to be present before reconciliation", backplanev1.MaestroPreview)
+	}
+
+	if _, err := reconciler.setDefaults(context.TODO(), mce); err != nil {
+		t.Fatalf("setDefaults() error = %v", err)
+	}
+
+	if mce.ComponentPresent(backplanev1.MaestroPreview) {
+		t.Errorf("expected removed component %q to be pruned from spec, but it is still present",
+			backplanev1.MaestroPreview)
+	}
+}

--- a/docs/available-components.md
+++ b/docs/available-components.md
@@ -17,3 +17,14 @@
 | local-cluster                    | Enables the import and self-management of the local hub cluster where the {mce-short} is deployed.                          | True    |
 | managedserviceaccount            | Synchronizes service accounts to managed clusters, and collects tokens as secret resources to give back to the hub cluster. | True    |
 | server-foundation                | Provides foundational services for server-side operations within the cluster environment.                                   | True    |
+
+## Removed components
+
+The following components have been completely removed from the operator. They are no longer valid
+values for `spec.overrides.components[].name`. If present on an existing `MultiClusterEngine` resource
+(e.g. after upgrading from a version where the component still existed), they are automatically pruned
+during reconciliation and do not require manual removal.
+
+| Name             | Removed in | Notes                                                        |
+|------------------|------------|---------------------------------------------------------------|
+| maestro-preview  | MCE 5.1    | Maestro was removed entirely; see ACM-40205 for details.      |


### PR DESCRIPTION
# Description

QE testing for ACM-40205 found that upgrading from MCE 5.0 to 5.1 leaves the removed `maestro-preview` component present in the `MultiClusterEngine` CR spec. Once present, any further update to the CR is rejected by the webhook because `maestro-preview` is no longer a known component, forcing users to manually edit the CR to unblock themselves.

## Related Issue

[ACM-40205](https://redhat.atlassian.net/browse/ACM-40205)

## Changes Made

- `api/v1/multiclusterengine_methods.go`: Re-add the `MaestroPreview` constant, add a `RemovedComponents` list (currently just `MaestroPreview`), and add an `IsRemovedComponent` helper alongside the existing component lists (`AllComponents`, `PreviewComponents`, `PreviewToStable`).
- `controllers/backplaneconfig_controller.go`: In `setDefaults()`, automatically prune any `RemovedComponents` entries from the CR spec on every reconcile, mirroring the existing preview → stable component migration pattern immediately above it.
- `api/v1/multiclusterengine_webhook.go`:
  - `ValidateCreate`: reject removed components with a clear error, since there's no reason to allow adding a component that no longer exists to a brand new resource.
  - `ValidateUpdate`: accept removed components but return an admission **warning** instead of an error. This is the path an in-place 5.0 → 5.1 upgrade takes (the component is already in the stored spec) before the reconciler gets a chance to prune it; rejecting the update here would just reproduce the bug.
- `docs/available-components.md`: Add a "Removed components" section documenting `maestro-preview` and the release it was removed in.
- Minimal webhook (Ginkgo/envtest) and controller (fake client) tests covering the new create-rejection, update-acceptance, and reconciler-pruning behavior.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added/updated relevant unit tests.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main branch.

## Additional Notes

This targets `main` since it is being fast-forwarded to become the MCE 5.1 branch.


[ACM-40205]: https://redhat.atlassian.net/browse/ACM-40205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Removed components can no longer be specified when creating a MultiClusterEngine.
  * Existing resources containing removed components are automatically cleaned up during updates and reconciliation, with a warning where applicable.
  * The `maestro-preview` component is no longer supported.

* **Documentation**
  * Added guidance on removed components and automatic cleanup during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->